### PR TITLE
Fix error message in `.sample_posterior_predictive()` and improve validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
       # Ruff version.
-      rev: v0.12.10
+      rev: v0.12.11
       hooks:
           # Run the linter.
           - id: ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file and are best viewed on the [Changelog](https://aimz.readthedocs.io/en/latest/changelog.html) page.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -9,83 +9,84 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added a `return_sites` parameter to the `.predict()` and `.predict_on_batch()` methods in `ImpactModel`, allowing users to specify which sites to include in the output (@markean, [#55](https://github.com/markean/aimz/issues/55)).
+- Added a `return_sites` parameter to the {meth}`~aimz.model.ImpactModel.predict` and {meth}`~aimz.model.ImpactModel.predict_on_batch` methods in {class}`~aimz.model.ImpactModel`, allowing users to specify which sites to include in the output ([#55](https://github.com/markean/aimz/issues/55)).
 
 ### Changed
 
 - Switched documentation build system from MkDocs to Sphinx and ReadTheDocs ([https://aimz.readthedocs.io](https://aimz.readthedocs.io)).
+- Added input `X` validation to {meth}`~aimz.model.ImpactModel.sample_prior_predictive` ([#65](https://github.com/markean/aimz/issues/65)).
 
 ### Fixed
 
-- Fixed incompatibility with Zarr when models output arrays in `bfloat16` by automatically promoting them to `float32` before saving (@markean, [#57](https://github.com/markean/aimz/issues/57)).
-
-- Enhanced data array validation to preserve device placement for JAX arrays (@markean, [#53](https://github.com/markean/aimz/issues/53)).
+- Fixed incompatibility with Zarr when models output arrays in `bfloat16` by automatically promoting them to `float32` before saving ([#57](https://github.com/markean/aimz/issues/57)).
+- Enhanced data array validation to preserve device placement for JAX arrays ([#53](https://github.com/markean/aimz/issues/53)).
+- Fixed the error message in {meth}`~aimz.model.ImpactModel.sample_posterior_predictive` when ``self.param_output`` is passed as an argument, which previously incorrectly referenced {meth}`~aimz.model.ImpactModel.sample_prior_predictive` ([#65](https://github.com/markean/aimz/issues/65)).
 
 ## [v0.4.0](https://github.com/markean/aimz/releases/tag/v0.4.0) - 2025-08-18
 
 ### Added
 
-- Support for NumPyro MCMC in `ImpactModel`, including `.fit_on_batch()`, `.sample()`, and `.set_posterior_sample()` methods (@markean, [#35](https://github.com/markean/aimz/issues/35)).
+- Support for NumPyro MCMC in {class}`~aimz.model.ImpactModel`, including {meth}`~aimz.model.ImpactModel.fit_on_batch`, {meth}`~aimz.model.ImpactModel.sample`, and {meth}`~aimz.model.ImpactModel.set_posterior_sample` methods ([#35](https://github.com/markean/aimz/issues/35)).
 
 ### Changed
 
-- `ImpactModel` methods `.predict()`, `.predict_on_batch()`, `.log_likelihood()`, and `.estimate_effect()` now return outputs as xarray DataTree instead of ArviZ InferenceData. Dimension names now follow the `dim_N` convention instead of the previous `dimN` style (@markean, [#49](https://github.com/markean/aimz/issues/49)).
-- `.fit()`, `.fit_on_batch()`, and `.train_on_batch()` methods in `ImpactModel` now check for `"/"` in kernel site names to ensure compatibility with xarray DataTree (@markean, [#49](https://github.com/markean/aimz/issues/49)).
+- {class}`~aimz.model.ImpactModel` methods {meth}`~aimz.model.ImpactModel.predict`, {meth}`~aimz.model.ImpactModel.predict_on_batch`, {meth}`~aimz.model.ImpactModel.log_likelihood`, and {meth}`~aimz.model.ImpactModel.estimate_effect` now return outputs as xarray DataTree instead of ArviZ InferenceData. Dimension names now follow the `dim_N` convention instead of the previous `dimN` style ([#49](https://github.com/markean/aimz/issues/49)).
+- {meth}`~aimz.model.ImpactModel.fit`, {meth}`~aimz.model.ImpactModel.fit_on_batch`, and {meth}`~aimz.model.ImpactModel.train_on_batch` methods in {class}`~aimz.model.ImpactModel` now check for `"/"` in kernel site names to ensure compatibility with xarray DataTree ([#49](https://github.com/markean/aimz/issues/49)).
 
 ### Removed
 
-- Removed the `arviz` dependency (@markean, [#49](https://github.com/markean/aimz/issues/49)).
+- Removed the `arviz` dependency ([#49](https://github.com/markean/aimz/issues/49)).
 
 ### Fixed
 
-- `.predict()` in `ImpactModel` now checks for available posterior samples before falling back to `.predict_on_batch()`.
-- `ArrayLoader` validates that `batch_size` is a positive integer.
+- {meth}`~aimz.model.ImpactModel.predict` in {class}`~aimz.model.ImpactModel` now checks for available posterior samples before falling back to {meth}`~aimz.model.ImpactModel.predict_on_batch`.
+- {class}`~aimz.utils.data.ArrayLoader` validates that `batch_size` is a positive integer.
 
 ## [v0.3.2](https://github.com/markean/aimz/releases/tag/v0.3.2) - 2025-08-13
 
 ### Changed
 
-- Updated `.predict()` and `.predict_on_batch()` to check for available posterior samples before returning outputs. This prevents errors when posterior samples are not defined based on the model specification.
+- Updated {meth}`~aimz.model.ImpactModel.predict` and {meth}`~aimz.model.ImpactModel.predict_on_batch` to check for available posterior samples before returning outputs. This prevents errors when posterior samples are not defined based on the model specification.
 
 ## [v0.3.1](https://github.com/markean/aimz/releases/tag/v0.3.1) - 2025-08-02
 
 ### Fixed
 
-- `ArrayDataset` and `ArrayLoader` now preserve the order in which input arrays are provided, ensuring consistent input mapping in methods like `.predict()` and `.log_likelihood()` (@markean, [#43](https://github.com/markean/aimz/issues/43)).
+- {class}`~aimz.utils.data.ArrayDataset` and {class}`~aimz.utils.data.ArrayLoader` now preserve the order in which input arrays are provided, ensuring consistent input mapping in methods like {meth}`~aimz.model.ImpactModel.predict` and {meth}`~aimz.model.ImpactModel.log_likelihood` ([#43](https://github.com/markean/aimz/issues/43)).
 
 ## [v0.3.0](https://github.com/markean/aimz/releases/tag/v0.3.0) - 2025-07-18
 
 ### Changed
 
-- `ImpactModel` initialization parameter `vi` has been renamed to `inference` for compatibility with MCMC in future releases (@markean, [#36](https://github.com/markean/aimz/issues/36)).
-- `ImpactModel` now supports `ArrayLoader` for both input and output data (@markean, [#24](https://github.com/markean/aimz/issues/24)).
-- Renamed the posterior sample attribute of `ImpactModel` from `.posterior_samples_` to `.posterior`, which is now initialized to `None` (@markean, [#25](https://github.com/markean/aimz/issues/25)).
-- `ArrayLoader` and `ArrayDataset` no longer require the `torch` dependency. `ArrayDataset` now accepts only named arrays, and `ArrayLoader` yields tuples of a dictionary and a padding integer (@markean, [#26](https://github.com/markean/aimz/issues/26)).
+- {class}`~aimz.model.ImpactModel` initialization parameter `vi` has been renamed to `inference` for compatibility with MCMC in future releases ([#36](https://github.com/markean/aimz/issues/36)).
+- {class}`~aimz.model.ImpactModel` now supports {class}`~aimz.utils.data.ArrayLoader` for both input and output data ([#24](https://github.com/markean/aimz/issues/24)).
+- Renamed the posterior sample attribute of {class}`~aimz.model.ImpactModel` from {attr}`~aimz.model.ImpactModel.posterior_samples_` to {attr}`~aimz.model.ImpactModel.posterior`, which is now initialized to `None` ([#25](https://github.com/markean/aimz/issues/25)).
+- {class}`~aimz.utils.data.ArrayLoader` and {class}`~aimz.utils.data.ArrayDataset` no longer require the `torch` dependency. {class}`~aimz.utils.data.ArrayDataset` now accepts only named arrays, and {class}`~aimz.utils.data.ArrayLoader` yields tuples of a dictionary and a padding integer ([#26](https://github.com/markean/aimz/issues/26)).
 
 ### Removed
 
-- Removed the `torch` dependency (@markean, [#26](https://github.com/markean/aimz/issues/26)).
+- Removed the `torch` dependency ([#26](https://github.com/markean/aimz/issues/26)).
 
 ## [v0.2.0](https://github.com/markean/aimz/releases/tag/v0.2.0) - 2025-07-10
 
 ### Added
 
-- `.train_on_batch()` and `.fit_on_batch()` methods to `ImpactModel` (@markean, [#15](https://github.com/markean/aimz/issues/15)).
-- Custom `ArrayDataset` class for handling data in `ImpactModel`, removing the need for the `jax-dataloader` dependency (@markean, [#14](https://github.com/markean/aimz/issues/14)).
-- GitHub Pages documentation site (@markean, [#10](https://github.com/markean/aimz/issues/10)).
-- Installation instructions in the documentation site (@markean, [#10](https://github.com/markean/aimz/issues/10)).
-- `ArrayLoader` class supports `shuffle` and `drop_last` parameters for epoch training for `.fit()` (@markean, [#15](https://github.com/markean/aimz/issues/15)).
+- {meth}`~aimz.model.ImpactModel.train_on_batch` and {meth}`~aimz.model.ImpactModel.fit_on_batch` methods to {class}`~aimz.model.ImpactModel` ([#15](https://github.com/markean/aimz/issues/15)).
+- Custom {class}`~aimz.utils.data.ArrayDataset` class for handling data in {class}`~aimz.model.ImpactModel`, removing the need for the `jax-dataloader` dependency ([#14](https://github.com/markean/aimz/issues/14)).
+- GitHub Pages documentation site ([#10](https://github.com/markean/aimz/issues/10)).
+- Installation instructions in the documentation site ([#10](https://github.com/markean/aimz/issues/10)).
+- {class}`~aimz.utils.data.ArrayLoader` class supports `shuffle` parameter for epoch training for {meth}`~aimz.model.ImpactModel.fit` ([#15](https://github.com/markean/aimz/issues/15)).
 
 ### Changed
 
-- Adopted `jax.typing` module for improved type hints.
-- Removed unnecessary JAX array type conversion in `ImpactModel` methods.
-- The `.fit()` method now uses epoch-based (minibatch) training (@markean, [#15](https://github.com/markean/aimz/issues/15)).
-- Updated `.fit()`, `.train_on_batch()`, and `.fit_on_batch()` to train the model using the internal SVI state, continuing from the last state if available (@markean, [#15](https://github.com/markean/aimz/issues/15)).
+- Adopted {mod}`jax.typing` module for improved type hints.
+- Removed unnecessary JAX array type conversion in {class}`~aimz.model.ImpactModel` methods.
+- The {meth}`~aimz.model.ImpactModel.fit` method now uses epoch-based (minibatch) training ([#15](https://github.com/markean/aimz/issues/15)).
+- Updated {meth}`~aimz.model.ImpactModel.fit`, {meth}`~aimz.model.ImpactModel.train_on_batch`, and {meth}`~aimz.model.ImpactModel.fit_on_batch` to train the model using the internal SVI state, continuing from the last state if available ([#15](https://github.com/markean/aimz/issues/15)).
 
 ### Removed
 
-- Removed the `jax-dataloader` dependency (@markean, [#14](https://github.com/markean/aimz/issues/14)).
+- Removed the `jax-dataloader` dependency ([#14](https://github.com/markean/aimz/issues/14)).
 - Removed the `guide` property, as it is part of the `vi` property.
 
 ## [v0.1.0](https://github.com/markean/aimz/releases/tag/v0.1.0) - 2025-06-27

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -234,13 +234,16 @@ class ImpactModel(BaseModel):
         if rng_key is None:
             self.rng_key, rng_key = random.split(self.rng_key)
 
+        X = _validate_X_y_to_jax(X)
+
         # Validate the provided parameters against the kernel's signature
         args_bound = (
             signature(self.kernel).bind(**{self.param_input: X, **kwargs}).arguments
         )
         if self.param_output in args_bound:
-            sub = self.param_output
-            msg = f"{sub!r} is not allowed in `.sample_prior_predictive()`."
+            msg = (
+                f"{self.param_output!r} is not allowed in `.sample_prior_predictive()`."
+            )
             raise TypeError(msg)
 
         return _sample_forward(
@@ -347,8 +350,10 @@ class ImpactModel(BaseModel):
             signature(self.kernel).bind(**{self.param_input: X, **kwargs}).arguments
         )
         if self.param_output in args_bound:
-            sub = self.param_output
-            msg = f"{sub!r} is not allowed in `.sample_prior_predictive()`."
+            msg = (
+                f"{self.param_output!r} is not allowed in "
+                "`.sample_posterior_predictive()`."
+            )
             raise TypeError(msg)
 
         if intervention is None:

--- a/aimz/sampling/_forward.py
+++ b/aimz/sampling/_forward.py
@@ -44,13 +44,13 @@ def _sample_forward(
         rng_key (Array): A pseudo-random number generator key.
         return_sites (tuple[str] | None): Names of variables (sites) to return.
         posterior_samples (dict[str, Array]| None): Dictionary of parameter samples
-            where each array has shape (num_samples, ...).
+            where each array has shape ``(num_samples, ...)``.
         model_kwargs (dict[str, ArrayLike] | None): Additional arguments passed to the
             model.
 
     Returns:
-        dict[str, Array]: A dictionary mapping each return site to an array of
-            traced values with shape (num_samples, ...).
+        dict[str, Array]: A dictionary mapping each return site to an array of traced
+            values with shape ``(num_samples, ...)``.
     """
 
     def _trace_one_sample(
@@ -70,7 +70,7 @@ def _sample_forward(
             masked_model,
             substitute_fn=_exclude_deterministic,
         )
-        model_trace = trace(seed(substituted_model, rng_key)).get_trace(
+        model_trace = trace(seed(substituted_model, rng_seed=rng_key)).get_trace(
             **(model_kwargs or {}),
         )
 
@@ -86,6 +86,6 @@ def _sample_forward(
 
         return {k: v["value"] for k, v in model_trace.items() if k in sites}
 
-    rng_keys = random.split(rng_key, num_samples).reshape((num_samples,))
+    rng_keys = random.split(rng_key, num=num_samples).reshape((num_samples,))
 
     return lax.map(_trace_one_sample, xs=(rng_keys, posterior_samples or {}))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,7 +49,6 @@ extensions = [
     "sphinx.ext.napoleon",
     "myst_parser",
     "jupyter_sphinx",
-    "nbsphinx",
     "sphinx_copybutton",
     "sphinx_design",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,13 +36,12 @@ classifiers = [
 dev = ["dill>=0.4.0", "pytest>=8.4", "pytest-cov>=6"]
 gpu = ["jax[cuda12]>=0.7"]
 docs = [
-    "sphinx==8.1.3",
-    "myst-parser==4.0.1",
-    "jupyter-sphinx==0.5.3",
-    "nbsphinx==0.9.7",
-    "sphinx-copybutton==0.5.2",
-    "sphinx-design==0.6.1",
-    "pydata-sphinx-theme==0.16.1",
+    "sphinx>=8.2",
+    "myst-parser>=4.0",
+    "jupyter-sphinx>=0.5",
+    "sphinx-copybutton>=0.5",
+    "sphinx-design>=0.6",
+    "pydata-sphinx-theme>=0.16",
     "dill>=0.4.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,6 @@ docs = [
     { name = "dill" },
     { name = "jupyter-sphinx" },
     { name = "myst-parser" },
-    { name = "nbsphinx" },
     { name = "pydata-sphinx-theme" },
     { name = "sphinx" },
     { name = "sphinx-copybutton" },
@@ -60,17 +59,16 @@ requires-dist = [
     { name = "dill", marker = "extra == 'docs'", specifier = ">=0.4.0" },
     { name = "jax", specifier = ">=0.7" },
     { name = "jax", extras = ["cuda12"], marker = "extra == 'gpu'", specifier = ">=0.7" },
-    { name = "jupyter-sphinx", marker = "extra == 'docs'", specifier = "==0.5.3" },
-    { name = "myst-parser", marker = "extra == 'docs'", specifier = "==4.0.1" },
-    { name = "nbsphinx", marker = "extra == 'docs'", specifier = "==0.9.7" },
+    { name = "jupyter-sphinx", marker = "extra == 'docs'", specifier = ">=0.5" },
+    { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0" },
     { name = "numpyro", specifier = ">=0.19.0" },
-    { name = "pydata-sphinx-theme", marker = "extra == 'docs'", specifier = "==0.16.1" },
+    { name = "pydata-sphinx-theme", marker = "extra == 'docs'", specifier = ">=0.16" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6" },
     { name = "scikit-learn", specifier = ">=1.6.1" },
-    { name = "sphinx", marker = "extra == 'docs'", specifier = "==8.1.3" },
-    { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = "==0.5.2" },
-    { name = "sphinx-design", marker = "extra == 'docs'", specifier = "==0.6.1" },
+    { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.2" },
+    { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5" },
+    { name = "sphinx-design", marker = "extra == 'docs'", specifier = ">=0.6" },
     { name = "tqdm", specifier = ">=4.67" },
     { name = "xarray", specifier = ">=2025.4" },
     { name = "zarr", specifier = ">=3,<4" },
@@ -1104,23 +1102,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nbsphinx"
-version = "0.9.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docutils" },
-    { name = "jinja2" },
-    { name = "nbconvert" },
-    { name = "nbformat" },
-    { name = "sphinx" },
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/84/b1856b7651ac34e965aa567a158714c7f3bd42a1b1ce76bf423ffb99872c/nbsphinx-0.9.7.tar.gz", hash = "sha256:abd298a686d55fa894ef697c51d44f24e53aa312dadae38e82920f250a5456fe", size = 180479, upload-time = "2025-03-03T19:46:08.069Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/2d/8c8e635bcc6757573d311bb3c5445426382f280da32b8cd6d82d501ef4a4/nbsphinx-0.9.7-py3-none-any.whl", hash = "sha256:7292c3767fea29e405c60743eee5393682a83982ab202ff98f5eb2db02629da8", size = 31660, upload-time = "2025-03-03T19:46:06.581Z" },
-]
-
-[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1784,6 +1765,15 @@ wheels = [
 ]
 
 [[package]]
+name = "roman-numerals-py"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/76/48fd56d17c5bdbdf65609abbc67288728a98ed4c02919428d4f52d23b24b/roman_numerals_py-3.1.0.tar.gz", hash = "sha256:be4bf804f083a4ce001b5eb7e3c0862479d10f94c936f6c4e5f250aa5ff5bd2d", size = 9017, upload-time = "2025-02-22T07:34:54.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/97/d2cbbaa10c9b826af0e10fdf836e1bf344d9f0abb873ebc34d1f49642d3f/roman_numerals_py-3.1.0-py3-none-any.whl", hash = "sha256:9da2ad2fb670bcf24e81070ceb3be72f6c11c440d73bd579fbeca1e9f330954c", size = 7742, upload-time = "2025-02-22T07:34:52.422Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2019,7 +2009,7 @@ wheels = [
 
 [[package]]
 name = "sphinx"
-version = "8.1.3"
+version = "8.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alabaster" },
@@ -2031,6 +2021,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pygments" },
     { name = "requests" },
+    { name = "roman-numerals-py" },
     { name = "snowballstemmer" },
     { name = "sphinxcontrib-applehelp" },
     { name = "sphinxcontrib-devhelp" },
@@ -2039,9 +2030,9 @@ dependencies = [
     { name = "sphinxcontrib-qthelp" },
     { name = "sphinxcontrib-serializinghtml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/60/1ddff83a56d33aaf6f10ec8ce84b4c007d9368b21008876fceda7e7381ef/sphinx-8.1.3-py3-none-any.whl", hash = "sha256:09719015511837b76bf6e03e42eb7595ac8c2e41eeb9c29c5b755c6b677992a2", size = 3487125, upload-time = "2024-10-13T20:27:10.448Z" },
+    { url = "https://files.pythonhosted.org/packages/31/53/136e9eca6e0b9dc0e1962e2c908fbea2e5ac000c2a2fbd9a35797958c48b/sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3", size = 3589741, upload-time = "2025-03-02T22:31:56.836Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Correct the error message in the `.sample_posterior_predictive()` method to accurately reference itself instead of `.sample_prior_predictive()`. Enhance validation in both `sample_prior_predictive` and `sample_posterior_predictive` methods to prevent invalid parameter usage. Update dependencies and documentation for clarity.

Fixes #65