### PR TITLE
Remove `in_sample` argument and clean up docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Methods in {class}`~aimz.ImpactModel` now automatically determine the `batch_size` if it is not provided, based on the input data and number of samples ([#70](https://github.com/markean/aimz/issues/70)).
 
+- {meth}`~aimz.ImpactModel.sample_posterior_predictive_on_batch` and {meth}`~aimz.ImpactModel.sample_posterior_predictive` no longer accept the ``in_sample`` argument. Results are now always written to the ``posterior_predictive`` group.
+
 ### Fixed
 
 - Methods in {class}`~aimz.ImpactModel` now handle empty posterior dictionaries (`{}`) gracefully instead of failing when no posterior samples are available ([#76](https://github.com/markean/aimz/issues/76)).

--- a/aimz/model/_core.py
+++ b/aimz/model/_core.py
@@ -39,11 +39,10 @@ class BaseModel(ABC):
         """Initialize the BaseModel with a callable model.
 
         Args:
-            kernel (Callable): A probabilistic model with NumPyro primitives.
-            param_input (str, optional): Name of the parameter in the ``kernel`` for the
-                main input data.
-            param_output (str, optional): Name of the parameter in the ``kernel`` for
-                the output data.
+            kernel: A probabilistic model with NumPyro primitives.
+            param_input: Name of the parameter in the ``kernel`` for the main input
+                data.
+            param_output: Name of the parameter in the ``kernel`` for the output data.
         """
         self._kernel = kernel
         self._param_input = param_input

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -88,15 +88,14 @@ class ImpactModel(BaseModel):
         """Initialize an ImpactModel instance.
 
         Args:
-            kernel (Callable): A probabilistic model with NumPyro primitives.
+            kernel: A probabilistic model with NumPyro primitives.
             rng_key (ArrayLike): A pseudo-random number generator key.
-            inference (SVI | MCMC): An inference method supported by NumPyro, such as an
-                instance of :external:py:class:`numpyro.infer.svi.SVI` or
+            inference: An inference method supported by NumPyro, such as an instance of
+                :external:py:class:`numpyro.infer.svi.SVI` or
                 :external:py:class:`numpyro.infer.mcmc.MCMC`.
-            param_input (str, optional): The name of the parameter in the ``kernel`` for
-                the main input data.
-            param_output (str, optional): The name of the parameter in the ``kernel``
-                for the output data.
+            param_input: Name of the parameter in the ``kernel`` for the main input
+                data.
+            param_output: Name of the parameter in the ``kernel`` for the output data.
 
         Warning:
             The ``rng_key`` parameter should be provided as a **typed key array**
@@ -169,7 +168,7 @@ class ImpactModel(BaseModel):
         """Restore the state and reinitialize runtime attributes.
 
         Args:
-            state (dict): The state to restore, excluding the runtime attributes.
+            state: The state to restore, excluding the runtime attributes.
         """
         self.__dict__.update(state)
         self._init_runtime_attrs()
@@ -242,17 +241,16 @@ class ImpactModel(BaseModel):
 
         Args:
             X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
-            num_samples (int, optional): The number of samples to draw.
-            rng_key (ArrayLike | None, optional): A pseudo-random number generator key.
-                By default, an internal key is used and split as needed.
-            return_sites (tuple[str] | None, optional): Names of variables (sites) to
-                return. If ``None``, samples all latent, observed, and deterministic
-                sites.
-            return_datatree (bool, optional): If ``True``, return a
+            num_samples: The number of samples to draw.
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            return_sites: Names of variables (sites) to return. If ``None``, samples all
+                latent, observed, and deterministic sites.
+            return_datatree: If ``True``, return a
                 :external:py:class:`~xarray.DataTree`; otherwise return a
                 :py:class:`dict`.
-            **kwargs (object): Additional arguments passed to the model. All array-like
-                values are expected to be JAX arrays.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
 
         Returns:
             Prior predictive samples.
@@ -311,24 +309,23 @@ class ImpactModel(BaseModel):
 
         Args:
             X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
-            num_samples (int, optional): The number of samples to draw.
-            rng_key (ArrayLike | None, optional): A pseudo-random number generator key.
-                By default, an internal key is used and split as needed.
-            return_sites (tuple[str] | None, optional): Names of variables (sites) to
-                return. If ``None``, samples ``self.param_output`` and deterministic
-                sites.
-            batch_size (int | None, optional): The batch size for data loading during
-                prior predictive sampling. It also determines the chunk size used to
-                store the samples. If ``None``, it is determined automatically based on
-                the input data and number of samples.
-            output_dir (str | Path | None, optional): The directory where the outputs
-                will be saved. If the specified directory does not exist, it will be
-                created automatically. If ``None``, a default temporary directory will
-                be created. A timestamped subdirectory will be generated within this
-                directory to store the outputs. Outputs are saved in the Zarr format.
-            progress (bool, optional): Whether to display a progress bar.
-            **kwargs (object): Additional arguments passed to the model. All array-like
-                values are expected to be JAX arrays.
+            num_samples: The number of samples to draw.
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            return_sites: Names of variables (sites) to return. If ``None``, samples
+                ``self.param_output`` and deterministic sites.
+            batch_size: The batch size for data loading during prior predictive
+                sampling. It also determines the chunk size used to store the samples.
+                If ``None``, it is determined automatically based on the input data and
+                number of samples.
+            output_dir: The directory where the outputs will be saved. If the specified
+                directory does not exist, it will be created automatically. If ``None``,
+                a default temporary directory will be created. A timestamped
+                subdirectory will be generated within this directory to store the
+                outputs. Outputs are saved in the Zarr format.
+            progress: Whether to display a progress bar.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
 
         Returns:
             Prior predictive samples.
@@ -457,20 +454,19 @@ class ImpactModel(BaseModel):
         """Draw posterior samples from a fitted model.
 
         Args:
-            num_samples (int, optional): The number of posterior samples to draw.
-            rng_key (ArrayLike | None, optional): A pseudo-random number generator key.
-                By default, an internal key is used and split as needed. Has no effect
-                if the inference method is MCMC, where the ``post_warmup_state``
-                property will be used to continue sampling.
-            return_sites (tuple[str] | None, optional): Names of variables (sites) to
-                return. If ``None``, samples all latent sites. Has no effect if the
-                inference method is MCMC.
-            return_datatree (bool, optional): If ``True``, return a
+            num_samples: The number of posterior samples to draw.
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed. Has no effect if
+                the inference method is MCMC, where the ``post_warmup_state`` property
+                will be used to continue sampling.
+            return_sites: Names of variables (sites) to return. If ``None``, samples
+                all latent sites. Has no effect if the inference method is MCMC.
+            return_datatree: If ``True``, return a
                 :external:py:class:`~xarray.DataTree`; otherwise return a
                 :py:class:`dict`.
-            **kwargs (object): Additional arguments passed to the model. All array-like
-                values are expected to be JAX arrays. Only relevant when the inference
-                method is MCMC.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays. Only relevant when the inference method
+                is MCMC.
 
         Returns:
             Posterior samples.
@@ -523,7 +519,6 @@ class ImpactModel(BaseModel):
         *,
         intervention: dict | None = None,
         rng_key: ArrayLike | None = None,
-        in_sample: bool = True,
         return_sites: tuple[str] | None = None,
         return_datatree: bool = True,
         **kwargs: object,
@@ -531,30 +526,24 @@ class ImpactModel(BaseModel):
         """Draw samples from the posterior predictive distribution.
 
         This method is a convenience alias for
-        :py:meth:`~aimz.ImpactModel.predict_on_batch`.
+        :py:meth:`~aimz.ImpactModel.predict_on_batch`, with ``in_sample`` automatically
+        set to ``True``.
 
         Args:
             X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
-            intervention (dict | None, optional): A dictionary mapping sample sites to
-                their corresponding intervention values. Interventions enable
-                counterfactual analysis by modifying the specified sample sites during
-                prediction (posterior predictive sampling).
-            rng_key (ArrayLike | None, optional): A pseudo-random number generator key.
-                By default, an internal key is used and split as needed.
-            in_sample (bool, optional): Specifies the group where posterior predictive
-                samples are stored in the returned output. If ``True``, samples are
-                stored in the ``posterior_predictive`` group, indicating they were
-                generated based on data used during model fitting. If ``False``, samples
-                are stored in the ``predictions`` group, indicating they were generated
-                based on out-of-sample data.
-            return_sites (tuple[str] | None, optional): Names of variables (sites) to
-                return. If ``None``, samples ``self.param_output`` and deterministic
-                sites.
-            return_datatree (bool, optional): If ``True``, return a
+            intervention: A dictionary mapping sample sites to their corresponding
+                intervention values. Interventions enable counterfactual analysis by
+                modifying the specified sample sites during prediction (posterior
+                predictive sampling).
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            return_sites: Names of variables (sites) to return. If ``None``, samples
+                ``self.param_output`` and deterministic sites.
+            return_datatree: If ``True``, return a
                 :external:py:class:`~xarray.DataTree`; otherwise return a
                 :py:class:`dict`.
-            **kwargs (object): Additional arguments passed to the model. All array-like
-                values are expected to be JAX arrays.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
 
         Returns:
             Posterior predictive samples. Posterior samples are included if available.
@@ -569,7 +558,7 @@ class ImpactModel(BaseModel):
             X,
             intervention=intervention,
             rng_key=rng_key,
-            in_sample=in_sample,
+            in_sample=True,
             return_sites=return_sites,
             return_datatree=return_datatree,
             **kwargs,
@@ -581,7 +570,6 @@ class ImpactModel(BaseModel):
         *,
         intervention: dict | None = None,
         rng_key: ArrayLike | None = None,
-        in_sample: bool = True,
         return_sites: tuple[str] | None = None,
         batch_size: int | None = None,
         output_dir: str | Path | None = None,
@@ -590,40 +578,34 @@ class ImpactModel(BaseModel):
     ) -> xr.DataTree:
         """Draw samples from the posterior predictive distribution.
 
-        This method is a convenience alias for :py:meth:`~aimz.ImpactModel.predict`.
+        This method is a convenience alias for :py:meth:`~aimz.ImpactModel.predict`,
+        with ``in_sample`` automatically set to ``True``.
 
         Args:
             X (ArrayLike | ArrayLoader): Input data, either an array-like of shape
                 ``(n_samples, n_features)`` or a data loader that holds all array-like
                 objects and handles batching internally; if a data loader is passed,
                 ``batch_size`` is ignored.
-            intervention (dict | None, optional): A dictionary mapping sample sites to
-                their corresponding intervention values. Interventions enable
-                counterfactual analysis by modifying the specified sample sites during
-                prediction (posterior predictive sampling).
-            rng_key (ArrayLike | None, optional): A pseudo-random number generator key.
-                By default, an internal key is used and split as needed.
-            in_sample (bool, optional): Specifies the group where posterior predictive
-                samples are stored in the returned output. If ``True``, samples are
-                stored in the ``posterior_predictive`` group, indicating they were
-                generated based on data used during model fitting. If ``False``, samples
-                are stored in the ``predictions`` group, indicating they were generated
-                based on out-of-sample data.
-            return_sites (tuple[str] | None, optional): Names of variables (sites) to
-                return. If ``None``, samples ``self.param_output`` and deterministic
-                sites.
-            batch_size (int | None, optional): The batch size for data loading during
-                posterior predictive sampling. It also determines the chunk size used to
-                store the samples. If ``None``, it is determined automatically based on
-                the input data and number of samples.
-            output_dir (str | Path | None, optional): The directory where the outputs
-                will be saved. If the specified directory does not exist, it will be
-                created automatically. If ``None``, a default temporary directory will
-                be created. A timestamped subdirectory will be generated within this
-                directory to store the outputs. Outputs are saved in the Zarr format.
-            progress (bool, optional): Whether to display a progress bar.
-            **kwargs (object): Additional arguments passed to the model. All array-like
-                values are expected to be JAX arrays.
+            intervention: A dictionary mapping sample sites to their corresponding
+                intervention values. Interventions enable counterfactual analysis by
+                modifying the specified sample sites during prediction (posterior
+                predictive sampling).
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            return_sites: Names of variables (sites) to return. If ``None``, samples
+                ``self.param_output`` and deterministic sites.
+            batch_size: The batch size for data loading during posterior predictive
+                sampling. It also determines the chunk size used to store the samples.
+                If ``None``, it is determined automatically based on the input data and
+                number of samples.
+            output_dir: The directory where the outputs will be saved. If the specified
+                directory does not exist, it will be created automatically. If ``None``,
+                a default temporary directory will be created. A timestamped
+                subdirectory will be generated within this directory to store the
+                outputs. Outputs are saved in the Zarr format.
+            progress: Whether to display a progress bar.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
 
         Returns:
             Posterior predictive samples. Posterior samples are included if available.
@@ -638,7 +620,7 @@ class ImpactModel(BaseModel):
             X,
             intervention=intervention,
             rng_key=rng_key,
-            in_sample=in_sample,
+            in_sample=True,
             return_sites=return_sites,
             batch_size=batch_size,
             output_dir=output_dir,
@@ -658,11 +640,11 @@ class ImpactModel(BaseModel):
         Args:
             X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
             y (ArrayLike): Output data with shape ``(n_samples_Y,)``.
-            rng_key (ArrayLike | None, optional): A pseudo-random number generator key.
-                By default, an internal key is used and split as needed. The key is only
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed. The key is only
                 used for initialization if the internal SVI state is not yet set.
-            **kwargs (object): Additional arguments passed to the model. All array-like
-                values are expected to be JAX arrays.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
 
         Returns:
             - Updated SVI state after the training step.
@@ -739,16 +721,16 @@ class ImpactModel(BaseModel):
         Args:
             X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
             y (ArrayLike): Output data with shape ``(n_samples_Y,)``.
-            num_steps (int, optional): Number of steps for variational inference
-                optimization. Has no effect if the inference method is MCMC.
-            num_samples (int | None, optional): The number of posterior samples to draw.
-                Has no effect if the inference method is MCMC.
-            rng_key (ArrayLike | None, optional): A pseudo-random number generator key.
-                By default, an internal key is used and split as needed.
-            progress (bool, optional): Whether to display a progress bar. Has no effect
+            num_steps: Number of steps for variational inference optimization. Has no
+                effect if the inference method is MCMC.
+            num_samples: The number of posterior samples to draw. Has no effect if the
+                inference method is MCMC.
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            progress: Whether to display a progress bar. Has no effect
                 if the inference method is MCMC.
-            **kwargs (object): Additional arguments passed to the model. All array-like
-                values are expected to be JAX arrays.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
 
         Returns:
             The fitted model instance, enabling method chaining.
@@ -851,18 +833,17 @@ class ImpactModel(BaseModel):
                 ``batch_size`` is ignored.
             y (ArrayLike | None): Output data with shape ``(n_samples_Y,)``. Must be
                 ``None`` if ``X`` is a data loader.
-            num_samples (int | None, optional): The number of posterior samples to draw.
-            rng_key (ArrayLike | None, optional): A pseudo-random number generator key.
-                By default, an internal key is used and split as needed.
-            progress (bool, optional): Whether to display a progress bar.
-            batch_size (int | None, optional): The number of data points processed at
-                each step of variational inference. If ``None``, the entire dataset is
-                used as a single batch in each epoch.
-            epochs (int, optional): The number of epochs for variational inference
-                optimization.
-            shuffle (bool, optional): Whether to shuffle the data at each epoch.
-            **kwargs (object): Additional arguments passed to the model. All array-like
-                values are expected to be JAX arrays.
+            num_samples: The number of posterior samples to draw.
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            progress: Whether to display a progress bar.
+            batch_size: The number of data points processed at each step of variational
+                inference. If ``None``, the entire dataset is used as a single batch in
+                each epoch.
+            epochs: The number of epochs for variational inference optimization.
+            shuffle: Whether to shuffle the data at each epoch.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
 
         Returns:
             The fitted model instance, enabling method chaining.
@@ -986,9 +967,9 @@ class ImpactModel(BaseModel):
         `NumPyro documentation <https://num.pyro.ai/en/stable/utilities.html#predictive>`__.
 
         Args:
-            posterior_sample (dict[str, Array]): Posterior samples to set for the model.
-            return_sites (tuple[str] | None, optional): Names of variable (sites) to
-                return in :py:meth:`~aimz.ImpactModel.predict`. By default, it is set to
+            posterior_sample: Posterior samples to set for the model.
+            return_sites: Names of variable (sites) to return in
+                :py:meth:`~aimz.ImpactModel.predict`. By default, it is set to
                 ``self.param_output``.
 
         Returns:
@@ -1040,26 +1021,25 @@ class ImpactModel(BaseModel):
 
         Args:
             X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
-            intervention (dict | None, optional): A dictionary mapping sample sites to
-                their corresponding intervention values. Interventions enable
-                counterfactual analysis by modifying the specified sample sites during
-                prediction (posterior predictive sampling).
-            rng_key (ArrayLike | None, optional): A pseudo-random number generator key.
-                By default, an internal key is used and split as needed.
-            in_sample (bool, optional): Specifies the group where posterior predictive
-                samples are stored in the returned output. If ``True``, samples are
-                stored in the ``posterior_predictive`` group, indicating they were
-                generated based on data used during model fitting. If ``False``, samples
-                are stored in the ``predictions`` group, indicating they were generated
-                based on out-of-sample data.
-            return_sites (tuple[str] | None, optional): Names of variables (sites) to
-                return. If ``None``, samples ``self.param_output`` and deterministic
-                sites.
-            return_datatree (bool, optional): If ``True``, return a
+            intervention: A dictionary mapping sample sites to their corresponding
+                intervention values. Interventions enable counterfactual analysis by
+                modifying the specified sample sites during prediction (posterior
+                predictive sampling).
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            in_sample: Specifies the group where posterior predictive samples are stored
+                in the returned output. If ``True``, samples are stored in the
+                ``posterior_predictive`` group, indicating they were generated based on
+                data used during model fitting. If ``False``, samples are stored in the
+                ``predictions`` group, indicating they were generated based on
+                out-of-sample data.
+            return_sites: Names of variables (sites) to return. If ``None``, samples
+                ``self.param_output`` and deterministic sites.
+            return_datatree: If ``True``, return a
                 :external:py:class:`~xarray.DataTree`; otherwise return a
                 :py:class:`dict`.
-            **kwargs (object): Additional arguments passed to the model. All array-like
-                values are expected to be JAX arrays.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
 
         Returns:
             Posterior predictive samples. Posterior samples are included if available.
@@ -1136,33 +1116,32 @@ class ImpactModel(BaseModel):
                 ``(n_samples, n_features)`` or a data loader that holds all array-like
                 objects and handles batching internally; if a data loader is passed,
                 ``batch_size`` is ignored.
-            intervention (dict | None, optional): A dictionary mapping sample sites to
-                their corresponding intervention values. Interventions enable
-                counterfactual analysis by modifying the specified sample sites during
-                prediction (posterior predictive sampling).
-            rng_key (ArrayLike | None, optional): A pseudo-random number generator key.
-                By default, an internal key is used and split as needed.
-            in_sample (bool, optional): Specifies the group where posterior predictive
-                samples are stored in the returned output. If ``True``, samples are
-                stored in the ``posterior_predictive`` group, indicating they were
-                generated based on data used during model fitting. If ``False``, samples
-                are stored in the ``predictions`` group, indicating they were generated
-                based on out-of-sample data.
-            return_sites (tuple[str] | None, optional): Names of variables (sites) to
-                return. If ``None``, samples ``self.param_output`` and deterministic
-                sites.
-            batch_size (int | None, optional): The batch size for data loading during
-                posterior predictive sampling. It also determines the chunk size used to
-                store the samples. If ``None``, it is determined automatically based on
-                the input data and number of samples.
-            output_dir (str | Path | None, optional): The directory where the outputs
-                will be saved. If the specified directory does not exist, it will be
-                created automatically. If ``None``, a default temporary directory will
-                be created. A timestamped subdirectory will be generated within this
-                directory to store the outputs. Outputs are saved in the Zarr format.
-            progress (bool, optional): Whether to display a progress bar.
-            **kwargs (object): Additional arguments passed to the model. All array-like
-                values are expected to be JAX arrays.
+            intervention: A dictionary mapping sample sites to their corresponding
+                intervention values. Interventions enable counterfactual analysis by
+                modifying the specified sample sites during prediction (posterior
+                predictive sampling).
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            in_sample: Specifies the group where posterior predictive samples are stored
+                in the returned output. If ``True``, samples are stored in the
+                ``posterior_predictive`` group, indicating they were generated based on
+                data used during model fitting. If ``False``, samples are stored in the
+                ``predictions`` group, indicating they were generated based on
+                out-of-sample data.
+            return_sites: Names of variables (sites) to return. If ``None``, samples
+                ``self.param_output`` and deterministic sites.
+            batch_size: The batch size for data loading during posterior predictive
+                sampling. It also determines the chunk size used to store the samples.
+                If ``None``, it is determined automatically based on the input data
+                and number of samples.
+            output_dir: The directory where the outputs will be saved. If the specified
+                directory does not exist, it will be created automatically. If ``None``,
+                a default temporary directory will be created. A timestamped
+                subdirectory will be generated within this directory to store the
+                outputs. Outputs are saved in the Zarr format.
+            progress: Whether to display a progress bar.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
 
         Returns:
             Posterior predictive samples. Posterior samples are included if available.
@@ -1295,17 +1274,14 @@ class ImpactModel(BaseModel):
         """Estimate the effect of an intervention.
 
         Args:
-            output_baseline (xr.DataTree | None, optional): Precomputed output for the
-                baseline scenario.
-            output_intervention (xr.DataTree | None, optional): Precomputed output for
-                the intervention scenario.
-            args_baseline (dict | None, optional): Input arguments for the baseline
-                scenario. Passed to the :py:meth:`~aimz.ImpactModel.predict` to compute
-                predictions if ``output_baseline`` is not provided. Ignored if
-                ``output_baseline`` is already given.
-            args_intervention (dict | None, optional): Input arguments for the
-                intervention scenario. Passed to the
+            output_baseline: Precomputed output for the baseline scenario.
+            output_intervention: Precomputed output for the intervention scenario.
+            args_baseline: Input arguments for the baseline scenario. Passed to the
                 :py:meth:`~aimz.ImpactModel.predict` to compute predictions if
+                ``output_baseline`` is not provided. Ignored if ``output_baseline`` is
+                already given.
+            args_intervention: Input arguments for the intervention scenario. Passed to
+                the :py:meth:`~aimz.ImpactModel.predict` to compute predictions if
                 ``output_intervention`` is not provided. Ignored if
                 ``output_intervention`` is already given.
 
@@ -1370,18 +1346,18 @@ class ImpactModel(BaseModel):
                 ``batch_size`` is ignored.
             y (ArrayLike | None): Output data with shape ``(n_samples_Y,)``. Must be
                 ``None`` if ``X`` is a data loader.
-            batch_size (int | None, optional): The batch size for data loading during
-                log-likelihood computation. It also determines the chunk size used to
-                store the samples. If ``None``, it is determined automatically based on
-                the input data and number of samples.
-            output_dir (str | Path | None, optional): The directory where the outputs
-                will be saved. If the specified directory does not exist, it will be
-                created automatically. If ``None``, a default temporary directory will
-                be created. A timestamped subdirectory will be generated within this
-                directory to store the outputs. Outputs are saved in the Zarr format.
-            progress (bool, optional): Whether to display a progress bar.
-            **kwargs (object): Additional arguments passed to the model. All array-like
-                values are expected to be JAX arrays.
+            batch_size: The batch size for data loading during log-likelihood
+                computation. It also determines the chunk size used to store the
+                samples. If ``None``, it is determined automatically based on the input
+                data and number of samples.
+            output_dir: The directory where the outputs will be saved. If the specified
+                directory does not exist, it will be created automatically. If ``None``,
+                a default temporary directory will be created. A timestamped
+                subdirectory will be generated within this directory to store the
+                outputs. Outputs are saved in the Zarr format.
+            progress: Whether to display a progress bar.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
 
         Returns:
             Log-likelihood values. Posterior samples are included if available.
@@ -1538,19 +1514,19 @@ class ImpactModel(BaseModel):
         the provided ``samples``, and writes the resulting arrays to a Zarr group.
 
         Args:
-            num_samples (int): Number of samples to draw.
-            rng_key (ArrayLike): Pseudo-random number generator key.
-            return_sites (tuple[str]): Names of variables (sites) to return.
-            output_dir (Path): Directory where outputs will be saved.
-            kernel (Callable): Probabilistic model with NumPyro primitives.
-            sampler (Callable): Function performing predictive sampling; must accept
-                the same signature as this function.
-            samples (dict[str, Array]): Arrays to condition predictions on.
-            dataloader (ArrayLoader): Iterator over batches of input data. Each batch
-                must be a tuple containing a dictionary of arrays and a padding value.
-            pbar (tqdm): Progress bar instance to display sampling progress.
-            **kwargs (object): Additional arguments passed to the model. All array-like
-                values are expected to be JAX arrays.
+            num_samples: Number of samples to draw.
+            rng_key: Pseudo-random number generator key.
+            return_sites: Names of variables (sites) to return.
+            output_dir: Directory where outputs will be saved.
+            kernel: Probabilistic model with NumPyro primitives.
+            sampler: Function performing predictive sampling; must accept the same
+                signature as this function.
+            samples: Arrays to condition predictions on.
+            dataloader: Iterator over batches of input data. Each batch must be a tuple
+                containing a dictionary of arrays and a padding value.
+            pbar: Progress bar instance to display sampling progress.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
 
         Raises:
             Exception: Any exception raised during sampling or writing is logged, the

--- a/aimz/sampling/_forward.py
+++ b/aimz/sampling/_forward.py
@@ -39,18 +39,17 @@ def _sample_forward(
     parameter values. Deterministic sites in the model are excluded from substitution.
 
     Args:
-        model (Callable): A probabilistic model with NumPyro primitives.
-        num_samples (int): The number of samples to draw.
+        model: A probabilistic model with NumPyro primitives.
+        num_samples: The number of samples to draw.
         rng_key (ArrayLike): A pseudo-random number generator key.
-        return_sites (tuple[str] | None): Names of variables (sites) to return.
-        samples (dict[str, Array]| None): A dictionary of samples to condition on,
-            where each array has shape ``(num_samples, ...)``.
-        model_kwargs (dict[str, Array] | None): Additional arguments passed to the
-            model.
+        return_sites: Names of variables (sites) to return.
+        samples: A dictionary of samples to condition on, where each array has shape
+            ``(num_samples, ...)``.
+        model_kwargs: Additional arguments passed to the model.
 
     Returns:
-        dict[str, Array]: A dictionary mapping each return site to an array of traced
-            values with shape ``(num_samples, ...)``.
+        A dictionary mapping each return site to an array of traced values with shape
+            ``(num_samples, ...)``.
     """
 
     def _trace_one_sample(

--- a/aimz/utils/_format.py
+++ b/aimz/utils/_format.py
@@ -26,7 +26,7 @@ def _make_attrs() -> dict[str, str]:
     """Generate metadata attributes for the aimz library.
 
     Returns:
-        dict[str, str]: Attributes including creation timestamp and library version.
+        Attributes including creation timestamp and library version.
     """
     return {
         "created_at": datetime.datetime.now(datetime.UTC).isoformat(),
@@ -43,9 +43,9 @@ def _dict_to_datatree(data: dict[str, Array]) -> xr.DataTree:
     pattern ``<variable>_dim_<N>``.
 
     Args:
-        data (dict[str, Array]): Dictionary mapping variable names to arrays. Each array
-        should have shape ``(num_samples, dim_0, dim_1, ...)`` where the first dimension
-        represents samples or draws.
+        data: A dictionary mapping variable names to arrays. Each array should have
+            shape ``(num_samples, dim_0, dim_1, ...)`` where the first dimension
+            represents samples or draws.
 
     Returns:
         All variables with added ``chain`` and ``draw`` dimensions, along with

--- a/aimz/utils/_kwargs.py
+++ b/aimz/utils/_kwargs.py
@@ -24,11 +24,11 @@ def _group_kwargs(kwargs: dict) -> tuple[NamedTuple, NamedTuple]:
     """Separate keyword arguments into array-like and non-array-like groups.
 
     Args:
-        kwargs (dict): A dictionary of keyword arguments where values could be
-            array-like or non-array-like.
+        kwargs: A dictionary of keyword arguments where values could be array-like or
+            non-array-like.
 
     Returns:
-        tuple[KwargsArray, KwargsExtra]: A tuple containing two ``NamedTuple`` objects:
+        A tuple containing two ``NamedTuple`` objects:
             - kwargs_array (KwargsArray): Contains the array-like arguments.
             - kwargs_extra (KwargsExtra): Contains the non-array-like arguments.
     """

--- a/aimz/utils/_output.py
+++ b/aimz/utils/_output.py
@@ -39,8 +39,7 @@ def _create_output_subdir(output_dir: str | Path) -> Path:
     specified output directory with a timestamp.
 
     Args:
-        output_dir (str | Path): The directory where the output subdirectory will be
-            created.
+        output_dir: The directory where the output subdirectory will be created.
 
     Returns:
         Path: The path to the created output subdirectory.
@@ -64,10 +63,10 @@ def _writer(site: str, queue: Queue, group_path: Path, error_queue: Queue) -> No
     details are put into the ``error_queue``.
 
     Args:
-        site (str): The name of the sample site.
-        queue (Queue): The queue to retrieve posterior predictive samples from.
-        group_path (Path): The path to the Zarr group where data will be written.
-        error_queue (Queue): The queue to collect errors raised by the writer thread.
+        site: The name of the sample site.
+        queue: The queue to retrieve posterior predictive samples from.
+        group_path: The path to the Zarr group where data will be written.
+        error_queue: The queue to collect errors raised by the writer thread.
     """
     group = open_group(group_path, mode="r+")
 
@@ -105,14 +104,14 @@ def _start_writer_threads(
     """Start writer threads and their corresponding queues for each site.
 
     Args:
-        sites (tuple[str]): Names of the return sites.
-        group_path (Path): The path to the Zarr group where data will be written.
-        writer (Callable): The function that processes queued data and writes to Zarr.
-        queue_size (int): Maximum size of each queue (per site).
+        sites: Names of the return sites.
+        group_path: The path to the Zarr group where data will be written.
+        writer: The function that processes queued data and writes to Zarr.
+        queue_size: Maximum size of each queue (per site).
 
     Returns:
-        tuple[list[Thread], dict[str, Queue]]: A tuple containing a list of threads and
-            a dictionary mapping each site to its corresponding queue.
+        A tuple containing a list of threads and a dictionary mapping each site to its
+        corresponding queue.
     """
     queues: dict[str, Queue] = {site: Queue(queue_size) for site in sites}
     threads = []
@@ -132,9 +131,9 @@ def _shutdown_writer_threads(
     """Signal writer threads to stop and wait for their completion.
 
     Args:
-        threads (list[Thread]): List of writer threads to join.
-        queues (dict[str, Queue]): Mapping of site names to their respective queues.
-        error_queue (Queue): Queue to collect errors raised by writer threads.
+        threads: List of writer threads to join.
+        queues: Mapping of site names to their respective queues.
+        error_queue: Queue to collect errors raised by writer threads.
     """
     for queue in queues.values():
         queue.put(None)

--- a/aimz/utils/_validation.py
+++ b/aimz/utils/_validation.py
@@ -59,11 +59,11 @@ def _validate_group(dt_baseline: "xr.DataTree", dt_intervention: "xr.DataTree") 
     """Validate the groups in ``dt_baseline`` and ``dt_intervention``.
 
     Args:
-        dt_baseline (xr.DataTree): Precomputed output for the baseline scenario.
-        dt_intervention (xr.DataTree): Precomputed output for the intervention scenario.
+        dt_baseline: Precomputed output for the baseline scenario.
+        dt_intervention: Precomputed output for the intervention scenario.
 
     Returns:
-        str: The group name (``predictions`` or ``posterior_predictive``).
+        The group name (``predictions`` or ``posterior_predictive``).
 
     Raises:
         ValueError: If the group is not found in ``dt_intervention``.
@@ -93,11 +93,9 @@ def _validate_kernel_signature(
     """Validate the signature of a kernel function.
 
     Args:
-        kernel (Callable): The kernel function to validate.
-        param_input (str): Name of the parameter in ``kernel`` corresponding to the
-            input.
-        param_output (str): Name of the parameter in ``kernel`` corresponding to the
-            output.
+        kernel: The kernel function to validate.
+        param_input: Name of the parameter in ``kernel`` corresponding to the input.
+        param_output: Name of the parameter in ``kernel`` corresponding to the output.
 
     Raises:
         KernelValidationError: If the kernel signature does not meet the required
@@ -140,10 +138,9 @@ def _validate_kernel_body(
     """Validate the body of a kernel function.
 
     Args:
-        kernel (Callable): The kernel function to validate.
-        param_output (str): Name of the parameter in ``kernel`` corresponding to the
-            output.
-        model_trace (OrderedDict[str, dict]): The model trace containing the sites.
+        kernel: The kernel function to validate.
+        param_output: Name of the parameter in ``kernel`` corresponding to the output.
+        model_trace: The model trace containing the sites.
 
     Raises:
         KernelValidationError: If the kernel body does not meet the required

--- a/aimz/utils/data/_input_setup.py
+++ b/aimz/utils/data/_input_setup.py
@@ -56,15 +56,14 @@ def _setup_inputs(
         y (ArrayLike | None): Output data with shape ``(n_samples_Y,)``. Must be
             ``None`` if ``X`` is a data loader.
         rng_key (ArrayLike): A pseudo-random number generator key.
-        batch_size (int | None): The size of batches for data loading.
-        num_samples (int): Number of samples to draw, which affects the size of batches.
-        shuffle (bool, optional): Whether to shuffle the dataset before batching.
-        device (Sharding | None, optional): The device or sharding specification to
-            which the data should be moved. By default, no device transfer is applied.
-            If ``X`` is a data loader, it will override the device setting of the
-            loader.
-        **kwargs (object): Additional arguments passed to the model. All array-like
-                values are expected to be JAX arrays.
+        batch_size: The size of batches for data loading.
+        num_samples: Number of samples to draw, which affects the size of batches.
+        shuffle: Whether to shuffle the dataset before batching.
+        device: The device or sharding specification to which the data should be moved.
+            By default, no device transfer is applied. If ``X`` is a data loader, it
+            will override the device setting of the loader.
+        **kwargs: Additional arguments passed to the model. All array-like values are
+            expected to be JAX arrays.
 
     Returns:
         - The data loader for batching.

--- a/aimz/utils/data/_sharding.py
+++ b/aimz/utils/data/_sharding.py
@@ -43,14 +43,14 @@ def _create_sharded_sampler(
     """Create a sharded predictive sampling function.
 
     Args:
-        mesh (Mesh): The JAX mesh object defining the device mesh for sharding.
-        n_kwargs_array (int): The number of arguments in the keyword arguments that are
+        mesh: The JAX mesh object defining the device mesh for sharding.
+        n_kwargs_array: The number of arguments in the keyword arguments that are
             array-like (sharded).
-        n_kwargs_extra (int): The number of extra keyword arguments that are not
-            array-like (not sharded).
+        n_kwargs_extra: The number of extra keyword arguments that are not array-like
+            (not sharded).
 
     Returns:
-        Callable: A sharded function that takes the following arguments:
+        A sharded function that takes the following arguments:
             - rng_key (Array): A pseudo-random number generator key.
             - kernel (Callable): A probabilistic model with NumPyro primitives.
             - samples (dict): A dictionary of samples to condition on.
@@ -143,14 +143,14 @@ def _create_sharded_log_likelihood(
     """Create a sharded log-likelihood function.
 
     Args:
-        mesh (Mesh): The JAX mesh object defining the device mesh for sharding.
-        n_kwargs_array (int): The number of arguments in the keyword arguments that are
+        mesh: The JAX mesh object defining the device mesh for sharding.
+        n_kwargs_array: The number of arguments in the keyword arguments that are
             array-like (sharded).
-        n_kwargs_extra (int): The number of extra keyword arguments that are not
-            array-like (not sharded).
+        n_kwargs_extra: The number of extra keyword arguments that are not array-like
+            (not sharded).
 
     Returns:
-        Callable: A sharded function that takes the following arguments:
+        A sharded function that takes the following arguments:
             - kernel (Callable): A probabilistic model with NumPyro primitives optimized
                 with variational inference.
             - posterior_samples (dict): A dictionary of posterior samples.

--- a/aimz/utils/data/array_dataset.py
+++ b/aimz/utils/data/array_dataset.py
@@ -26,7 +26,7 @@ class ArrayDataset:
         """Initialize an ArrayDataset instance.
 
         Args:
-            to_jax (bool): Whether to convert the input arrays to JAX arrays.
+            to_jax: Whether to convert the input arrays to JAX arrays.
             **arrays (ArrayLike): One or more JAX arrays or compatible array-like
                 objects.
 

--- a/aimz/utils/data/array_loader.py
+++ b/aimz/utils/data/array_loader.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 from warnings import warn
 
 import jax.numpy as jnp
+import numpy.typing as npt
 from jax import Array, device_put, local_device_count, random
 from jax.typing import ArrayLike
 
@@ -32,7 +33,6 @@ from aimz.utils.data.array_dataset import ArrayDataset
 
 if TYPE_CHECKING:
     from jax.sharding import Sharding
-    from numpy import ndarray
 
 
 class ArrayLoader:
@@ -50,14 +50,13 @@ class ArrayLoader:
         """Initialize an ArrayLoader instance.
 
         Args:
-            dataset (ArrayDataset): The dataset to load.
+            dataset: The dataset to load.
             rng_key (ArrayLike): A pseudo-random number generator key.
-            batch_size (int): The number of samples per batch.
-            shuffle (bool, optional): Whether to shuffle the dataset before batching.
-            device (Sharding | None, optional): The device or sharding specification to
-                which the data should be moved. By default, no device transfer is
-                applied. When used as an input to a model, this will be overridden by
-                the device setting of the model.
+            batch_size: The number of samples per batch.
+            shuffle: Whether to shuffle the dataset before batching.
+            device: The device or sharding specification to which the data should be
+                moved. By default, no device transfer is applied. When used as an input
+                to a model, this will be overridden by the device setting of the model.
         """
         self.dataset = dataset
         if (
@@ -78,13 +77,13 @@ class ArrayLoader:
         self._num_devices = local_device_count()
         self.device = device
 
-    def pad_array(self, x: "Array | ndarray", n_pad: int, axis: int = 0) -> Array:
+    def pad_array(self, x: Array | npt.NDArray, n_pad: int, axis: int = 0) -> Array:
         """Pad an array to ensure compatibility with sharding.
 
         Args:
-            x (Array | ndarray): The input array to be padded.
-            n_pad (int): The number of padding elements to add.
-            axis (int): The axis along which to apply the padding.
+            x: The input array to be padded.
+            n_pad: The number of padding elements to add.
+            axis: The axis along which to apply the padding.
 
         Returns:
             The padded array with padding applied along the specified axis.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,10 @@ per-file-ignores = { "aimz/model/_core.py" = [
     "ANN001", # missing-type-function-argument
     "ANN003", # missing-type-kwargs
 ], "aimz/mlflow*" = [
+    "ANN202",  # missing-return-type-private-function
     "ARG001",  # unused-function-argument
     "PLR0913", # too-many-arguments
+    "PLC0415", # import-outside-top-level
 ], "docs*" = [
     "INP001", # implicit-namespace-package
     "A001",   # builtin-variable-shadowing
@@ -99,7 +101,6 @@ pylint = { max-args = 10 }
 
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
-banned-module-level-imports = ["cloudpickle"]
 
 [tool.setuptools.packages.find]
 include = ["aimz*"]


### PR DESCRIPTION
Eliminate the `in_sample` argument from specific methods to streamline functionality. Simplify docstrings by removing unnecessary type hints for better readability.