### PR TITLE
Refactor ArrayLoader and ArrayDataset to remove PyTorch dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
       # Ruff version.
-      rev: v0.12.2
+      rev: v0.12.3
       hooks:
           # Run the linter.
           - id: ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Removed
+
+- Removed the `torch` dependency (@markean, [#26](https://github.com/markean/aimz/issues/26)).
+
 ## [v0.2.0](https://github.com/markean/aimz/releases/tag/v0.2.0) - 2025-07-10
 
 ### Added

--- a/aimz/utils/data/array_loader.py
+++ b/aimz/utils/data/array_loader.py
@@ -19,75 +19,67 @@ padding to ensure the batch size is compatible with sharding across multiple XLA
 devices.
 """
 
+from collections.abc import Iterator
+from math import ceil
 from typing import TYPE_CHECKING
+from warnings import warn
 
 import jax.numpy as jnp
-from jax import Array, device_put
+from jax import Array, device_put, local_device_count, random, tree
 from jax.typing import ArrayLike
-from torch.utils.data import DataLoader
 
 from aimz.utils.data.array_dataset import ArrayDataset
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
-    from jax.sharding import NamedSharding
-    from torch.utils.data import Sampler
+    from jax.sharding import Sharding
 
 
-class ArrayLoader(DataLoader):
-    """Custom DataLoader class for JAX arrays based on PyTorch's DataLoader."""
+class ArrayLoader:
+    """ArrayLoader class for JAX arrays."""
 
     def __init__(
         self,
         dataset: ArrayDataset,
+        rng_key: ArrayLike,
         *,
-        batch_size: int = 1,
+        batch_size: int = 32,
         shuffle: bool = False,
-        sampler: "Sampler | None" = None,
-        num_workers: int = 0,
-        collate_fn: "Callable | None" = None,
-        pin_memory: bool = False,
-        drop_last: bool = False,
+        device: "Sharding | None" = None,
     ) -> None:
-        """Initializes an ArrayLoader instance."""
-        super().__init__(
-            dataset,
-            batch_size=batch_size,
-            shuffle=shuffle,
-            sampler=sampler,
-            num_workers=num_workers,
-            collate_fn=collate_fn,
-            pin_memory=pin_memory,
-            drop_last=drop_last,
-        )
-
-    @staticmethod
-    def calculate_padding(batch_size: int, num_devices: int) -> int:
-        """Calculate the number of padding needed.
+        """Initialize an ArrayLoader instance.
 
         Args:
-            batch_size (int): The size of the batch.
-            num_devices (int): The number of devices.
-
-        Returns:
-            int: The number of padding rows (or elements) needed to make the batch size
-                divisible by the number of devices.
+            dataset (ArrayDataset): The dataset to load.
+            rng_key (ArrayLike): A pseudo-random number generator key.
+            batch_size (int): The number of samples per batch. Defaults to `32`.
+            shuffle (bool, optional): Whether to shuffle the dataset before batching.
+                Defaults to `False`.
+            device (Sharding | None, optional): The device or sharding specification to
+                which the data should be moved. Defaults to `None`, meaning no device
+                transfer is applied.
         """
-        remainder = batch_size % num_devices
-        return 0 if remainder == 0 else num_devices - remainder
+        self.dataset = dataset
+        self.batch_size = batch_size
+        self.shuffle = shuffle
+        self.indices = jnp.arange(len(self.dataset))
+        if rng_key.dtype == jnp.uint32:
+            msg = "Legacy `uint32` PRNGKey detected; converting to a typed key array."
+            warn(msg, category=UserWarning, stacklevel=2)
+            rng_key = random.wrap_key_data(rng_key)
+        self.rng_key = rng_key
+        self._num_devices = local_device_count()
+        self.device = device
 
-    @staticmethod
-    def pad_array(x: ArrayLike, n_pad: int, axis: int) -> Array:
+    def pad_array(self, x: ArrayLike, n_pad: int, axis: int = 0) -> Array:
         """Pad an array to ensure compatibility with sharding.
 
         Args:
             x (ArrayLike): The input array to be padded.
             n_pad (int): The number of padding elements to add.
-            axis (int): The axis along which to apply the padding.
+            axis (int): The axis along which to apply the padding. Defaults to `0`.
 
         Returns:
-            Array: The padded array with padding applied along the specified axis.
+            The padded array with padding applied along the specified axis.
 
         Raises:
             ValueError: If padding is requested along an unsupported axis for a 1D
@@ -106,103 +98,36 @@ class ArrayLoader(DataLoader):
 
         return jnp.pad(x, pad_width=pad_width, mode="edge")
 
-    @staticmethod
-    def collate_without_output(
-        batch: list[tuple],
-        device: "NamedSharding | None" = None,
-    ) -> tuple:
-        """Collate function to process batches with sharding and padding.
+    def __iter__(self) -> Iterator[tuple[dict[str, Array], int]]:
+        """Iterate over the dataset in batches.
 
-        This function unpacks the batch of data, converts it into JAX arrays, and
-        applies padding to ensure the batch size is compatible with the number of
-        devices, if sharding is necessary. When a device is provided, the data is
-        automatically distributed across the available devices.
+        Yields:
+            A batch of arrays with data from the dataset.
+            The number of padded samples added for sharding compatibility.
+        """
+        indices = self.indices
+        if self.shuffle:
+            self.rng_key, subkey = random.split(self.rng_key)
+            indices = random.permutation(subkey, self.indices)
+        for start in range(0, len(self.dataset), self.batch_size):
+            end = start + self.batch_size
+            batch_idx = indices[start:end]
+            if self.device is not None:
+                n_pad = (-len(batch_idx)) % self._num_devices
+                batch = {
+                    k: self.pad_array(arr[batch_idx], n_pad=n_pad)
+                    for k, arr in self.dataset.arrays.items()
+                }
+                batch = tree.map(lambda x: device_put(x, self.device), batch)
+            else:
+                n_pad = 0
+                batch = {k: arr[batch_idx] for k, arr in self.dataset.arrays.items()}
+            yield batch, n_pad
 
-        Args:
-            batch (list[tuple]): A list of tuples, where each tuple contains the input
-                data, optional target data, and array-like keyword arguments.
-            device (NamedSharding | None, optional): Sharding using named axes for
-                parallel data distribution across devices. Defaults to `None`, meaning
-                no sharding is applied.
+    def __len__(self) -> int:
+        """Return the number of batches.
 
         Returns:
-            tuple: A tuple containing:
-                - n_pad (int): The number of padding rows/elements added (0 if no
-                    padding was required).
-                - x_batch (Array): The input batch with padding applied if necessary.
-                - kwargs_batch (list[Array]): A list of keyword arguments with
-                    padding applied if necessary.
+            The total number of batches.
         """
-        x_batch, *kwargs_batch = map(jnp.asarray, zip(*batch, strict=True))
-
-        n_pad = (
-            ArrayLoader.calculate_padding(
-                len(x_batch),
-                num_devices=device.num_devices,
-            )
-            if device
-            else 0
-        )
-        if n_pad:
-            x_batch = ArrayLoader.pad_array(x_batch, n_pad=n_pad, axis=0)
-            kwargs_batch = [
-                ArrayLoader.pad_array(x, n_pad=n_pad, axis=0) for x in kwargs_batch
-            ]
-
-        if device:
-            x_batch = device_put(x_batch, device=device)
-            kwargs_batch = [device_put(x, device=device) for x in kwargs_batch]
-
-        return n_pad, x_batch, *kwargs_batch
-
-    @staticmethod
-    def collate_with_sharding(
-        batch: list[tuple],
-        device: "NamedSharding | None" = None,
-    ) -> tuple:
-        """Collate function to process batches with sharding and padding.
-
-        This function unpacks the batch of data, converts it into JAX arrays, and
-        applies padding to ensure the batch size is compatible with the number of
-        devices, if sharding is necessary. When a device is provided, the data is
-        automatically distributed across the available devices.
-
-        Args:
-            batch (list[tuple]): A list of tuples, where each tuple contains the input
-                data, optional target data, and array-like keyword arguments.
-            device (NamedSharding | None, optional): Sharding using named axes for
-                parallel data distribution across devices. Defaults to `None`, meaning
-                no sharding is applied.
-
-        Returns:
-            tuple: A tuple containing:
-                - n_pad (int): The number of padding rows/elements added (0 if no
-                    padding was required).
-                - x_batch (Array): The input batch with padding applied if necessary.
-                - y_batch (Array): The target batch with padding applied.
-                - kwargs_batch (list[Array]): A list of keyword arguments with padding
-                    applied if necessary.
-        """
-        x_batch, y_batch, *kwargs_batch = map(jnp.asarray, zip(*batch, strict=True))
-
-        n_pad = (
-            ArrayLoader.calculate_padding(
-                len(x_batch),
-                num_devices=device.num_devices,
-            )
-            if device
-            else 0
-        )
-        if n_pad:
-            x_batch = ArrayLoader.pad_array(x_batch, n_pad=n_pad, axis=0)
-            y_batch = ArrayLoader.pad_array(y_batch, n_pad=n_pad, axis=0)
-            kwargs_batch = [
-                ArrayLoader.pad_array(x, n_pad=n_pad, axis=0) for x in kwargs_batch
-            ]
-
-        if device:
-            x_batch = device_put(x_batch, device=device)
-            y_batch = device_put(y_batch, device=device)
-            kwargs_batch = [device_put(x, device=device) for x in kwargs_batch]
-
-        return n_pad, x_batch, y_batch, *kwargs_batch
+        return ceil(len(self.dataset) / self.batch_size)

--- a/array_loader_copy.py
+++ b/array_loader_copy.py
@@ -1,0 +1,208 @@
+# Copyright 2025 Eli Lilly and Company
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for custom data loader with padding logic for JAX arrays.
+
+This module defines a custom `ArrayLoader` that processes batches of data and applies
+padding to ensure the batch size is compatible with sharding across multiple XLA
+devices.
+"""
+
+from typing import TYPE_CHECKING
+
+import jax.numpy as jnp
+from jax import Array, device_put
+from jax.typing import ArrayLike
+from torch.utils.data import DataLoader
+
+from aimz.utils.data.array_dataset import ArrayDataset
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from jax.sharding import NamedSharding
+    from torch.utils.data import Sampler
+
+
+class ArrayLoader(DataLoader):
+    """Custom DataLoader class for JAX arrays based on PyTorch's DataLoader."""
+
+    def __init__(
+        self,
+        dataset: ArrayDataset,
+        *,
+        batch_size: int = 1,
+        shuffle: bool = False,
+        sampler: "Sampler | None" = None,
+        num_workers: int = 0,
+        collate_fn: "Callable | None" = None,
+        pin_memory: bool = False,
+        drop_last: bool = False,
+    ) -> None:
+        """Initializes an ArrayLoader instance."""
+        super().__init__(
+            dataset,
+            batch_size=batch_size,
+            shuffle=shuffle,
+            sampler=sampler,
+            num_workers=num_workers,
+            collate_fn=collate_fn,
+            pin_memory=pin_memory,
+            drop_last=drop_last,
+        )
+
+    @staticmethod
+    def calculate_padding(batch_size: int, num_devices: int) -> int:
+        """Calculate the number of padding needed.
+
+        Args:
+            batch_size (int): The size of the batch.
+            num_devices (int): The number of devices.
+
+        Returns:
+            int: The number of padding rows (or elements) needed to make the batch size
+                divisible by the number of devices.
+        """
+        remainder = batch_size % num_devices
+        return 0 if remainder == 0 else num_devices - remainder
+
+    @staticmethod
+    def pad_array(x: ArrayLike, n_pad: int, axis: int) -> Array:
+        """Pad an array to ensure compatibility with sharding.
+
+        Args:
+            x (ArrayLike): The input array to be padded.
+            n_pad (int): The number of padding elements to add.
+            axis (int): The axis along which to apply the padding.
+
+        Returns:
+            Array: The padded array with padding applied along the specified axis.
+
+        Raises:
+            ValueError: If padding is requested along an unsupported axis for a 1D
+                array.
+        """
+        if x.ndim == 1:
+            if axis == 0:
+                return jnp.pad(x, pad_width=(0, n_pad), mode="edge")
+            msg = "Padding 1D arrays is only supported along axis 0."
+            raise ValueError(msg)
+
+        # Initialize all axes with no padding
+        pad_width: list[tuple[int, int]] = [(0, 0)] * x.ndim
+        # Apply padding to the specified axis
+        pad_width[axis] = (0, n_pad)
+
+        return jnp.pad(x, pad_width=pad_width, mode="edge")
+
+    @staticmethod
+    def collate_without_output(
+        batch: list[tuple],
+        device: "NamedSharding | None" = None,
+    ) -> tuple:
+        """Collate function to process batches with sharding and padding.
+
+        This function unpacks the batch of data, converts it into JAX arrays, and
+        applies padding to ensure the batch size is compatible with the number of
+        devices, if sharding is necessary. When a device is provided, the data is
+        automatically distributed across the available devices.
+
+        Args:
+            batch (list[tuple]): A list of tuples, where each tuple contains the input
+                data, optional target data, and array-like keyword arguments.
+            device (NamedSharding | None, optional): Sharding using named axes for
+                parallel data distribution across devices. Defaults to `None`, meaning
+                no sharding is applied.
+
+        Returns:
+            tuple: A tuple containing:
+                - n_pad (int): The number of padding rows/elements added (0 if no
+                    padding was required).
+                - x_batch (Array): The input batch with padding applied if necessary.
+                - kwargs_batch (list[Array]): A list of keyword arguments with
+                    padding applied if necessary.
+        """
+        x_batch, *kwargs_batch = map(jnp.asarray, zip(*batch, strict=True))
+
+        n_pad = (
+            ArrayLoader.calculate_padding(
+                len(x_batch),
+                num_devices=device.num_devices,
+            )
+            if device
+            else 0
+        )
+        if n_pad:
+            x_batch = ArrayLoader.pad_array(x_batch, n_pad=n_pad, axis=0)
+            kwargs_batch = [
+                ArrayLoader.pad_array(x, n_pad=n_pad, axis=0) for x in kwargs_batch
+            ]
+
+        if device:
+            x_batch = device_put(x_batch, device=device)
+            kwargs_batch = [device_put(x, device=device) for x in kwargs_batch]
+
+        return n_pad, x_batch, *kwargs_batch
+
+    @staticmethod
+    def collate_with_sharding(
+        batch: list[tuple],
+        device: "NamedSharding | None" = None,
+    ) -> tuple:
+        """Collate function to process batches with sharding and padding.
+
+        This function unpacks the batch of data, converts it into JAX arrays, and
+        applies padding to ensure the batch size is compatible with the number of
+        devices, if sharding is necessary. When a device is provided, the data is
+        automatically distributed across the available devices.
+
+        Args:
+            batch (list[tuple]): A list of tuples, where each tuple contains the input
+                data, optional target data, and array-like keyword arguments.
+            device (NamedSharding | None, optional): Sharding using named axes for
+                parallel data distribution across devices. Defaults to `None`, meaning
+                no sharding is applied.
+
+        Returns:
+            tuple: A tuple containing:
+                - n_pad (int): The number of padding rows/elements added (0 if no
+                    padding was required).
+                - x_batch (Array): The input batch with padding applied if necessary.
+                - y_batch (Array): The target batch with padding applied.
+                - kwargs_batch (list[Array]): A list of keyword arguments with padding
+                    applied if necessary.
+        """
+        x_batch, y_batch, *kwargs_batch = map(jnp.asarray, zip(*batch, strict=True))
+
+        n_pad = (
+            ArrayLoader.calculate_padding(
+                len(x_batch),
+                num_devices=device.num_devices,
+            )
+            if device
+            else 0
+        )
+        if n_pad:
+            x_batch = ArrayLoader.pad_array(x_batch, n_pad=n_pad, axis=0)
+            y_batch = ArrayLoader.pad_array(y_batch, n_pad=n_pad, axis=0)
+            kwargs_batch = [
+                ArrayLoader.pad_array(x, n_pad=n_pad, axis=0) for x in kwargs_batch
+            ]
+
+        if device:
+            x_batch = device_put(x_batch, device=device)
+            y_batch = device_put(y_batch, device=device)
+            kwargs_batch = [device_put(x, device=device) for x in kwargs_batch]
+
+        return n_pad, x_batch, y_batch, *kwargs_batch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aimz"
-version = "0.2.1.dev0"
+version = "0.3.0b0"
 description = "Flexible probabilistic impact modeling at scale"
 readme = "README.md"
 license = "Apache-2.0"
@@ -20,7 +20,6 @@ dependencies = [
     "jax>=0.5.3",
     "numpyro>=0.18.0",
     "scikit-learn>=1.6.1",
-    "torch>=2.7",
     "tqdm>=4.67",
     "xarray>=2025.4",
     "zarr>=3,<4",
@@ -36,7 +35,7 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = ["dill>=0.4.0", "pytest>=8.3", "pytest-cov>=6"]
-gpu = ["jax[cuda12]>=0.5.3", "torch>=2.7"]
+gpu = ["jax[cuda12]>=0.5.3"]
 
 [project.urls]
 source = "https://github.com/markean/aimz"
@@ -75,11 +74,3 @@ pylint = { max-args = 10 }
 [tool.setuptools.packages.find]
 include = ["aimz*"]
 namespaces = false
-
-[tool.uv.sources]
-torch = [{ index = "pytorch-cu128", extra = "gpu" }]
-
-[[tool.uv.index]]
-name = "pytorch-cu128"
-url = "https://download.pytorch.org/whl/cu128"
-explicit = true

--- a/tests/test_set_posterior_sample.py
+++ b/tests/test_set_posterior_sample.py
@@ -14,7 +14,6 @@
 
 """Tests for the `.set_posterior_sample()` method."""
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import pytest
@@ -49,8 +48,6 @@ def test_set_posterior_sample(
     posterior_sample = posterior(rng_subkey)
 
     im = ImpactModel(lm, rng_key=rng_key, vi=vi)
-    im.guide = vi.guide
-    assert isinstance(im.guide, Callable)
     im.vi_result = vi_result
     # Use the same key for reproducibility
     im.set_posterior_sample(im.sample(num_samples=100, rng_key=rng_subkey))

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "aimz"
-version = "0.2.1.dev0"
+version = "0.3.0b0"
 source = { editable = "." }
 dependencies = [
     { name = "arviz" },
@@ -17,7 +17,6 @@ dependencies = [
     { name = "jax" },
     { name = "numpyro" },
     { name = "scikit-learn" },
-    { name = "torch" },
     { name = "tqdm" },
     { name = "xarray" },
     { name = "zarr" },
@@ -31,7 +30,6 @@ dev = [
 ]
 gpu = [
     { name = "jax", extra = ["cuda12"] },
-    { name = "torch" },
 ]
 
 [package.metadata]
@@ -45,8 +43,6 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6" },
     { name = "scikit-learn", specifier = ">=1.6.1" },
-    { name = "torch", specifier = ">=2.7" },
-    { name = "torch", marker = "extra == 'gpu'", specifier = ">=2.7", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "aimz", extra = "gpu" } },
     { name = "tqdm", specifier = ">=4.67" },
     { name = "xarray", specifier = ">=2025.4" },
     { name = "zarr", specifier = ">=3,<4" },
@@ -319,15 +315,6 @@ wheels = [
 ]
 
 [[package]]
-name = "filelock"
-version = "3.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload-time = "2025-03-14T07:11:40.47Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload-time = "2025-03-14T07:11:39.145Z" },
-]
-
-[[package]]
 name = "fonttools"
 version = "4.58.5"
 source = { registry = "https://pypi.org/simple" }
@@ -518,18 +505,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jinja2"
-version = "3.1.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
 name = "joblib"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -614,54 +589,6 @@ wheels = [
 ]
 
 [[package]]
-name = "markupsafe"
-version = "3.0.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/28/bbf83e3f76936960b850435576dd5e67034e200469571be53f69174a2dfd/MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d", size = 14353, upload-time = "2024-10-18T15:21:02.187Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/30/316d194b093cde57d448a4c3209f22e3046c5bb2fb0820b118292b334be7/MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93", size = 12392, upload-time = "2024-10-18T15:21:02.941Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/96/9cdafba8445d3a53cae530aaf83c38ec64c4d5427d975c974084af5bc5d2/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832", size = 23984, upload-time = "2024-10-18T15:21:03.953Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/a4/aefb044a2cd8d7334c8a47d3fb2c9f328ac48cb349468cc31c20b539305f/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84", size = 23120, upload-time = "2024-10-18T15:21:06.495Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/21/5e4851379f88f3fad1de30361db501300d4f07bcad047d3cb0449fc51f8c/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca", size = 23032, upload-time = "2024-10-18T15:21:07.295Z" },
-    { url = "https://files.pythonhosted.org/packages/00/7b/e92c64e079b2d0d7ddf69899c98842f3f9a60a1ae72657c89ce2655c999d/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798", size = 24057, upload-time = "2024-10-18T15:21:08.073Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/ac/46f960ca323037caa0a10662ef97d0a4728e890334fc156b9f9e52bcc4ca/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e", size = 23359, upload-time = "2024-10-18T15:21:09.318Z" },
-    { url = "https://files.pythonhosted.org/packages/69/84/83439e16197337b8b14b6a5b9c2105fff81d42c2a7c5b58ac7b62ee2c3b1/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4", size = 23306, upload-time = "2024-10-18T15:21:10.185Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/34/a15aa69f01e2181ed8d2b685c0d2f6655d5cca2c4db0ddea775e631918cd/MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d", size = 15094, upload-time = "2024-10-18T15:21:11.005Z" },
-    { url = "https://files.pythonhosted.org/packages/da/b8/3a3bd761922d416f3dc5d00bfbed11f66b1ab89a0c2b6e887240a30b0f6b/MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b", size = 15521, upload-time = "2024-10-18T15:21:12.911Z" },
-    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274, upload-time = "2024-10-18T15:21:13.777Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348, upload-time = "2024-10-18T15:21:14.822Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149, upload-time = "2024-10-18T15:21:15.642Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118, upload-time = "2024-10-18T15:21:17.133Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993, upload-time = "2024-10-18T15:21:18.064Z" },
-    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178, upload-time = "2024-10-18T15:21:18.859Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319, upload-time = "2024-10-18T15:21:19.671Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload-time = "2024-10-18T15:21:20.971Z" },
-    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097, upload-time = "2024-10-18T15:21:22.646Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601, upload-time = "2024-10-18T15:21:23.499Z" },
-    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274, upload-time = "2024-10-18T15:21:24.577Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload-time = "2024-10-18T15:21:25.382Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122, upload-time = "2024-10-18T15:21:26.199Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload-time = "2024-10-18T15:21:27.029Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978, upload-time = "2024-10-18T15:21:27.846Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208, upload-time = "2024-10-18T15:21:28.744Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357, upload-time = "2024-10-18T15:21:29.545Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344, upload-time = "2024-10-18T15:21:30.366Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101, upload-time = "2024-10-18T15:21:31.207Z" },
-    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603, upload-time = "2024-10-18T15:21:32.032Z" },
-    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510, upload-time = "2024-10-18T15:21:33.625Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486, upload-time = "2024-10-18T15:21:34.611Z" },
-    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480, upload-time = "2024-10-18T15:21:35.398Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914, upload-time = "2024-10-18T15:21:36.231Z" },
-    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796, upload-time = "2024-10-18T15:21:37.073Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473, upload-time = "2024-10-18T15:21:37.932Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114, upload-time = "2024-10-18T15:21:39.799Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
-    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
-]
-
-[[package]]
 name = "matplotlib"
 version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
@@ -731,30 +658,12 @@ wheels = [
 ]
 
 [[package]]
-name = "mpmath"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
-]
-
-[[package]]
 name = "multipledispatch"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/3e/a62c3b824c7dec33c4a1578bcc842e6c30300051033a4e5975ed86cc2536/multipledispatch-1.0.0.tar.gz", hash = "sha256:5c839915465c68206c3e9c473357908216c28383b425361e5d144594bf85a7e0", size = 12385, upload-time = "2023-06-27T16:45:11.074Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl", hash = "sha256:0c53cd8b077546da4e48869f49b13164bebafd0c2a5afceb6bb6a316e7fb46e4", size = 12818, upload-time = "2023-06-27T16:45:09.418Z" },
-]
-
-[[package]]
-name = "networkx"
-version = "3.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/8d/776adee7bbf76365fdd7f2552710282c79a4ead5d2a46408c9043a2b70ba/networkx-3.5-py3-none-any.whl", hash = "sha256:0030d386a9a06dee3565298b4a734b68589749a544acbb6c412dc9e2489ec6ec", size = 2034406, upload-time = "2025-05-29T11:35:04.961Z" },
 ]
 
 [[package]]
@@ -894,14 +803,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.8.61"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/22/32029d4583f7b19cfe75c84399cbcfd23f2aaf41c66fc8db4da460104fff/nvidia_cuda_nvrtc_cu12-12.8.61-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a0fa9c2a21583105550ebd871bd76e2037205d56f33f128e69f6d2a55e0af9ed", size = 88024585, upload-time = "2025-01-23T17:50:10.722Z" },
-]
-
-[[package]]
 name = "nvidia-cuda-runtime-cu12"
 version = "12.8.57"
 source = { registry = "https://pypi.org/simple" }
@@ -938,22 +839,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nvidia-cufile-cu12"
-version = "1.13.0.11"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/9c/1f3264d0a84c8a031487fb7f59780fc78fa6f1c97776233956780e3dc3ac/nvidia_cufile_cu12-1.13.0.11-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:483f434c541806936b98366f6d33caef5440572de8ddf38d453213729da3e7d4", size = 1197801, upload-time = "2025-01-23T17:57:07.247Z" },
-]
-
-[[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.9.55"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/fc/7be5d0082507269bb04ac07cc614c84b78749efb96e8cf4100a8a1178e98/nvidia_curand_cu12-10.3.9.55-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8387d974240c91f6a60b761b83d4b2f9b938b7e0b9617bae0f0dafe4f5c36b86", size = 63618038, upload-time = "2025-01-23T17:57:41.838Z" },
-]
-
-[[package]]
 name = "nvidia-cusolver-cu12"
 version = "11.7.2.55"
 source = { registry = "https://pypi.org/simple" }
@@ -982,14 +867,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nvidia-cusparselt-cu12"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/9a/72ef35b399b0e183bc2e8f6f558036922d453c4d8237dab26c666a04244b/nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:e5c8a26c36445dd2e6812f1177978a24e2d37cacce7e090f297a688d1ec44f46", size = 156785796, upload-time = "2024-10-15T21:29:17.709Z" },
-]
-
-[[package]]
 name = "nvidia-nccl-cu12"
 version = "2.26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1006,14 +883,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/03/f8/9d85593582bd99b8d7c65634d2304780aefade049b2b94d96e44084be90b/nvidia_nvjitlink_cu12-12.8.61-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:45fd79f2ae20bd67e8bc411055939049873bfd8fac70ff13bd4865e0b9bdab17", size = 39243473, upload-time = "2025-01-23T18:03:03.509Z" },
     { url = "https://files.pythonhosted.org/packages/af/53/698f3758f48c5fcb1112721e40cc6714da3980d3c7e93bae5b29dafa9857/nvidia_nvjitlink_cu12-12.8.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b80ecab31085dda3ce3b41d043be0ec739216c3fc633b8abe212d5a30026df0", size = 38374634, upload-time = "2025-01-23T18:02:35.812Z" },
     { url = "https://files.pythonhosted.org/packages/7f/c6/0d1b2bfeb2ef42c06db0570c4d081e5cde4450b54c09e43165126cfe6ff6/nvidia_nvjitlink_cu12-12.8.61-py3-none-win_amd64.whl", hash = "sha256:1166a964d25fdc0eae497574d38824305195a5283324a21ccb0ce0c802cbf41c", size = 268514099, upload-time = "2025-01-23T18:12:33.874Z" },
-]
-
-[[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.8.55"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/cd/0e8c51b2ae3a58f054f2e7fe91b82d201abfb30167f2431e9bd92d532f42/nvidia_nvtx_cu12-12.8.55-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dd0780f1a55c21d8e06a743de5bd95653de630decfff40621dbde78cc307102", size = 89896, upload-time = "2025-01-23T17:50:44.487Z" },
 ]
 
 [[package]]
@@ -1384,18 +1253,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sympy"
-version = "1.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mpmath" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
-]
-
-[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1453,49 +1310,6 @@ wheels = [
 ]
 
 [[package]]
-name = "torch"
-version = "2.7.1+cu128"
-source = { registry = "https://download.pytorch.org/whl/cu128" }
-dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools", marker = "python_full_version >= '3.12'" },
-    { name = "sympy" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions" },
-]
-wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3a0954c54fd7cb9f45beab1272dece2a05b0e77023c1da33ba32a7919661260f" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c301dc280458afd95450af794924c98fe07522dd148ff384739b810e3e3179f2" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp311-cp311-win_amd64.whl", hash = "sha256:138c66dcd0ed2f07aafba3ed8b7958e2bed893694990e0b4b55b6b2b4a336aa6" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:268e54db9f0bc2b7b9eb089852d3e592c2dea2facc3db494100c3d3b796549fa" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0b64f7d0a6f2a739ed052ba959f7b67c677028c9566ce51997f9f90fe573ddaa" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:2bb8c05d48ba815b316879a18195d53a6472a03e297d971e916753f8e1053d30" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:d56d29a6ad7758ba5173cc2b0c51c93e126e2b0a918e874101dc66545283967f" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9560425f9ea1af1791507e8ca70d5b9ecf62fed7ca226a95fcd58d0eb2cca78f" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:500ad5b670483f62d4052e41948a3fb19e8c8de65b99f8d418d879cbb15a82d6" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:f112465fdf42eb1297c6dddda1a8b7f411914428b704e1b8a47870c52e290909" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c355db49c218ada70321d5c5c9bb3077312738b99113c8f3723ef596b554a7b9" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:e27e5f7e74179fb5d814a0412e5026e4b50c9e0081e9050bc4c28c992a276eb1" },
-]
-
-[[package]]
 name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1505,20 +1319,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
-]
-
-[[package]]
-name = "triton"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "setuptools" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/2f/3e56ea7b58f80ff68899b1dbe810ff257c9d177d288c6b0f55bf2fe4eb50/triton-3.3.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b31e3aa26f8cb3cc5bf4e187bf737cbacf17311e1112b781d4a059353dfd731b", size = 155689937, upload-time = "2025-05-29T23:39:44.182Z" },
-    { url = "https://files.pythonhosted.org/packages/24/5f/950fb373bf9c01ad4eb5a8cd5eaf32cdf9e238c02f9293557a2129b9c4ac/triton-3.3.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9999e83aba21e1a78c1f36f21bce621b77bcaa530277a50484a7cb4a822f6e43", size = 155669138, upload-time = "2025-05-29T23:39:51.771Z" },
-    { url = "https://files.pythonhosted.org/packages/74/1f/dfb531f90a2d367d914adfee771babbd3f1a5b26c3f5fbc458dee21daa78/triton-3.3.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b89d846b5a4198317fec27a5d3a609ea96b6d557ff44b56c23176546023c4240", size = 155673035, upload-time = "2025-05-29T23:40:02.468Z" },
-    { url = "https://files.pythonhosted.org/packages/28/71/bd20ffcb7a64c753dc2463489a61bf69d531f308e390ad06390268c4ea04/triton-3.3.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3198adb9d78b77818a5388bff89fa72ff36f9da0bc689db2f0a651a67ce6a42", size = 155735832, upload-time = "2025-05-29T23:40:10.522Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Refactor the ArrayLoader and ArrayDataset classes to eliminate the dependency on PyTorch, transitioning to JAX for array handling. Update the version to 0.3.0b0 and document the changes in the changelog.

This closes #26.