### PR TITLE
Fix Colab link in WIP document

### DIFF
--- a/docs/wip.md
+++ b/docs/wip.md
@@ -1,3 +1,3 @@
 # WIP
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/markean/aimz/blob/main/notebook/docs/test.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/markean/aimz/blob/main/docs/notebook/test.ipynbp)


### PR DESCRIPTION
Update the Colab link in the WIP document to direct to the correct notebook path.