### PR TITLE
Automatic batch size selection for ImpactModel methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
       rev: v1.5.0
       hooks:
           - id: detect-secrets
+            args: [--exclude-files, ".*\\.ipynb"]
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
       # Ruff version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file and are best
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Methods in {class}`~aimz.ImpactModel` now automatically determine the `batch_size` if it is not provided, based on the input data and number of samples([#70](https://github.com/markean/aimz/issues/70)).
+
 ## [v0.5.0](https://github.com/markean/aimz/releases/tag/v0.5.0) - 2025-09-01
 
 ### Added

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -292,10 +292,10 @@ class ImpactModel(BaseModel):
             return_sites (tuple[str] | None, optional): Names of variables (sites) to
                 return. If ``None``, samples ``self.param_output`` and deterministic
                 sites.
-            batch_size (int | None, optional): The size of batches for data loading
-                during prior predictive sampling. By default, it is set to the total
-                number of samples (``n_samples_X``). This value also determines the
-                chunk size for storing the prior predictive samples.
+            batch_size (int | None, optional): The batch size for data loading during
+                prior predictive sampling. It also determines the chunk size used to
+                store the samples. If ``None``, it is determined automatically based on
+                the input data and number of samples.
             output_dir (str | Path | None, optional): The directory where the outputs
                 will be saved. If the specified directory does not exist, it will be
                 created automatically. If ``None``, a default temporary directory will
@@ -329,6 +329,7 @@ class ImpactModel(BaseModel):
             y=None,
             rng_key=self.rng_key,
             batch_size=self._device.num_devices if self._device is not None else 1,
+            num_samples=num_samples,
             shuffle=False,
             device=self._device,
             **kwargs,
@@ -382,6 +383,7 @@ class ImpactModel(BaseModel):
             y=None,
             rng_key=self.rng_key,
             batch_size=batch_size,
+            num_samples=num_samples,
             shuffle=False,
             device=self._device,
             **kwargs,
@@ -567,10 +569,10 @@ class ImpactModel(BaseModel):
             return_sites (tuple[str] | None, optional): Names of variables (sites) to
                 return. If ``None``, samples ``self.param_output`` and deterministic
                 sites.
-            batch_size (int | None, optional): The size of batches for data loading
-                during posterior predictive sampling. By default, it is set to the
-                total number of samples (``n_samples_X``). This value also determines
-                the chunk size for storing the posterior predictive samples.
+            batch_size (int | None, optional): The batch size for data loading during
+                posterior predictive sampling. It also determines the chunk size used to
+                store the samples. If ``None``, it is determined automatically based on
+                the input data and number of samples.
             output_dir (str | Path | None, optional): The directory where the outputs
                 will be saved. If the specified directory does not exist, it will be
                 created automatically. If ``None``, a default temporary directory will
@@ -849,7 +851,8 @@ class ImpactModel(BaseModel):
             X=X,
             y=y,
             rng_key=rng_subkey,
-            batch_size=batch_size,
+            batch_size=batch_size if batch_size is not None else len(X),
+            num_samples=num_samples,
             shuffle=shuffle,
             device=None,
             **kwargs,
@@ -1094,10 +1097,10 @@ class ImpactModel(BaseModel):
             return_sites (tuple[str] | None, optional): Names of variables (sites) to
                 return. If ``None``, samples ``self.param_output`` and deterministic
                 sites.
-            batch_size (int | None, optional): The size of batches for data loading
-                during posterior predictive sampling. By default, it is set to the
-                total number of samples (``n_samples_X``). This value also determines
-                the chunk size for storing the posterior predictive samples.
+            batch_size (int | None, optional): The batch size for data loading during
+                posterior predictive sampling. It also determines the chunk size used to
+                store the samples. If ``None``, it is determined automatically based on
+                the input data and number of samples.
             output_dir (str | Path | None, optional): The directory where the outputs
                 will be saved. If the specified directory does not exist, it will be
                 created automatically. If ``None``, a default temporary directory will
@@ -1186,6 +1189,7 @@ class ImpactModel(BaseModel):
             y=None,
             rng_key=self.rng_key,
             batch_size=batch_size,
+            num_samples=self._num_samples,
             shuffle=False,
             device=self._device,
             **kwargs,
@@ -1296,7 +1300,7 @@ class ImpactModel(BaseModel):
         progress: bool = True,
         **kwargs: object,
     ) -> xr.DataTree:
-        """Compute the log likelihood of the data under the given model.
+        """Compute the log-likelihood of the data under the given model.
 
         Results are written to disk in the Zarr format, with computing and file writing
         decoupled and executed concurrently.
@@ -1308,10 +1312,10 @@ class ImpactModel(BaseModel):
                 ``batch_size`` is ignored.
             y (ArrayLike | None): Output data with shape ``(n_samples_Y,)``. Must be
                 ``None`` if ``X`` is a data loader.
-            batch_size (int | None, optional): The size of batches for data loading
-                during posterior predictive sampling. By default, it is set to the total
-                number of samples (``n_samples_X``). This value also determines the
-                chunk size for storing the log-likelihood values.
+            batch_size (int | None, optional): The batch size for data loading during
+                log-likelihood computation. It also determines the chunk size used to
+                store the samples. If ``None``, it is determined automatically based on
+                the input data and number of samples.
             output_dir (str | Path | None, optional): The directory where the outputs
                 will be saved. If the specified directory does not exist, it will be
                 created automatically. If ``None``, a default temporary directory will
@@ -1357,6 +1361,7 @@ class ImpactModel(BaseModel):
             y=y,
             rng_key=self.rng_key,
             batch_size=batch_size,
+            num_samples=self._num_samples,
             shuffle=False,
             device=self._device,
             **kwargs,

--- a/docs/source/user_guide/sampling.rst
+++ b/docs/source/user_guide/sampling.rst
@@ -94,7 +94,7 @@ Before training the model, we draw prior predictive samples and visualize the pr
 Posterior Sampling
 ------------------
 
-We first train the model using variational inference, but only draw a single posterior sample for demonstration purposes. 
+We first train the model using variational inference, but only draw a single posterior sample for demonstration purposes.
 After fitting, we use :py:meth:`~aimz.ImpactModel.sample` to draw 100 posterior samples for further analysis:
 
 .. jupyter-execute::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aimz"
-version = "0.5.0"
+version = "0.6.0.dev0"
 description = "Scalable probabilistic impact modeling"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_log_likelihood.py
+++ b/tests/test_log_likelihood.py
@@ -59,7 +59,9 @@ class TestBatchSize:
         X, y = synthetic_data
         im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
         im.fit(X=X, y=y, batch_size=3)
-        # NOTE: An additional warning about batch size not being divisible by the number
-        # of devices may also be raised.
-        with pytest.warns(UserWarning, match=".*"):
+        msg = (
+            r"The `batch_size` \(\d+\) is not divisible by the number of devices "
+            r"\(\d+\)\."
+        )
+        with pytest.warns(UserWarning, match=msg):
             im.log_likelihood(X=X, y=y)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -127,8 +127,6 @@ class TestBatchSize:
         X, y = synthetic_data
         im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
         im.fit(X=X, y=y, batch_size=3)
-        # NOTE: An additional warning about batch size not being divisible by the number
-        # of devices may also be raised.
         with pytest.warns(UserWarning, match=".*"):
             im.predict(X=X, progress=False)
 
@@ -141,10 +139,6 @@ def test_predict_after_cleanup(
     """Test `.predict()` recreates tempdir after `.cleanup()`."""
     X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
-    # NOTE: An additional warning about batch size not being divisible by the number
-    # of devices may also be raised.
-    with pytest.warns(UserWarning, match=".*"):
-        im.fit(X=X, y=y)
     im.fit(X=X, y=y, batch_size=3)
     msg = (
         r"The `batch_size` \(\d+\) is not divisible by the number of devices \(\d+\)\."

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ wheels = [
 
 [[package]]
 name = "aimz"
-version = "0.5.0"
+version = "0.6.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "dask" },


### PR DESCRIPTION
ImpactModel methods now automatically determine the `batch_size` based on input data size and number of samples when not provided.

Fixes #70