### PR TITLE
Add ArrayDataset class and remove jax-dataloader dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,30 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## Unreleased
+
 ### Added
+
 - `.train_on_batch()` and `.fit_on_batch()` methods to `ImpactModel` (@markean, [#15](https://github.com/markean/aimz/issues/15)).
 - Custom `ArrayDataset` class for handling data in `ImpactModel`, removing the need for the `jax-dataloader` dependency (@markean, [#14](https://github.com/markean/aimz/issues/14)).
 - GitHub Pages documentation site (@markean, [#10](https://github.com/markean/aimz/issues/10)).
-- Installation instructions (@markean, [#10](https://github.com/markean/aimz/issues/10)).
+- Installation instructions in the documentation site (@markean, [#10](https://github.com/markean/aimz/issues/10)).
 
 ### Changed
+
 - Adopted `jax.typing` module for improved type hints.
 - Removed unnecessary JAX array type conversion in `ImpactModel` methods.
 - Updated `.fit()`, `.train_on_batch()`, and `.fit_on_batch()` to train the model using the internal SVI state, continuing from the last state if available (@markean, [#15](https://github.com/markean/aimz/issues/15)).
 
 ### Removed
+
 - Removed `jax-dataloader` dependency (@markean, [#14](https://github.com/markean/aimz/issues/14)).
 
-## 0.1.0 (2025-06-27)
+## [v0.1.0](https://github.com/markean/aimz/releases/tag/v0.1.0) - 2025-06-27
+
+### Added
 - Initial public release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## Unreleased
+### Added
+- `.train_on_batch()` and `.fit_on_batch()` methods to `ImpactModel` (@markean, [#15](https://github.com/markean/aimz/issues/15)).
+- Custom `ArrayDataset` class for handling data in `ImpactModel`, removing the need for the `jax-dataloader` dependency (@markean, [#14](https://github.com/markean/aimz/issues/14)).
+- GitHub Pages documentation site (@markean, [#10](https://github.com/markean/aimz/issues/10)).
+- Installation instructions (@markean, [#10](https://github.com/markean/aimz/issues/10)).
+
+### Changed
+- Adopted `jax.typing` module for improved type hints.
+- Removed unnecessary JAX array type conversion in `ImpactModel` methods.
+- Updated `.fit()`, `.train_on_batch()`, and `.fit_on_batch()` to train the model using the internal SVI state, continuing from the last state if available (@markean, [#15](https://github.com/markean/aimz/issues/15)).
+
+### Removed
+- Removed `jax-dataloader` dependency (@markean, [#14](https://github.com/markean/aimz/issues/14)).
+
+## 0.1.0 (2025-06-27)
+- Initial public release.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # aimz: Flexible probabilistic impact modeling at scale
-[![Python](https://img.shields.io/pypi/pyversions/aimz.svg)](https://pypi.org/project/aimz/)
 [![PyPI version](https://img.shields.io/pypi/v/aimz)](https://pypi.org/project/aimz/)
+[![Python](https://img.shields.io/pypi/pyversions/aimz.svg)](https://pypi.org/project/aimz/)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 [![codecov](https://codecov.io/gh/markean/aimz/graph/badge.svg?token=34OH7KQBXE)](https://codecov.io/gh/markean/aimz)
 
 
@@ -26,9 +28,9 @@ Designed to work with user-defined models with probabilistic primitives, the lib
 This example demonstrates a simple regression model following a typical ML workflow. The `ImpactModel` class provides `.fit()` for variational inference and posterior sampling, and `.predict()` for posterior predictive sampling. The optional `.cleanup()` removes posterior predictive samples saved as temporary files.
 ```python
 import jax.numpy as jnp
-import numpy as np
 import numpyro.distributions as dist
 from jax import random
+from jax.typing import ArrayLike
 from numpyro import optim, plate, sample
 from numpyro.infer import SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
@@ -44,7 +46,7 @@ X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=42)
 
 
 # NumPyro model: linear regression
-def model(X: np.ndarray, y: np.ndarray | None = None) -> None:
+def model(X: ArrayLike, y: ArrayLike | None = None) -> None:
     """Bayesian linear regression."""
     n_features = X.shape[1]
 
@@ -88,10 +90,10 @@ This example illustrates a simple causal network. The variable `Z` has a direct 
 Our objective is to estimate the causal effect of `Z` (or alternatively `X`) on `Y`, while properly accounting for the confounding influence of `C`. We assume the following generative model for the observed data:
 
 ```python
-import jax
 import jax.numpy as jnp
 import numpyro.distributions as dist
 from jax import nn, random
+from jax.typing import ArrayLike
 from numpyro import optim, plate, sample
 from numpyro.infer import SVI, Trace_ELBO, init_to_feasible
 from numpyro.infer.autoguide import AutoNormal
@@ -100,7 +102,7 @@ from aimz.model import ImpactModel
 
 
 # NumPyro model: Z and y are influenced by C and X, with Z mediating part of y
-def model(X: jax.Array, C: jax.Array, y: jax.Array | None = None) -> None:
+def model(X: ArrayLike, C: ArrayLike, y: ArrayLike | None = None) -> None:
     # Observed confounder
     c = sample("c", dist.Exponential(), obs=C)
 

--- a/aimz/data/array_dataset.py
+++ b/aimz/data/array_dataset.py
@@ -1,0 +1,65 @@
+# Copyright 2025 Eli Lilly and Company
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for custom dataset for JAX arrays."""
+from typing import TYPE_CHECKING
+
+from jax import tree
+from torch.utils.data import Dataset
+
+if TYPE_CHECKING:
+    import jax
+
+class ArrayDataset(Dataset):
+    """Custom Dataset class for JAX arrays based on PyTorch's Dataset."""
+
+    def __init__(self, *arrays: "jax.Array") -> None:
+        """Initialize an ArrayDataset instance.
+
+        Args:
+            *arrays: One or more JAX arrays or compatible array-like objects.
+
+        Raises:
+            ValueError: If no arrays are provided or if the arrays do not have the same
+                length.
+        """
+        if not arrays:
+            msg = "At least one array must be provided."
+            raise ValueError(msg)
+        length = len(arrays[0])
+        if any(len(arr) != length for arr in arrays):
+            msg = "All arrays must have the same length."
+            raise ValueError(msg)
+
+        self.arrays = tuple(arrays)
+
+    def __len__(self) -> int:
+        """Get the number of samples in the dataset.
+
+        Returns:
+            The number of samples, equal to the length of the first array.
+        """
+        # Since all arrays have the same length, return the length of the first one
+        return len(self.arrays[0])
+
+    def __getitem__(self, index: int) -> object:
+        """Retrieve the elements at the specified index.
+
+        Args:
+            index: Index of the item to retrieve.
+
+        Returns:
+            A pytree containing the elements at the given index from each array.
+        """
+        return tree.map(lambda x: x[index], self.arrays)

--- a/aimz/data/array_loader.py
+++ b/aimz/data/array_loader.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
 
 class ArrayLoader(DataLoader):
-    """A custom DataLoader class that extends PyTorch's DataLoader."""
+    """Custom DataLoader class for JAX arrays based on PyTorch's DataLoader."""
 
     def __init__(
         self,

--- a/aimz/model/__init__.py
+++ b/aimz/model/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Model object."""
+"""Model implementations."""
 
 from aimz.model.impact_model import ImpactModel
 

--- a/aimz/model/_core.py
+++ b/aimz/model/_core.py
@@ -17,12 +17,13 @@
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Self
 
+from jax.typing import ArrayLike
+
 from aimz.utils._validation import _validate_kernel_signature
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    import jax
 
 
 class BaseModel(ABC):
@@ -55,15 +56,15 @@ class BaseModel(ABC):
     @abstractmethod
     def fit(
         self,
-        X: "jax.Array",
-        y: "jax.Array",
+        X: ArrayLike,
+        y: ArrayLike,
         **kwargs: object,
     ) -> Self:
         """Fit the model to the input data `X` and output data `y`.
 
         Args:
-            X (jax.Array): Input data with shape `(n_samples_X, n_features)`.
-            y (jax.Array): Output data with shape `(n_samples_Y,)`.
+            X (ArrayLike): Input data with shape `(n_samples_X, n_features)`.
+            y (ArrayLike): Output data with shape `(n_samples_Y,)`.
             **kwargs (object): Additional arguments passed to the model, except for `X`
                 and `y`. All array-like objects in `**kwargs` are expected to be JAX
                 arrays.
@@ -74,11 +75,11 @@ class BaseModel(ABC):
         return self
 
     @abstractmethod
-    def predict(self, X: "jax.Array", **kwargs: object) -> None:
+    def predict(self, X: ArrayLike, **kwargs: object) -> None:
         """Predict the output based on the fitted model.
 
         Args:
-            X (jax.Array): Input data with shape `(n_samples_X, n_features)`.
+            X (ArrayLike): Input data with shape `(n_samples_X, n_features)`.
             **kwargs (object): Additional arguments passed to the model, except for `X`
                 and `y`. All array-like objects in `**kwargs` are expected to be JAX
                 arrays.

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -530,7 +530,7 @@ class ImpactModel(BaseModel):
         if rng_key is None:
             self.rng_key, rng_key = random.split(self.rng_key)
 
-        X, y = map(jnp.asarray, check_X_y(X, y, y_numeric=True))
+        X, y = check_X_y(X, y, y_numeric=True)
 
         # Validate the provided parameters against the kernel's signature
         args_bound = (
@@ -950,7 +950,7 @@ class ImpactModel(BaseModel):
         if rng_key is None:
             self.rng_key, rng_key = random.split(self.rng_key)
 
-        X = jnp.asarray(check_array(X))
+        X = check_array(X)
 
         # Validate the provided parameters against the kernel's signature
         args_bound = (
@@ -1128,7 +1128,7 @@ class ImpactModel(BaseModel):
         # Validate the provided parameters against the kernel's signature
         signature(self.kernel).bind(**{self.param_input: X, **kwargs})
 
-        X, y = map(jnp.asarray, check_X_y(X, y, y_numeric=True))
+        X, y = check_X_y(X, y, y_numeric=True)
 
         kwargs_array, kwargs_extra = _group_kwargs(kwargs)
         if self._fn_log_likelihood is None:

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -85,7 +85,7 @@ class ImpactModel(BaseModel):
         param_input: str = "X",
         param_output: str = "y",
     ) -> None:
-        """Initialize the ImpactModel.
+        """Initialize an ImpactModel instance.
 
         Args:
             kernel (Callable): A probabilistic model with Pyro primitives.

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -530,7 +530,7 @@ class ImpactModel(BaseModel):
         if rng_key is None:
             self.rng_key, rng_key = random.split(self.rng_key)
 
-        X, y = check_X_y(X, y, y_numeric=True)
+        X, y = map(jnp.asarray, check_X_y(X, y, y_numeric=True))
 
         # Validate the provided parameters against the kernel's signature
         args_bound = (

--- a/aimz/sampling/_forward.py
+++ b/aimz/sampling/_forward.py
@@ -16,24 +16,23 @@
 
 from typing import TYPE_CHECKING, Any
 
-from jax import lax, random
+from jax import Array, lax, random
+from jax.typing import ArrayLike
 from numpyro.handlers import mask, seed, substitute, trace
 
 if TYPE_CHECKING:
     from collections import OrderedDict
     from collections.abc import Callable
 
-    import jax
-
 
 def _sample_forward(
     model: "Callable",
     num_samples: int,
-    rng_key: "jax.Array",
+    rng_key: ArrayLike,
     return_sites: tuple[str] | None,
-    posterior_samples: dict[str, "jax.Array"] | None,
-    model_kwargs: dict[str, "jax.Array"] | None,
-) -> dict[str, "jax.Array"]:
+    posterior_samples: dict[str, ArrayLike] | None,
+    model_kwargs: dict[str, ArrayLike] | None,
+) -> dict[str, Array]:
     """Generates forward samples from a model conditioned on parameter draws.
 
     This function repeatedly traces the model with different random keys and sets of
@@ -42,24 +41,24 @@ def _sample_forward(
     Args:
         model (Callable): A probabilistic model with Pyro primitives.
         num_samples (int): The number of samples to draw.
-        rng_key (jax.Array): A pseudo-random number generator key.
+        rng_key (ArrayLike): A pseudo-random number generator key.
         return_sites (tuple[str] | None): Names of variables (sites) to return.
-        posterior_samples (dict[str, jax.Array]| None): Dictionary of parameter samples
+        posterior_samples (dict[str, ArrayLike]| None): Dictionary of parameter samples
             where each array has shape (num_samples, ...).
-        model_kwargs (dict[str, jax.Array] | None): Additional arguments passed to the
+        model_kwargs (dict[str, ArrayLike] | None): Additional arguments passed to the
             model.
 
     Returns:
-        dict[str, jax.Array]: A dictionary mapping each return site to an array of
+        dict[str, Array]: A dictionary mapping each return site to an array of
             traced values with shape (num_samples, ...).
     """
 
     def _trace_one_sample(
-        sample_input: tuple["jax.Array", dict[str, "jax.Array"]],
-    ) -> dict[str, "jax.Array"]:
+        sample_input: tuple[ArrayLike, dict[str, ArrayLike]],
+    ) -> dict[str, Array]:
         rng_key, posterior_sample = sample_input
 
-        def _exclude_deterministic(msg: "OrderedDict[str, Any]") -> "jax.Array | None":
+        def _exclude_deterministic(msg: "OrderedDict[str, Any]") -> Array| None:
             return (
                 posterior_sample.get(msg["name"])
                 if msg["type"] != "deterministic"

--- a/aimz/utils/_kwargs.py
+++ b/aimz/utils/_kwargs.py
@@ -16,7 +16,7 @@
 
 from typing import NamedTuple
 
-import jax
+from jax.typing import ArrayLike
 from sklearn.utils.validation import _is_arraylike
 
 
@@ -38,7 +38,7 @@ def _group_kwargs(kwargs: dict) -> tuple[NamedTuple, NamedTuple]:
     # Dynamically create NamedTuple classes
     KwargsArray = NamedTuple(
         "KwargsArray",
-        [(k, jax.Array) for k in dict_kwargs_array],
+        [(k, ArrayLike) for k in dict_kwargs_array],
     )
     KwargsExtra = NamedTuple(
         "KwargsExtra",

--- a/aimz/utils/data/__init__.py
+++ b/aimz/utils/data/__init__.py
@@ -14,6 +14,7 @@
 
 """Utilities for data handling and processing."""
 
-from aimz.data.array_loader import ArrayLoader
+from aimz.utils.data.array_dataset import ArrayDataset
+from aimz.utils.data.array_loader import ArrayLoader
 
-__all__ = ["ArrayLoader"]
+__all__ = ["ArrayDataset", "ArrayLoader"]

--- a/aimz/utils/data/_sharding.py
+++ b/aimz/utils/data/_sharding.py
@@ -21,9 +21,10 @@ to distribute computations across devices. Tested on CPU and GPU.
 from functools import partial
 from typing import TYPE_CHECKING
 
-from jax import jit
+from jax import Array, jit
 from jax.experimental.shard_map import shard_map
 from jax.sharding import PartitionSpec
+from jax.typing import ArrayLike
 from numpyro.infer import log_likelihood as log_lik
 
 from aimz.sampling._forward import _sample_forward
@@ -31,7 +32,6 @@ from aimz.sampling._forward import _sample_forward
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    import jax
     from jax.sharding import Mesh
 
 
@@ -51,7 +51,7 @@ def _create_sharded_sampler(
 
     Returns:
         Callable: A sharded function that takes the following arguments:
-            - rng_key (jax.Array): A pseudo-random number generator key.
+            - rng_key (Array): A pseudo-random number generator key.
             - kernel (Callable): A probabilistic model with Pyro primitives.
             - posterior_samples (dict): A dictionary of posterior samples.
             - batch_shape (tuple[int]): The shape of the batch dimension, specifically
@@ -59,7 +59,7 @@ def _create_sharded_sampler(
             - param_input (str): The name of the parameter in the `kernel` for the
                 input data.
             - kwargs_key (tuple[str]): A tuple of keyword argument names.
-            - X (jax.Array): Input data.
+            - X (Array): Input data.
             - *args (tuple): Additional arguments constructed from the original keyword
                 arguments (both sharded and non-sharded).
 
@@ -68,14 +68,14 @@ def _create_sharded_sampler(
     def f(
         kernel: "Callable",
         num_samples: int,
-        rng_key: "jax.Array",
+        rng_key: ArrayLike,
         return_sites: tuple[str],
-        posterior_samples: dict[str, "jax.Array"],
+        posterior_samples: dict[str, ArrayLike],
         param_input: str,
         kwargs_key: tuple[str],
-        X: "jax.Array",
+        X: ArrayLike,
         *args: tuple,
-    ) -> dict[str, "jax.Array"]:
+    ) -> dict[str, ArrayLike]:
         return _sample_forward(
             model=kernel,
             num_samples=num_samples,
@@ -159,8 +159,8 @@ def _create_sharded_log_likelihood(
             - param_output (str): The name of the parameter in the `kernel` for the
                 output data.
             - kwargs_key (tuple[str]): A tuple of keyword argument names.
-            - X (jax.Array): Input data.
-            - y (jax.Array): Output data.
+            - X (Array): Input data.
+            - y (Array): Output data.
             - *args (tuple): Additional arguments constructed from the original keyword
                 arguments (both sharded and non-sharded).
 
@@ -172,10 +172,10 @@ def _create_sharded_log_likelihood(
         param_input: str,
         param_output: str,
         kwargs_key: tuple[str],
-        X: "jax.Array",
-        y: "jax.Array",
+        X: ArrayLike,
+        y: ArrayLike,
         *args: tuple,
-    ) -> "jax.Array":
+    ) -> Array:
         return log_lik(
             kernel,
             posterior_samples=posterior_samples,

--- a/aimz/utils/data/array_dataset.py
+++ b/aimz/utils/data/array_dataset.py
@@ -14,19 +14,17 @@
 
 """Module for custom dataset for JAX arrays."""
 
-from typing import TYPE_CHECKING
 
 import numpy as np
 from jax import tree
+from jax.typing import ArrayLike
 from torch.utils.data import Dataset
 
-if TYPE_CHECKING:
-    from jax.typing import ArrayLike
 
 class ArrayDataset(Dataset):
     """Custom Dataset class for JAX arrays based on PyTorch's Dataset."""
 
-    def __init__(self, *arrays: "ArrayLike") -> None:
+    def __init__(self, *arrays: ArrayLike) -> None:
         """Initialize an ArrayDataset instance.
 
         Args:

--- a/aimz/utils/data/array_dataset.py
+++ b/aimz/utils/data/array_dataset.py
@@ -13,18 +13,20 @@
 # limitations under the License.
 
 """Module for custom dataset for JAX arrays."""
+
 from typing import TYPE_CHECKING
 
+import numpy as np
 from jax import tree
 from torch.utils.data import Dataset
 
 if TYPE_CHECKING:
-    import jax
+    from jax.typing import ArrayLike
 
 class ArrayDataset(Dataset):
     """Custom Dataset class for JAX arrays based on PyTorch's Dataset."""
 
-    def __init__(self, *arrays: "jax.Array") -> None:
+    def __init__(self, *arrays: "ArrayLike") -> None:
         """Initialize an ArrayDataset instance.
 
         Args:
@@ -41,8 +43,10 @@ class ArrayDataset(Dataset):
         if any(len(arr) != length for arr in arrays):
             msg = "All arrays must have the same length."
             raise ValueError(msg)
-
-        self.arrays = tuple(arrays)
+        # Convert inputs to NumPy arrays for efficient CPU-based batching and slicing.
+        # Keeping data as NumPy arrays until batch collation speeds up data loading
+        # and reduces overhead from host-to-device data transfers.
+        self.arrays = tuple(np.asarray(arr) for arr in arrays)
 
     def __len__(self) -> int:
         """Get the number of samples in the dataset.

--- a/aimz/utils/data/array_loader.py
+++ b/aimz/utils/data/array_loader.py
@@ -22,14 +22,15 @@ devices.
 from typing import TYPE_CHECKING
 
 import jax.numpy as jnp
-from jax import device_put
-from jax_dataloader import ArrayDataset
+from jax import Array, device_put
+from jax.typing import ArrayLike
 from torch.utils.data import DataLoader
+
+from aimz.utils.data import ArrayDataset
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    import jax
     from jax.sharding import NamedSharding
     from torch.utils.data import Sampler
 
@@ -73,16 +74,16 @@ class ArrayLoader(DataLoader):
         return 0 if remainder == 0 else num_devices - remainder
 
     @staticmethod
-    def pad_array(x: "jax.Array", n_pad: int, axis: int) -> "jax.Array":
+    def pad_array(x: ArrayLike, n_pad: int, axis: int) -> Array:
         """Pad an array to ensure compatibility with sharding.
 
         Args:
-            x (jax.Array): The input array to be padded.
+            x (ArrayLike): The input array to be padded.
             n_pad (int): The number of padding elements to add.
             axis (int): The axis along which to apply the padding.
 
         Returns:
-            jax.Array: The padded array with padding applied along the specified axis.
+            Array: The padded array with padding applied along the specified axis.
 
         Raises:
             ValueError: If padding is requested along an unsupported axis for a 1D
@@ -124,9 +125,8 @@ class ArrayLoader(DataLoader):
             tuple: A tuple containing:
                 - n_pad (int): The number of padding rows/elements added (0 if no
                     padding was required).
-                - x_batch (jax.Array): The input batch with padding applied if
-                    necessary.
-                - kwargs_batch (list[jax.Array]): A list of keyword arguments with
+                - x_batch (Array): The input batch with padding applied if necessary.
+                - kwargs_batch (list[Array]): A list of keyword arguments with
                     padding applied if necessary.
         """
         x_batch, *kwargs_batch = map(jnp.asarray, zip(*batch, strict=True))
@@ -174,11 +174,10 @@ class ArrayLoader(DataLoader):
             tuple: A tuple containing:
                 - n_pad (int): The number of padding rows/elements added (0 if no
                     padding was required).
-                - x_batch (jax.Array): The input batch with padding applied if
-                    necessary.
-                - y_batch (jax.Array): The target batch with padding applied.
-                - kwargs_batch (list[jax.Array]): A list of keyword arguments with
-                    padding applied if necessary.
+                - x_batch (Array): The input batch with padding applied if necessary.
+                - y_batch (Array): The target batch with padding applied.
+                - kwargs_batch (list[Array]): A list of keyword arguments with padding
+                    applied if necessary.
         """
         x_batch, y_batch, *kwargs_batch = map(jnp.asarray, zip(*batch, strict=True))
 

--- a/docs/array_dataset.md
+++ b/docs/array_dataset.md
@@ -1,0 +1,1 @@
+::: aimz.data.array_dataset.ArrayDataset

--- a/docs/array_dataset.md
+++ b/docs/array_dataset.md
@@ -1,1 +1,1 @@
-::: aimz.data.array_dataset.ArrayDataset
+::: aimz.utils.data.array_dataset.ArrayDataset

--- a/docs/array_loader.md
+++ b/docs/array_loader.md
@@ -1,1 +1,1 @@
-::: aimz.data.array_loader.ArrayLoader
+::: aimz.utils.data.array_loader.ArrayLoader

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,5 @@
+---
+title: Changelog
+---
+
+--8<-- "CHANGELOG.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,8 +87,9 @@ nav:
   - API Reference: 
     - Model:
       - ImpactModel: impact_model.md
-    - Data:
-      - ArrayDataset: array_dataset.md
-      - ArrayLoader: array_loader.md
+    - Utils:
+      - Data:
+        - ArrayDataset: array_dataset.md
+        - ArrayLoader: array_loader.md
   - Examples:
     - WIP: wip.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,12 +5,16 @@ site_author: Eunseop Kim
 repo_name: markean/aimz
 repo_url: https://github.com/markean/aimz
 
+watch: [mkdocs.yml, README.md, CONTRIBUTING.md, CHANGELOG.md, docs]
+
 copyright: Copyright &copy; Eli Lilly and Company
 
 theme: 
   name: material
   features:
     - announce.dismiss
+    - content.code.copy
+    - content.action.view
     - header.autohide
     - navigation.tracking
     - navigation.sections
@@ -53,6 +57,7 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.superfences
+  - pymdownx.snippets
 
 plugins:
 - search
@@ -84,6 +89,8 @@ nav:
   - Home: index.md
   - Getting Started:
     - Installation: installation.md
+  - Examples:
+    - WIP: wip.md
   - API Reference: 
     - Model:
       - ImpactModel: impact_model.md
@@ -91,5 +98,4 @@ nav:
       - Data:
         - ArrayDataset: array_dataset.md
         - ArrayLoader: array_loader.md
-  - Examples:
-    - WIP: wip.md
+  - Changelog: changelog.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
     - Model:
       - ImpactModel: impact_model.md
     - Data:
+      - ArrayDataset: array_dataset.md
       - ArrayLoader: array_loader.md
   - Examples:
     - WIP: wip.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "arviz>=0.21",
     "dask>=2025.5",
     "jax>=0.5.3",
-    "jax-dataloader>=0.1.3",
     "numpyro>=0.18.0",
     "scikit-learn>=1.6.1",
     "torch>=2.7",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,30 +14,26 @@
 
 """pytest configuration."""
 
-from typing import TYPE_CHECKING
 
 import jax.numpy as jnp
 import numpyro
 import numpyro.distributions as dist
 import pytest
-from jax import random
+from jax import Array, random
+from jax.typing import ArrayLike
 from numpyro import sample
 from numpyro.infer import SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
-
-if TYPE_CHECKING:
-    import jax
 
 numpyro.set_host_device_count(3)
 
 
 @pytest.fixture(scope="module")
-def synthetic_data() -> tuple["jax.Array", "jax.Array"]:
+def synthetic_data() -> tuple[Array, Array]:
     """Fixture for generating synthetic data.
 
     Returns:
-        tuple[jax.Array, jax.Array]: A tuple containing the input data and
-            output data.
+        tuple[Array, Array]: A tuple containing the input data and output data.
     """
     rng_key = random.key(42)
     key_w, key_b, key_x, key_e = random.split(rng_key, 4)
@@ -73,7 +69,7 @@ def vi(request: pytest.FixtureRequest) -> SVI:
     )
 
 
-def lm(X: "jax.Array", y: "jax.Array | None" = None) -> None:
+def lm(X: ArrayLike, y: ArrayLike | None = None) -> None:
     """Linear regression model."""
     n_features = X.shape[1]
 
@@ -88,9 +84,9 @@ def lm(X: "jax.Array", y: "jax.Array | None" = None) -> None:
 
 
 def lm_with_kwargs_array(
-    X: "jax.Array",
-    c: "jax.Array",
-    y: "jax.Array | None" = None,
+    X: ArrayLike,
+    c: ArrayLike,
+    y: ArrayLike | None = None,
 ) -> None:
     """Linear regression model with an extra array argument."""
     n_features = X.shape[1]
@@ -105,7 +101,7 @@ def lm_with_kwargs_array(
     sample("y", dist.Normal(mu, sigma), obs=y)
 
 
-def latent_variable_model(X: "jax.Array", y: "jax.Array | None" = None) -> None:
+def latent_variable_model(X: ArrayLike, y: ArrayLike | None = None) -> None:
     """Latent variable model."""
     z = numpyro.sample(
         "z",

--- a/tests/test_fit_on_batch.py
+++ b/tests/test_fit_on_batch.py
@@ -14,22 +14,19 @@
 
 """Tests for the `.fit_on_batch()` method."""
 
-from typing import TYPE_CHECKING
 
 import pytest
 from conftest import lm
 from jax import random
+from jax.typing import ArrayLike
 from numpyro.infer import SVI
 
 from aimz.model import ImpactModel
 from aimz.utils._validation import _is_fitted
 
-if TYPE_CHECKING:
-    import jax
-
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
-def test_fit_lm(synthetic_data: tuple["jax.Array", "jax.Array"], vi: SVI) -> None:
+def test_fit_lm(synthetic_data: tuple[ArrayLike, ArrayLike], vi: SVI) -> None:
     """Test the `.fit()` method of `ImpactModel`."""
     X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), vi=vi)

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -14,19 +14,16 @@
 
 """Tests for the model kernel."""
 
-from typing import TYPE_CHECKING
 
 import pytest
 from jax import random
+from jax.typing import ArrayLike
 from numpyro.infer import SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
 from numpyro.optim import Adam
 
 from aimz._exceptions import KernelValidationError
 from aimz.model import ImpactModel
-
-if TYPE_CHECKING:
-    import jax
 
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
@@ -36,7 +33,7 @@ class TestModelKernel:
     def test_kernel_with_args(self) -> None:
         """Kernel with *args raises an error."""
 
-        def kernel(X: "jax.Array", y: "jax.Array | None" = None, *args: tuple) -> None:
+        def kernel(X: ArrayLike, y: ArrayLike | None = None, *args: tuple) -> None:
             pass
 
         with pytest.raises(KernelValidationError):
@@ -55,8 +52,8 @@ class TestModelKernel:
         """Kernel with **kwargs raises an error."""
 
         def kernel(
-            X: "jax.Array",
-            y: "jax.Array | None" = None,
+            X: ArrayLike,
+            y: ArrayLike | None = None,
             **kwargs: object,
         ) -> None:
             pass
@@ -76,7 +73,7 @@ class TestModelKernel:
     def test_kernel_with_no_input(self) -> None:
         """Kernel without input raises an error."""
 
-        def kernel(x: object, y: "jax.Array | None" = None) -> None:
+        def kernel(x: object, y: ArrayLike | None = None) -> None:
             pass
 
         with pytest.raises(KernelValidationError):
@@ -94,7 +91,7 @@ class TestModelKernel:
     def test_kernel_with_no_ouput(self) -> None:
         """Kernel without output raises an error."""
 
-        def kernel(X: "jax.Array", yy: object) -> None:
+        def kernel(X: ArrayLike, yy: object) -> None:
             pass
 
         with pytest.raises(KernelValidationError):
@@ -112,7 +109,7 @@ class TestModelKernel:
     def test_kernel_with_default_input(self) -> None:
         """Kernel with a `None` default input parameter raises an error."""
 
-        def kernel(X: "jax.Array | None" = None, y: "jax.Array | None" = None) -> None:
+        def kernel(X: ArrayLike | None = None, y: ArrayLike | None = None) -> None:
             pass
 
         with pytest.raises(KernelValidationError):
@@ -130,7 +127,7 @@ class TestModelKernel:
     def test_kernel_with_non_default_output(self) -> None:
         """Kernel with a non-`None` default output parameter raises an error."""
 
-        def kernel(X: "jax.Array", y: "jax.Array") -> None:
+        def kernel(X: ArrayLike, y: ArrayLike) -> None:
             pass
 
         with pytest.raises(KernelValidationError):

--- a/tests/test_log_likelihood.py
+++ b/tests/test_log_likelihood.py
@@ -14,11 +14,11 @@
 
 """Tests for the `.log_likelihood()` method."""
 
-from typing import TYPE_CHECKING
 
 import pytest
 from conftest import lm
 from jax import random
+from jax.typing import ArrayLike
 from numpyro.infer import SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
 from numpyro.optim import Adam
@@ -26,14 +26,11 @@ from numpyro.optim import Adam
 from aimz._exceptions import NotFittedError
 from aimz.model import ImpactModel
 
-if TYPE_CHECKING:
-    import jax
-
 
 def test_model_not_fitted() -> None:
     """Calling `.log_likelihood()` on an unfitted model raises an error."""
 
-    def kernel(X: "jax.Array", y: "jax.Array | None" = None) -> None:
+    def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
         pass
 
     im = ImpactModel(
@@ -56,7 +53,7 @@ class TestBatchSize:
     @pytest.mark.parametrize("vi", [lm], indirect=True)
     def test_default_batch_size(
         self,
-        synthetic_data: tuple["jax.Array", "jax.Array"],
+        synthetic_data: tuple[ArrayLike, ArrayLike],
         vi: SVI,
     ) -> None:
         """Warns if `batch_size` is not explicitly set."""

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -14,12 +14,11 @@
 
 """Tests for the `.predict()` method."""
 
-from typing import TYPE_CHECKING
-
 import numpyro.distributions as dist
 import pytest
 from conftest import latent_variable_model, lm
 from jax import random
+from jax.typing import ArrayLike
 from numpyro import sample
 from numpyro.infer import SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
@@ -28,14 +27,11 @@ from numpyro.optim import Adam
 from aimz._exceptions import NotFittedError
 from aimz.model import ImpactModel
 
-if TYPE_CHECKING:
-    import jax
-
 
 def test_model_not_fitted() -> None:
     """Calling `.predict()` on an unfitted model raises an error."""
 
-    def kernel(X: "jax.Array", y: "jax.Array | None" = None) -> None:
+    def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
         pass
 
     im = ImpactModel(
@@ -54,7 +50,7 @@ def test_model_not_fitted() -> None:
 
 @pytest.mark.parametrize("vi", [latent_variable_model], indirect=True)
 def test_predict_fall_back(
-    synthetic_data: tuple["jax.Array", "jax.Array"],
+    synthetic_data: tuple[ArrayLike, ArrayLike],
     vi: SVI,
 ) -> None:
     """Calling `.predict()` warns and falls back on an incompatible model."""
@@ -72,7 +68,7 @@ class TestKernelParameterValidation:
     @pytest.mark.parametrize("vi", [lm], indirect=True)
     def test_invalid_parameter(
         self,
-        synthetic_data: tuple["jax.Array", "jax.Array"],
+        synthetic_data: tuple[ArrayLike, ArrayLike],
         vi: SVI,
     ) -> None:
         """An invalid parameter raise an error."""
@@ -85,7 +81,7 @@ class TestKernelParameterValidation:
     @pytest.mark.parametrize("vi", [lm], indirect=True)
     def test_extra_parameters(
         self,
-        synthetic_data: tuple["jax.Array", "jax.Array"],
+        synthetic_data: tuple[ArrayLike, ArrayLike],
         vi: SVI,
     ) -> None:
         """Extra parameters not present in the kernel raise an error."""
@@ -97,13 +93,13 @@ class TestKernelParameterValidation:
 
     def test_missing_parameters(
         self,
-        synthetic_data: tuple["jax.Array", "jax.Array"],
+        synthetic_data: tuple[ArrayLike, ArrayLike],
     ) -> None:
         """Missing required parameters in the kernel raise an error."""
         X, y = synthetic_data
         arg = True
 
-        def kernel(X: "jax.Array", arg: object, y: "jax.Array | None" = None) -> None:
+        def kernel(X: ArrayLike, arg: object, y: ArrayLike | None = None) -> None:
             sample("y", dist.Normal(0.0, 1.0), obs=y)
 
         vi = SVI(
@@ -124,7 +120,7 @@ class TestBatchSize:
     @pytest.mark.parametrize("vi", [lm], indirect=True)
     def test_default_batch_size(
         self,
-        synthetic_data: tuple["jax.Array", "jax.Array"],
+        synthetic_data: tuple[ArrayLike, ArrayLike],
         vi: SVI,
     ) -> None:
         """Warns if `batch_size` is not explicitly set."""
@@ -139,7 +135,7 @@ class TestBatchSize:
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
 def test_predict_after_cleanup(
-    synthetic_data: tuple["jax.Array", "jax.Array"],
+    synthetic_data: tuple[ArrayLike, ArrayLike],
     vi: SVI,
 ) -> None:
     """Test `.predict()` recreates tempdir after `.cleanup()`."""

--- a/tests/test_predict_on_batch.py
+++ b/tests/test_predict_on_batch.py
@@ -14,12 +14,12 @@
 
 """Tests for the `.predict_on_batch()` method."""
 
-from typing import TYPE_CHECKING
 
 import numpyro.distributions as dist
 import pytest
 from conftest import lm, lm_with_kwargs_array
 from jax import random
+from jax.typing import ArrayLike
 from numpyro import sample
 from numpyro.infer import SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
@@ -28,14 +28,11 @@ from numpyro.optim import Adam
 from aimz._exceptions import NotFittedError
 from aimz.model import ImpactModel
 
-if TYPE_CHECKING:
-    import jax
-
 
 def test_model_not_fitted() -> None:
     """Calling `.predict_on_batch()` on an unfitted model raises an error."""
 
-    def kernel(X: "jax.Array", y: "jax.Array | None" = None) -> None:
+    def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
         pass
 
     im = ImpactModel(
@@ -58,7 +55,7 @@ class TestKernelParameterValidation:
     @pytest.mark.parametrize("vi", [lm], indirect=True)
     def test_invalid_parameter(
         self,
-        synthetic_data: tuple["jax.Array", "jax.Array"],
+        synthetic_data: tuple[ArrayLike, ArrayLike],
         vi: SVI,
     ) -> None:
         """An invalid parameter raise an error."""
@@ -71,7 +68,7 @@ class TestKernelParameterValidation:
     @pytest.mark.parametrize("vi", [lm], indirect=True)
     def test_extra_parameters(
         self,
-        synthetic_data: tuple["jax.Array", "jax.Array"],
+        synthetic_data: tuple[ArrayLike, ArrayLike],
         vi: SVI,
     ) -> None:
         """Extra parameters not present in the kernel raise an error."""
@@ -83,13 +80,13 @@ class TestKernelParameterValidation:
 
     def test_missing_parameters(
         self,
-        synthetic_data: tuple["jax.Array", "jax.Array"],
+        synthetic_data: tuple[ArrayLike, ArrayLike],
     ) -> None:
         """Missing required parameters in the kernel raise an error."""
         X, y = synthetic_data
         arg = True
 
-        def kernel(X: "jax.Array", arg: object, y: "jax.Array | None" = None) -> None:
+        def kernel(X: ArrayLike, arg: object, y: ArrayLike | None = None) -> None:
             sample("y", dist.Normal(0.0, 1.0), obs=y)
 
         vi = SVI(
@@ -106,7 +103,7 @@ class TestKernelParameterValidation:
 
 @pytest.mark.parametrize("vi", [lm_with_kwargs_array], indirect=True)
 def test_predict_on_batch_lm_with_kwargs_array(
-    synthetic_data: tuple["jax.Array", "jax.Array"],
+    synthetic_data: tuple[ArrayLike, ArrayLike],
     vi: SVI,
 ) -> None:
     """Test the `.predict_on_batch()` method of `ImpactModel`."""

--- a/tests/test_sample_posterior_predictive.py
+++ b/tests/test_sample_posterior_predictive.py
@@ -19,11 +19,11 @@ from typing import TYPE_CHECKING
 import pytest
 from conftest import lm
 from jax import random
+from jax.typing import ArrayLike
 
 from aimz.model import ImpactModel
 
 if TYPE_CHECKING:
-    import jax
     from numpyro.infer import SVI
 
 
@@ -33,7 +33,7 @@ class TestKernelParameterValidation:
 
     def test_invalid_parameter(
         self,
-        synthetic_data: tuple["jax.Array", "jax.Array"],
+        synthetic_data: tuple[ArrayLike, ArrayLike],
         vi: "SVI",
     ) -> None:
         """An invalid parameter raise an error."""
@@ -46,7 +46,7 @@ class TestKernelParameterValidation:
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
 def test_sample_posterior_predictive_lm(
-    synthetic_data: tuple["jax.Array", "jax.Array"],
+    synthetic_data: tuple[ArrayLike, ArrayLike],
     vi: "SVI",
 ) -> None:
     """Test the `.sample_posterior_predictive()` method of `ImpactModel`."""

--- a/tests/test_sample_prior_predictive.py
+++ b/tests/test_sample_prior_predictive.py
@@ -19,11 +19,11 @@ from typing import TYPE_CHECKING
 import pytest
 from conftest import lm
 from jax import random
+from jax.typing import ArrayLike
 
 from aimz.model import ImpactModel
 
 if TYPE_CHECKING:
-    import jax
     from numpyro.infer import SVI
 
 
@@ -33,7 +33,7 @@ class TestKernelParameterValidation:
 
     def test_invalid_parameter(
         self,
-        synthetic_data: tuple["jax.Array", "jax.Array"],
+        synthetic_data: tuple[ArrayLike, ArrayLike],
         vi: "SVI",
     ) -> None:
         """An invalid parameter raise an error."""
@@ -45,7 +45,7 @@ class TestKernelParameterValidation:
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
 def test_sample_prior_predictive_lm(
-    synthetic_data: tuple["jax.Array", "jax.Array"],
+    synthetic_data: tuple[ArrayLike, ArrayLike],
     vi: "SVI",
 ) -> None:
     """Test the `.sample_prior_predictive()` method of `ImpactModel`."""

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -21,17 +21,17 @@ import dill
 import pytest
 from conftest import lm
 from jax import random
+from jax.typing import ArrayLike
 
 from aimz.model import ImpactModel
 
 if TYPE_CHECKING:
-    import jax
     from numpyro.infer import SVI
 
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
 def test_save_load(
-    synthetic_data: tuple["jax.Array", "jax.Array"],
+    synthetic_data: tuple[ArrayLike, ArrayLike],
     vi: "SVI",
     tmp_path: "Path",
 ) -> None:

--- a/tests/test_set_posterior_sample.py
+++ b/tests/test_set_posterior_sample.py
@@ -21,6 +21,7 @@ import pytest
 from conftest import lm
 from jax import numpy as jnp
 from jax import random
+from jax.typing import ArrayLike
 from numpyro.infer import Predictive
 from numpyro.infer.svi import SVIRunResult
 
@@ -28,13 +29,12 @@ from aimz.model import ImpactModel
 from aimz.utils._validation import _is_fitted
 
 if TYPE_CHECKING:
-    import jax
     from numpyro.infer import SVI
 
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
 def test_set_posterior_sample(
-    synthetic_data: tuple["jax.Array", "jax.Array"],
+    synthetic_data: tuple[ArrayLike, ArrayLike],
     vi: "SVI",
 ) -> None:
     """Test the `.set_posterior_sample()` method of `ImpactModel`."""

--- a/tests/test_train_on_batch.py
+++ b/tests/test_train_on_batch.py
@@ -14,22 +14,18 @@
 
 """Tests for the `.train_on_batch()` method."""
 
-from typing import TYPE_CHECKING
-
 import pytest
 from conftest import lm_with_kwargs_array
 from jax import random
+from jax.typing import ArrayLike
 from numpyro.infer import SVI
 
 from aimz.model import ImpactModel
 
-if TYPE_CHECKING:
-    import jax
-
 
 @pytest.mark.parametrize("vi", [lm_with_kwargs_array], indirect=True)
 def test_train_on_batch_lm_with_kwargs_array(
-    synthetic_data: tuple["jax.Array", "jax.Array"],
+    synthetic_data: tuple[ArrayLike, ArrayLike],
     vi: SVI,
 ) -> None:
     """Test the `.train_on_batch()` method of `ImpactModel`."""

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,6 @@ dependencies = [
     { name = "arviz" },
     { name = "dask" },
     { name = "jax" },
-    { name = "jax-dataloader" },
     { name = "numpyro" },
     { name = "scikit-learn" },
     { name = "torch" },
@@ -42,7 +41,6 @@ requires-dist = [
     { name = "dill", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "jax", specifier = ">=0.5.3" },
     { name = "jax", extras = ["cuda12"], marker = "extra == 'gpu'", specifier = ">=0.5.3" },
-    { name = "jax-dataloader", specifier = ">=0.1.3" },
     { name = "numpyro", specifier = ">=0.18.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6" },
@@ -74,15 +72,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/16/f9/68758d136599d0a48344f5528d8da3f1f6e10df119ff3dd95e8535595e8d/arviz-0.21.0.tar.gz", hash = "sha256:ad5c99b998b750e585bdd1f3ba11e3f8729e01d06dc7fdc251450039e88cfd71", size = 1586252, upload-time = "2025-03-06T16:06:52.835Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/a5/ee388284ef7fc945f3f58ef6a1045e45f7124aa73d0ecab556e23e5bd3ee/arviz-0.21.0-py3-none-any.whl", hash = "sha256:fee1008af6d10c35dbd6b3335569d46a685d87be1b23e17f1fd0ef673aae5623", size = 1667842, upload-time = "2025-03-06T16:06:50.523Z" },
-]
-
-[[package]]
-name = "beartype"
-version = "0.21.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/f9/21e5a9c731e14f08addd53c71fea2e70794e009de5b98e6a2c3d2f3015d6/beartype-0.21.0.tar.gz", hash = "sha256:f9a5078f5ce87261c2d22851d19b050b64f6a805439e8793aecf01ce660d3244", size = 1437066, upload-time = "2025-05-22T05:09:27.116Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/31/87045d1c66ee10a52486c9d2047bc69f00f2689f69401bb1e998afb4b205/beartype-0.21.0-py3-none-any.whl", hash = "sha256:b6a1bd56c72f31b0a496a36cc55df6e2f475db166ad07fa4acc7e74f4c7f34c0", size = 1191340, upload-time = "2025-05-22T05:09:24.606Z" },
 ]
 
 [[package]]
@@ -504,19 +493,6 @@ with-cuda = [
 ]
 
 [[package]]
-name = "jax-dataloader"
-version = "0.1.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jax" },
-    { name = "plum-dispatch" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/97/6f50d15802d2ce6854ee3d6d394424c18e67b4733981bbd265d01dcc8fd6/jax-dataloader-0.1.3.tar.gz", hash = "sha256:2a1b4aecfc608579c29e1bbe41cfd7830be635d1c41abaca27491b5e9cb02dd0", size = 18998, upload-time = "2024-10-18T19:45:34.202Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/d7/4e4e23009ccb9b8b329035179be6b7f20ed01a9db9174bf94d7430552138/jax_dataloader-0.1.3-py3-none-any.whl", hash = "sha256:ee5950938f90ba18a78ec07eaa4bbbfb67fd5d18f76d2848558d00f89aa8ac32", size = 20347, upload-time = "2024-10-18T19:45:32.393Z" },
-]
-
-[[package]]
 name = "jaxlib"
 version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -638,18 +614,6 @@ wheels = [
 ]
 
 [[package]]
-name = "markdown-it-py"
-version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
-]
-
-[[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -738,15 +702,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/c7/473bc559beec08ebee9f86ca77a844b65747e1a6c2691e8c92e40b9f42a8/matplotlib-3.10.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6929fc618cb6db9cb75086f73b3219bbb25920cb24cee2ea7a12b04971a4158", size = 8618082, upload-time = "2025-05-08T19:10:39.892Z" },
     { url = "https://files.pythonhosted.org/packages/d8/e9/6ce8edd264c8819e37bbed8172e0ccdc7107fe86999b76ab5752276357a4/matplotlib-3.10.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6c7818292a5cc372a2dc4c795e5c356942eb8350b98ef913f7fda51fe175ac5d", size = 9413699, upload-time = "2025-05-08T19:10:42.376Z" },
     { url = "https://files.pythonhosted.org/packages/1b/92/9a45c91089c3cf690b5badd4be81e392ff086ccca8a1d4e3a08463d8a966/matplotlib-3.10.3-cp313-cp313t-win_amd64.whl", hash = "sha256:4f23ffe95c5667ef8a2b56eea9b53db7f43910fa4a2d5472ae0f72b64deab4d5", size = 8139044, upload-time = "2025-05-08T19:10:44.551Z" },
-]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -1227,20 +1182,6 @@ wheels = [
 ]
 
 [[package]]
-name = "plum-dispatch"
-version = "2.5.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beartype" },
-    { name = "rich" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/46/ab3928e864b0a88a8ae6987b3da3b7ae32fe0a610264f33272139275dab5/plum_dispatch-2.5.7.tar.gz", hash = "sha256:a7908ad5563b93f387e3817eb0412ad40cfbad04bc61d869cf7a76cd58a3895d", size = 35452, upload-time = "2025-01-17T20:07:31.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/31/21609a9be48e877bc33b089a7f495c853215def5aeb9564a31c210d9d769/plum_dispatch-2.5.7-py3-none-any.whl", hash = "sha256:06471782eea0b3798c1e79dca2af2165bafcfa5eb595540b514ddd81053b1ede", size = 42612, upload-time = "2025-01-17T20:07:26.461Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1342,19 +1283,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
-]
-
-[[package]]
-name = "rich"
-version = "14.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Introduce a new `ArrayDataset` class for handling JAX arrays, replace the `jax-dataloader` dependency with a custom data loader, and enhance type annotations throughout the codebase. Update documentation links, add a CHANGELOG, and refine type casting in methods.

This closes #14.