### PR TITLE
Add `output_dir` attribute to `xarray.DataTree` outputs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,23 @@ All notable changes to this project will be documented in this file and are best
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+`output_dir` attribute to the root and group nodes of {class}`xarray.DataTree` objects returned by {meth}`~aimz.ImpactModel.sample_prior_predictive`, {meth}`~aimz.ImpactModel.predict`, and {meth}`~aimz.ImpactModel.log_likelihood`, specifying the directory where results are saved ([#85](https://github.com/markean/aimz/issues/85)).
+
 ## [v0.6.0](https://github.com/markean/aimz/releases/tag/v0.6.0) - 2025-09-14
 
 ### Added
 
-- {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch`, {meth}`~aimz.ImpactModel.sample`, {meth}`~aimz.ImpactModel.sample_posterior_predictive_on_batch`, and {meth}`~aimz.ImpactModel.predict_on_batch` methods in {class}`~aimz.ImpactModel` now support a `return_datatree` parameter. When set to ``True`` (by default), results are returned as an {class}`xarray.DataTree`; otherwise, a ``dict`` is returned ([#74](https://github.com/markean/aimz/issues/74)).
+- {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch`, {meth}`~aimz.ImpactModel.sample`, {meth}`~aimz.ImpactModel.sample_posterior_predictive_on_batch`, and {meth}`~aimz.ImpactModel.predict_on_batch` methods in {class}`~aimz.ImpactModel` now support a `return_datatree` parameter. When set to `True` (by default), results are returned as an {class}`xarray.DataTree`; otherwise, a `dict` is returned ([#74](https://github.com/markean/aimz/issues/74)).
 
 ### Changed
 
 - Methods in {class}`~aimz.ImpactModel` now automatically determine the `batch_size` if it is not provided, based on the input data and number of samples ([#70](https://github.com/markean/aimz/issues/70)).
 
-- {meth}`~aimz.ImpactModel.sample_posterior_predictive_on_batch` and {meth}`~aimz.ImpactModel.sample_posterior_predictive` no longer accept the ``in_sample`` argument. Results are now always written to the ``posterior_predictive`` group.
+- {meth}`~aimz.ImpactModel.sample_posterior_predictive_on_batch` and {meth}`~aimz.ImpactModel.sample_posterior_predictive` no longer accept the `in_sample` argument. Results are now always written to the `posterior_predictive` group.
 
 ### Removed
 
@@ -45,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enhanced data array validation to preserve device placement for JAX arrays ([#53](https://github.com/markean/aimz/issues/53)).
 - Fixed incompatibility with Zarr when models output arrays in `bfloat16` by automatically promoting them to `float32` before saving ([#57](https://github.com/markean/aimz/issues/57)).
-- Fixed the error message in {meth}`~aimz.ImpactModel.sample_posterior_predictive` when ``self.param_output`` is passed as an argument, which previously incorrectly referenced {meth}`~aimz.ImpactModel.sample_prior_predictive` ([#65](https://github.com/markean/aimz/issues/65)).
+- Fixed the error message in {meth}`~aimz.ImpactModel.sample_posterior_predictive` when `self.param_output` is passed as an argument, which previously incorrectly referenced {meth}`~aimz.ImpactModel.sample_prior_predictive` ([#65](https://github.com/markean/aimz/issues/65)).
 
 ## [v0.4.0](https://github.com/markean/aimz/releases/tag/v0.4.0) - 2025-08-18
 

--- a/aimz/utils/_output.py
+++ b/aimz/utils/_output.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from zarr import Array
 
 
-def _create_output_subdir(output_dir: str | Path) -> Path:
+def _create_output_subdir(output_dir: Path) -> Path:
     """Create a subdirectory for storing output.
 
     This function is called for its side effect: it creates a subdirectory within the
@@ -44,8 +44,6 @@ def _create_output_subdir(output_dir: str | Path) -> Path:
     Returns:
         Path: The path to the created output subdirectory.
     """
-    output_dir = Path(output_dir).resolve()
-    output_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     output_subdir = output_dir / timestamp
     output_subdir.mkdir(parents=False, exist_ok=False)

--- a/docs/source/api/impact_model.rst
+++ b/docs/source/api/impact_model.rst
@@ -21,6 +21,7 @@ Attributes
    ImpactModel.param_output
    ImpactModel.vi_result
    ImpactModel.posterior
+   ImpactModel.temp_dir
 
 
 Inference

--- a/docs/source/user_guide/disk_and_on_batch.rst
+++ b/docs/source/user_guide/disk_and_on_batch.rst
@@ -20,7 +20,7 @@ Why Disk-Backed by Default
 --------------------------
 The non-``*_on_batch`` methods default to a disk-backed (chunked) execution model for several reasons:
 
-* Posterior predictive and prior predictive tensors can scale as ``(#samples x #dims x #posterior_samples x ...)``. 
+* Posterior predictive and prior predictive tensors can scale as ``(#samples x #dims x #posterior_samples x ...)``.
   Even moderate increases in any axis (time, spatial units, parameter samples) can exceed host or accelerator RAM.
 * Using ``batch_size`` with chunked iteration limits peak memory and prevents out-of-memory errors.
 * Persisted Zarr arrays with metadata (coords, dims, attrs) create an artifact you can reopen without rerunning inference.
@@ -31,7 +31,7 @@ The non-``*_on_batch`` methods default to a disk-backed (chunked) execution mode
 
 Comparison
 ----------
-Disk-backed variants target larger datasets, enable chunked processing, multi-device parallelism, and stable artifact generation. 
+Disk-backed variants target larger datasets, enable chunked processing, multi-device parallelism, and stable artifact generation.
 These methods build internal data loaders, iterate in chunks, and decouple sampling from file I/O, enabling concurrent execution.
 Outputs consolidate into a single :external:py:class:`xarray.DataTree` backed by Zarr files for post-hoc analysis.
 On-batch variants, in contrast, favor minimal overhead, immediate return, and greater flexibility when posterior sample shapes are not shard-friendly.
@@ -41,10 +41,10 @@ Feature Summary
 ============================= ==================================== =======================================================
 Feature                       Disk-backed (default)                On-batch (``*_on_batch``)
 ============================= ==================================== =======================================================
-Typical dataset size          Medium → large                       Small → moderate             
+Typical dataset size          Medium → large                       Small → moderate
 Supported use cases           Standard models                      Broader model support
-Peak memory usage             Chunk-bounded                        Full batch resident                                    
-Writes to disk                Yes                                  No                                                      
+Peak memory usage             Chunk-bounded                        Full batch resident
+Writes to disk                Yes                                  No
 Return type                   :external:py:class:`xarray.DataTree` :external:py:class:`xarray.DataTree` or :py:class:`dict`
                                                                    (via ``return_datatree=False``)
 Custom batch sizing           Yes (``batch_size``)                 No (single pass)
@@ -88,7 +88,7 @@ Quick Recommendations
 Example: :meth:`~aimz.ImpactModel.predict` with Fallback Warning
 ----------------------------------------------------------------
 
-A common scenario for the fallback warning occurs when the model contains **local latent variables**, which can make posterior sample shapes incompatible with shard-based parallel execution. 
+A common scenario for the fallback warning occurs when the model contains **local latent variables**, which can make posterior sample shapes incompatible with shard-based parallel execution.
 The example below illustrates this case.
 
 .. jupyter-execute::
@@ -127,7 +127,7 @@ The example below illustrates this case.
             optim=optim.Adam(step_size=1e-3),
             loss=Trace_ELBO(),
         ),
-    # This internally calls the `.run()` method of `SVI`  
+    # This internally calls the `.run()` method of `SVI`
     ).fit_on_batch(X, y)
 
 .. jupyter-execute::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aimz"
-version = "0.6.0"
+version = "0.6.1.dev0"
 description = "Scalable probabilistic impact modeling"
 readme = "README.md"
 license = "Apache-2.0"
@@ -49,7 +49,7 @@ docs = [
 
 [project.urls]
 source = "https://github.com/markean/aimz"
-documentation = "https://markean.github.io/aimz/"
+documentation = "https://aimz.readthedocs.io/"
 
 [tool.coverage.run]
 omit = ["aimz/mlflow/*"]
@@ -95,7 +95,6 @@ per-file-ignores = { "aimz/model/_core.py" = [
     "D107",   # undocumented-public-init
     "D417",   # undocumented-param
     "S101",   # assert
-    "S301",   # suspicious-pickle-usage
     "F811",   # redefined-while-unused
 ] }
 pydocstyle = { convention = "google" }

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -145,11 +145,11 @@ def test_predict_after_cleanup(
     )
     with pytest.warns(UserWarning, match=msg):
         im.predict(X=X, batch_size=len(X) // 2, progress=False)
-    temp_dir_before = im.temp_dir.name
+    temp_dir_before = im.temp_dir
     im.cleanup()
     with pytest.warns(UserWarning, match=msg):
         im.predict(X=X, batch_size=len(X) // 2, progress=False)
-    temp_dir_after = im.temp_dir.name
+    temp_dir_after = im.temp_dir
 
     assert temp_dir_before != temp_dir_after
 

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ wheels = [
 
 [[package]]
 name = "aimz"
-version = "0.6.0"
+version = "0.6.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "dask" },


### PR DESCRIPTION
Enhance `xarray.DataTree` objects returned by methods like `.sample_prior_predictive()`, `.predict()`, and `.log_likelihood()` by adding an `output_dir` attribute to indicate where results are saved. 

Fixes #85