### PR TITLE
Add MCMC support for ImpactModel inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Support for NumPyro MCMC in `ImpactModel`, including `.fit_on_batch()`, `.sample()`, and `.set_posterior_sample()` methods.
+
 ### Changed
 
 - `ImpactModel` methods `.predict()`, `.predict_on_batch()`, `.log_likelihood()`, and `.estimate_effect()` now return outputs as xarray DataTree instead of ArviZ InferenceData. Dimension names now follow the `dim_N` convention instead of the previous `dimN` style (@markean, [#49](https://github.com/markean/aimz/issues/49)).
 - `.fit()`, `.fit_on_batch()`, and `.train_on_batch()` methods in `ImpactModel` now check for `"/"` in kernel site names to ensure compatibility with xarray DataTree (@markean, [#49](https://github.com/markean/aimz/issues/49)).
-- `.predict()` in `ImpactModel` now checks for available posterior samples before falling back to `.predict_on_batch()`.
-- `ArrayLoader` validates that `batch_size` is a positive integer.
 
 ### Removed
 
 - Removed the `arviz` dependency (@markean, [#49](https://github.com/markean/aimz/issues/49)).
+
+### Fixed
+
+- `.predict()` in `ImpactModel` now checks for available posterior samples before falling back to `.predict_on_batch()`.
+- `ArrayLoader` validates that `batch_size` is a positive integer.
 
 ## [v0.3.2](https://github.com/markean/aimz/releases/tag/v0.3.2) - 2025-08-13
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,3 +24,16 @@
 ```sh
 conda install conda-forge::aimz
 ```
+
+## Install from GitHub
+
+```sh
+# Latest commit from the main branch (CPU version)
+pip install aimz@git+https://github.com/markean/aimz.git
+
+# Specific release tag (replace <release_tag> with the desired tag)
+pip install aimz@git+https://github.com/markean/aimz.git@<release_tag>
+
+# GPU-enabled version from the main branch
+pip install aimz[gpu]@git+https://github.com/markean/aimz.git
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = ["dill>=0.4.0", "pytest>=8.4", "pytest-cov>=6"]
-gpu = ["jax[cuda12]>=0.5.3"]
+gpu = ["jax[cuda12]>=0.7"]
 
 [project.urls]
 source = "https://github.com/markean/aimz"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ import pytest
 from jax import Array, random
 from jax.typing import ArrayLike
 from numpyro import sample
-from numpyro.infer import SVI, Trace_ELBO
+from numpyro.infer import MCMC, NUTS, SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
 
 numpyro.set_host_device_count(3)
@@ -48,6 +48,27 @@ def synthetic_data() -> tuple[Array, Array]:
 
 
 @pytest.fixture(scope="module")
+def mcmc(request: pytest.FixtureRequest) -> MCMC:
+    """Fixture for creating an MCMC object.
+
+    Args:
+        request (pytest.FixtureRequest): The pytest request object to access the
+            parameter.
+
+    Returns:
+        An MCMC object configured with the provided model.
+    """
+    model = request.param
+
+    return MCMC(
+        NUTS(model),
+        num_warmup=100,
+        num_samples=100,
+        num_chains=1,
+    )
+
+
+@pytest.fixture(scope="module")
 def vi(request: pytest.FixtureRequest) -> SVI:
     """Fixture for creating a variational inference object.
 
@@ -56,7 +77,7 @@ def vi(request: pytest.FixtureRequest) -> SVI:
             parameter.
 
     Returns:
-        SVI: A variational inference object configured with the provided model.
+        A variational inference object configured with the provided model.
     """
     model = request.param
 

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -21,7 +21,7 @@ from conftest import lm
 from jax import random
 from jax.typing import ArrayLike
 from numpyro import deterministic, sample
-from numpyro.infer import SVI, Trace_ELBO
+from numpyro.infer import MCMC, SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
 from numpyro.optim import Adam
 from sklearn.exceptions import DataConversionWarning
@@ -177,6 +177,14 @@ class TestKernelBodyValidation:
         )
         with pytest.raises(KernelValidationError):
             im.fit(X=jnp.ones((10, 1)), y=jnp.ones((10,)), batch_size=3)
+
+
+@pytest.mark.parametrize("mcmc", [lm], indirect=True)
+def test_fit_raises_for_mcmc_inference(mcmc: MCMC) -> None:
+    """Calling `.fit()` with MCMC inference raises a TypeError."""
+    im = ImpactModel(lm, rng_key=random.key(42), inference=mcmc)
+    with pytest.raises(TypeError):
+        im.fit(X=jnp.zeros((3, 2)), y=jnp.zeros((3, 1)), batch_size=3)
 
 
 def test_fit_unexpected_y_shape() -> None:

--- a/tests/test_fit_on_batch.py
+++ b/tests/test_fit_on_batch.py
@@ -18,7 +18,7 @@ import pytest
 from conftest import lm
 from jax import random
 from jax.typing import ArrayLike
-from numpyro.infer import SVI, Trace_ELBO
+from numpyro.infer import MCMC, SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
 from numpyro.optim import Adam
 
@@ -44,8 +44,8 @@ def test_fit_on_batch_nan_warning(synthetic_data: tuple[ArrayLike, ArrayLike]) -
 
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
-def test_fit_lm(synthetic_data: tuple[ArrayLike, ArrayLike], vi: SVI) -> None:
-    """Test the `.fit()` method of `ImpactModel`."""
+def test_fit_svi(synthetic_data: tuple[ArrayLike, ArrayLike], vi: SVI) -> None:
+    """Test the `.fit()` method of ImpactModel using SVI."""
     X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
     im.fit_on_batch(X=X, y=y)
@@ -59,3 +59,12 @@ def test_fit_lm(synthetic_data: tuple[ArrayLike, ArrayLike], vi: SVI) -> None:
     assert last_loss < first_loss, (
         f"Loss did not decrease after training: first={first_loss}, last={last_loss}"
     )
+
+
+@pytest.mark.parametrize("mcmc", [lm], indirect=True)
+def test_fit_mcmc(synthetic_data: tuple[ArrayLike, ArrayLike], mcmc: MCMC) -> None:
+    """Test the `.fit()` method of ImpactModel using MCMC."""
+    X, y = synthetic_data
+    im = ImpactModel(lm, rng_key=random.key(42), inference=mcmc)
+    im.fit_on_batch(X=X, y=y)
+    assert _is_fitted(im), "Model fitting check failed"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,27 @@
+# Copyright 2025 Eli Lilly and Company
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for initializing the `ImpactModel` class."""
+
+import pytest
+from conftest import lm
+from jax import random
+
+from aimz.model import ImpactModel
+
+
+def test_unsupported_inference_method() -> None:
+    """ImpactModel initialization with unsupported inference method raises TypeError."""
+    with pytest.raises(TypeError, match="Unsupported inference object"):
+        ImpactModel(lm, rng_key=random.key(42), inference=None)

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,0 +1,59 @@
+# Copyright 2025 Eli Lilly and Company
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the `.sample()` method."""
+
+import pytest
+from conftest import lm
+from jax import random
+from jax.typing import ArrayLike
+from numpyro.infer import MCMC
+
+from aimz.model import ImpactModel
+
+
+@pytest.mark.parametrize("mcmc", [lm], indirect=True)
+def test_missing_param_output(
+    synthetic_data: tuple[ArrayLike, ArrayLike],
+    mcmc: MCMC,
+) -> None:
+    """Missing `param_output` argument raises TypeError."""
+    X, y = synthetic_data
+    im = ImpactModel(lm, rng_key=random.key(42), inference=mcmc)
+    im.fit_on_batch(X=X, y=y)
+    with pytest.raises(TypeError):
+        im.sample(rng_key=random.key(42), X=X)
+
+
+@pytest.mark.parametrize("mcmc", [lm], indirect=True)
+def test_sample_with_mcmc(
+    synthetic_data: tuple[ArrayLike, ArrayLike],
+    mcmc: MCMC,
+) -> None:
+    """Test the `.sample()` method of `ImpactModel` with MCMC."""
+    X, y = synthetic_data
+    im = ImpactModel(lm, rng_key=random.key(42), inference=mcmc)
+    im.fit_on_batch(X=X, y=y)
+
+    # rng_key is ignored for MCMC; sampling uses the post_warmup_state
+    num_samples = 7
+    posterior = im.sample(num_samples=num_samples, rng_key=random.key(42), X=X, y=y)
+
+    # Check shapes for all sampled sites
+    for site, values in posterior.items():
+        assert values.shape[0] == num_samples, (
+            f"Incorrect number of samples for site {site}"
+        )
+
+    assert im.inference.num_samples == num_samples


### PR DESCRIPTION
Implement MCMC as an inference method in `ImpactModel`, enhancing the `.fit_on_batch()`, `.set_posterior_sample()`, and `.sample()` methods. Include error handling for incompatible methods and improve tests to validate MCMC functionality. Update installation instructions and dependencies accordingly.

Fixes #35