### PR TITLE
Fix handling of `output_dir` attribute in ImpactModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - All `tqdm` progress bars now use `dynamic_ncols=True` to adjust column width dynamically ([#93](https://github.com/markean/aimz/issues/93)).
 
+### Fixed
+
+- Methods in {class}`~aimz.ImpactModel` no longer include an empty `posterior` data variable in root node of the returned {class}`xarray.DataTree` when no posterior samples are available ([#91](https://github.com/markean/aimz/issues/91)).
+
 ## [v0.6.0](https://github.com/markean/aimz/releases/tag/v0.6.0) - 2025-09-14
 
 ### Added

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -54,7 +54,6 @@ from aimz.sampling._forward import _sample_forward
 from aimz.utils._format import _dict_to_datatree, _make_attrs
 from aimz.utils._kwargs import _group_kwargs
 from aimz.utils._output import (
-    # _create_output_subdir,
     _shutdown_writer_threads,
     _start_writer_threads,
     _writer,
@@ -189,12 +188,12 @@ class ImpactModel(BaseModel):
 
     @property
     def param_input(self) -> str:
-        """Name of the parameter in the ``kernel`` for the main input data."""
+        """Parameter name in :attr:`~aimz.ImpactModel.kernel` for the input data."""
         return self._param_input
 
     @property
     def param_output(self) -> str:
-        """Name of the parameter in the ``kernel`` for the output data."""
+        """Parameter name in :attr:`~aimz.ImpactModel.kernel` for the output data."""
         return self._param_output
 
     @property
@@ -265,7 +264,8 @@ class ImpactModel(BaseModel):
             Prior predictive samples.
 
         Raises:
-            TypeError: If ``self.param_output`` is passed as an argument.
+            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
+                argument.
         """
         X = cast("Array", _validate_X_y_to_jax(X))
 
@@ -322,7 +322,7 @@ class ImpactModel(BaseModel):
             rng_key (ArrayLike | None): A pseudo-random number generator key. By
                 default, an internal key is used and split as needed.
             return_sites: Names of variables (sites) to return. If ``None``, samples
-                ``self.param_output`` and deterministic sites.
+                :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
             batch_size: The batch size for data loading during prior predictive
                 sampling. It also determines the chunk size used to store the samples.
                 If ``None``, it is determined automatically based on the input data and
@@ -340,7 +340,8 @@ class ImpactModel(BaseModel):
             Prior predictive samples.
 
         Raises:
-            TypeError: If ``self.param_output`` is passed as an argument.
+            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
+                argument.
 
         See Also:
             :py:meth:`~aimz.ImpactModel.cleanup` to remove the temporary directory if
@@ -395,7 +396,7 @@ class ImpactModel(BaseModel):
                 len(kwargs_extra),
             )
 
-        output_subdir = self._create_output_subdir(output_dir)
+        output_dir, output_subdir = self._create_output_subdir(output_dir)
 
         dataloader, _ = _setup_inputs(
             X=X,
@@ -470,8 +471,8 @@ class ImpactModel(BaseModel):
             Posterior samples.
 
         Raises:
-            TypeError: If ``self.param_output`` is not passed as an argument if the
-                inference method is MCMC.
+            TypeError: If :attr:`~aimz.ImpactModel.param_output` is not passed as an
+                argument when the inference method is MCMC.
         """
         _check_is_fitted(self)
 
@@ -536,7 +537,7 @@ class ImpactModel(BaseModel):
             rng_key (ArrayLike | None): A pseudo-random number generator key. By
                 default, an internal key is used and split as needed.
             return_sites: Names of variables (sites) to return. If ``None``, samples
-                ``self.param_output`` and deterministic sites.
+                :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
             return_datatree: If ``True``, return a
                 :external:py:class:`~xarray.DataTree`; otherwise return a
                 :py:class:`dict`.
@@ -547,7 +548,8 @@ class ImpactModel(BaseModel):
             Posterior predictive samples. Posterior samples are included if available.
 
         Raises:
-            TypeError: If ``self.param_output`` is passed as an argument.
+            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
+                argument.
 
         See Also:
             :py:meth:`~aimz.ImpactModel.predict_on_batch`.
@@ -591,7 +593,7 @@ class ImpactModel(BaseModel):
             rng_key (ArrayLike | None): A pseudo-random number generator key. By
                 default, an internal key is used and split as needed.
             return_sites: Names of variables (sites) to return. If ``None``, samples
-                ``self.param_output`` and deterministic sites.
+                :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
             batch_size: The batch size for data loading during posterior predictive
                 sampling. It also determines the chunk size used to store the samples.
                 If ``None``, it is determined automatically based on the input data and
@@ -609,7 +611,8 @@ class ImpactModel(BaseModel):
             Posterior predictive samples. Posterior samples are included if available.
 
         Raises:
-            TypeError: If ``self.param_output`` is passed as an argument.
+            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
+                argument.
 
         See Also:
             :py:meth:`~aimz.ImpactModel.predict()`.
@@ -963,7 +966,7 @@ class ImpactModel(BaseModel):
             posterior_sample: Posterior samples to set for the model.
             return_sites: Names of variable (sites) to return in
                 :py:meth:`~aimz.ImpactModel.predict`. By default, it is set to
-                ``self.param_output``.
+                :attr:`~aimz.ImpactModel.param_output`.
 
         Returns:
             The model instance, treated as fitted with posterior samples set, enabling
@@ -1026,7 +1029,7 @@ class ImpactModel(BaseModel):
                 ``predictions`` group, indicating they were generated based on
                 out-of-sample data.
             return_sites: Names of variables (sites) to return. If ``None``, samples
-                ``self.param_output`` and deterministic sites.
+                :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
             return_datatree: If ``True``, return a
                 :external:py:class:`~xarray.DataTree`; otherwise return a
                 :py:class:`dict`.
@@ -1037,7 +1040,8 @@ class ImpactModel(BaseModel):
             Posterior predictive samples. Posterior samples are included if available.
 
         Raises:
-            TypeError: If ``self.param_output`` is passed as an argument.
+            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
+                argument.
         """
         _check_is_fitted(self)
 
@@ -1122,7 +1126,7 @@ class ImpactModel(BaseModel):
                 ``predictions`` group, indicating they were generated based on
                 out-of-sample data.
             return_sites: Names of variables (sites) to return. If ``None``, samples
-                ``self.param_output`` and deterministic sites.
+                :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
             batch_size: The batch size for data loading during posterior predictive
                 sampling. It also determines the chunk size used to store the samples.
                 If ``None``, it is determined automatically based on the input data
@@ -1140,7 +1144,8 @@ class ImpactModel(BaseModel):
             Posterior predictive samples. Posterior samples are included if available.
 
         Raises:
-            TypeError: If ``self.param_output`` is passed as an argument.
+            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
+                argument.
 
         See Also:
             :py:meth:`~aimz.ImpactModel.cleanup` to remove the temporary directory if
@@ -1200,7 +1205,7 @@ class ImpactModel(BaseModel):
                 len(kwargs_extra),
             )
 
-        output_subdir = self._create_output_subdir(output_dir)
+        output_dir, output_subdir = self._create_output_subdir(output_dir)
 
         dataloader, _ = _setup_inputs(
             X=X,
@@ -1360,7 +1365,7 @@ class ImpactModel(BaseModel):
                 len(kwargs_extra),
             )
 
-        output_subdir = self._create_output_subdir(output_dir)
+        output_dir, output_subdir = self._create_output_subdir(output_dir)
 
         dataloader, _ = _setup_inputs(
             X=X,
@@ -1470,7 +1475,7 @@ class ImpactModel(BaseModel):
             self._temp_dir.cleanup()
             self._temp_dir = None
 
-    def _create_output_subdir(self, output_dir: str | Path | None) -> Path:
+    def _create_output_subdir(self, output_dir: str | Path | None) -> tuple[Path, Path]:
         """Create a subdirectory for storing output.
 
         This function is called for its side effect: it creates a subdirectory within
@@ -1480,7 +1485,7 @@ class ImpactModel(BaseModel):
             output_dir: The directory where the output subdirectory will be created.
 
         Returns:
-            The path to the created output subdirectory.
+            The paths to the output directory and the created subdirectory.
         """
         if output_dir is None:
             if self._temp_dir is None:
@@ -1497,7 +1502,7 @@ class ImpactModel(BaseModel):
         output_subdir = output_dir / timestamp
         output_subdir.mkdir(parents=False, exist_ok=False)
 
-        return output_subdir
+        return output_dir, output_subdir
 
     def _sample_and_write(
         self,

--- a/docs/source/user_guide/cleanup.rst
+++ b/docs/source/user_guide/cleanup.rst
@@ -1,16 +1,16 @@
 Output Directory Cleanup
 ========================
 
-Many high‑level methods of :py:class:`~aimz.ImpactModel` stream results to disk (e.g., posterior predictive samples, predictions) to support large datasets and memory efficiency.
+Many high‑level methods of :class:`~aimz.ImpactModel` stream results to disk (e.g., posterior predictive samples, predictions) to support large datasets and memory efficiency.
 Each of these methods accepts an ``output_dir`` parameter (see :doc:`disk_and_on_batch` for broader I/O behavior of them).
-This page focuses on managing the temporary directory created when the user does not supply ``output_dir`` and on the :py:meth:`~aimz.ImpactModel.cleanup` method that removes it.
+This page focuses on managing the temporary directory created when the user does not supply ``output_dir`` and on the :meth:`~aimz.ImpactModel.cleanup` method that removes it.
 
 
 Creation Logic
 --------------
-When a disk‑writing method is called with ``output_dir=None`` (the default), the model creates a process‑scoped temporary root directory (via :py:class:`tempfile.TemporaryDirectory`) the first time such a call occurs.
+When a disk‑writing method is called with ``output_dir=None`` (the default), the model creates a process‑scoped temporary root directory (via :class:`tempfile.TemporaryDirectory`) the first time such a call occurs.
 Each invocation then writes to a timestamped subdirectory under that root, ensuring that earlier results are never overwritten.
-This root directory is stored in the ``model.temp_dir`` attribute and reused for subsequent calls until the user invoke :py:meth:`~aimz.ImpactModel.cleanup`.
+This root directory is stored in the :attr:`~aimz.ImpactModel.temp_dir` attribute and reused for subsequent calls until the user invoke :meth:`~aimz.ImpactModel.cleanup`.
 
 Example Layout (implicit temp root)::
 
@@ -21,7 +21,7 @@ Example Layout (implicit temp root)::
 
 If the user provides ``output_dir``, that directory becomes the root, and it will be created if it does not already exist.
 The same timestamped subdirectory pattern is used there (e.g., ``my_runs/20250917T013040Z``).
-An explicit ``output_dir`` is **not** deleted by :py:meth:`~aimz.ImpactModel.cleanup`, since it is assumed that the user intends to manage its lifecycle manually.
+An explicit ``output_dir`` is **not** deleted by :meth:`~aimz.ImpactModel.cleanup`, since it is assumed that the user intends to manage its lifecycle manually.
 
 
 Cleanup Behavior
@@ -39,18 +39,18 @@ Additional guarantees:
 
 Rationale for Explicit Calls
 ----------------------------
-Although :py:class:`tempfile.TemporaryDirectory` *attempts* automatic removal upon garbage collection, the timing is nondeterministic—especially in notebooks or long-lived processes.
-Large artifacts can accumulate quickly; calling :py:meth:`~aimz.ImpactModel.cleanup` ensures prompt reclamation of disk space.
+Although :class:`tempfile.TemporaryDirectory` *attempts* automatic removal upon garbage collection, the timing is nondeterministic—especially in notebooks or long-lived processes.
+Large artifacts can accumulate quickly; calling :meth:`~aimz.ImpactModel.cleanup` ensures prompt reclamation of disk space.
 
 
 Accessing Output Directories
 ----------------------------
-Every disk-writing method returns an :external:py:class:`xarray.DataTree` containing the paths where results are stored as attributes:
+Every disk-writing method returns an :external:class:`xarray.DataTree` containing the paths where results are stored as attributes:
 
 * ``tree.attrs["output_dir"]`` – the root directory (either the temporary root or the user-provided directory).
 * ``tree[<group>].attrs["output_dir"]`` – the timestamped subdirectory containing the Zarr data for that group.
 
-The output below shows an example :external:py:class:`xarray.DataTree` illustrating the output directory paths.
+The output below shows an example :external:class:`xarray.DataTree` illustrating the output directory paths.
 
 .. jupyter-execute::
     :hide-code:
@@ -111,18 +111,18 @@ The output below shows an example :external:py:class:`xarray.DataTree` illustrat
 
 .. note::
 
-    Even after the ``output_dir`` is deleted, the returned :external:py:class:`xarray.DataTree` and all its group entries remain accessible.
+    Even after the ``output_dir`` is deleted, the returned :external:class:`xarray.DataTree` and all its group entries remain accessible.
     However, any arrays that were stored on disk have **all values set to zero**, since the underlying data files have been removed.
-    Users can still inspect the structure and metadata of the :external:py:class:`xarray.DataTree`, but the original disk-backed values are no longer available.
+    Users can still inspect the structure and metadata of the :external:class:`xarray.DataTree`, but the original disk-backed values are no longer available.
 
 
 Typical Usage Pattern
 ---------------------
-A typical workflow is to run these methods without specifying ``output_dir`` (using a temporary root), optionally access the results via the ``temp_dir`` attribute or the returned :external:py:class:`xarray.DataTree`, and then free disk space with :py:meth:`~aimz.ImpactModel.cleanup`.
+A typical workflow is to run these methods without specifying ``output_dir`` (using a temporary root), optionally access the results via the :attr:`~aimz.ImpactModel.temp_dir` attribute or the returned :external:class:`xarray.DataTree`, and then free disk space with :meth:`~aimz.ImpactModel.cleanup`.
 
 Tips for safe use:
 
-* Call :py:meth:`~aimz.ImpactModel.cleanup` at the end of a notebook or in a ``finally`` block.
-* Copy any results you want to keep before :py:meth:`~aimz.ImpactModel.cleanup`.
+* Call :meth:`~aimz.ImpactModel.cleanup` at the end of a notebook or in a ``finally`` block.
+* Copy any results you want to keep before :meth:`~aimz.ImpactModel.cleanup`.
 * In tests, check that temporary directories are removed to avoid disk bloat.
 * Avoid leaving long sessions with un-cleaned temporary directories.


### PR DESCRIPTION
Ensure that methods in `ImpactModel` correctly handle cases where `output_dir` is not explicitly provided, preventing it from being included as `None` in the output.