### PR TITLE
Enhance ImpactModel with KernelSpec for kernel metadata management

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
       # Ruff version.
-      rev: v0.13.0
+      rev: v0.13.1
       hooks:
           # Run the linter.
           - id: ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `output_dir` attribute to the root and group nodes of {class}`xarray.DataTree` objects returned by {meth}`~aimz.ImpactModel.sample_prior_predictive`, {meth}`~aimz.ImpactModel.predict`, and {meth}`~aimz.ImpactModel.log_likelihood`, specifying the directory where results are saved ([#85](https://github.com/markean/aimz/issues/85)).
 
+- Introduced the public {class}`~aimz.model.KernelSpec` dataclass and the {attr}`~aimz.ImpactModel.kernel_spec` attribute on {class}`~aimz.ImpactModel`.
+This exposes a lazily-built, cached structural specification of the user kernel (fields: ``traced``, ``return_sites``, ``output_observed``) so training and predictive methods avoid redundant model tracing ([#98](https://github.com/markean/aimz/issues/98)).
+
 ### Changed
 
 - All `tqdm` progress bars now use `dynamic_ncols=True` to adjust column width dynamically ([#93](https://github.com/markean/aimz/issues/93)).
+
+- {meth}`~aimz.ImpactModel.fit_on_batch`, {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch`, {meth}`~aimz.ImpactModel.sample_prior_predictive`, and {meth}`~aimz.ImpactModel.train_on_batch` now reuse the cached {attr}`~aimz.ImpactModel.kernel_spec` and avoid redundant model tracing ([#98](https://github.com/markean/aimz/issues/98)).
 
 ### Fixed
 

--- a/aimz/mlflow/autolog.py
+++ b/aimz/mlflow/autolog.py
@@ -52,10 +52,10 @@ def autolog(
     """Enable and configure autologging for aimz with MLflow.
 
     Autologging is performed when you call:
-        - :py:meth:`ImpactModel.fit() <aimz.ImpactModel.fit>`.
+        - :meth:`ImpactModel.fit() <aimz.ImpactModel.fit>`.
 
     Logs the following:
-        - Selected arguments to :py:meth:`ImpactModel.fit() <aimz.ImpactModel.fit>`,
+        - Selected arguments to :meth:`ImpactModel.fit() <aimz.ImpactModel.fit>`,
           together with ``param_input``, ``param_output``, ``inference_method``, and
           ``optimizer`` as parameters.
         - The final evidence lower bound (ELBO) loss as a metric.
@@ -68,10 +68,10 @@ def autolog(
             ``False``, input examples are not logged. Note: Input examples are MLflow
             model attributes and are only collected if ``log_models`` is also ``True``.
         log_model_signatures: If ``True``,
-            :external:py:class:`ModelSignatures <mlflow.models.ModelSignature>`
-            describing model inputs and outputs are collected and logged along with
-            model artifacts during training. If ``False``, signatures are not logged.
-            Note: Model signatures are MLflow model attributes and are only collected if
+            :external:class:`ModelSignatures <mlflow.models.ModelSignature>` describing
+            model inputs and outputs are collected and logged along with model artifacts
+            during training. If ``False``, signatures are not logged. Note: Model
+            signatures are MLflow model attributes and are only collected if
             ``log_models`` is also ``True``.
         log_models: If ``True``, trained models are logged as MLflow model artifacts. If
             ``False``, trained models are not logged. Input examples and model
@@ -98,7 +98,7 @@ def autolog(
         *args: object,
         **kwargs: object,
     ) -> ImpactModel:
-        """Patch for :py:meth:`~aimz.ImpactModel.fit` to log information.
+        """Patch for :meth:`~aimz.ImpactModel.fit` to log information.
 
         Args:
             original (Callable): The original method.

--- a/aimz/mlflow/autolog.py
+++ b/aimz/mlflow/autolog.py
@@ -18,6 +18,7 @@ import logging
 import tempfile
 from collections.abc import Callable
 from inspect import getsource
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 from mlflow import log_metric, log_param, log_params, log_text
@@ -32,6 +33,10 @@ from mlflow.utils.autologging_utils import (
     safe_patch,
 )
 from sklearn.utils.validation import _is_arraylike
+
+if TYPE_CHECKING:
+    from jax.typing import ArrayLike
+    from numpyro.infer.svi import SVIRunResult
 
 FLAVOR_NAME = "aimz"
 
@@ -127,7 +132,7 @@ def autolog(
         model = original(self, *args, **kwargs)
 
         log_param("num_samples", self._num_samples)
-        losses = self.vi_result.losses
+        losses = cast("SVIRunResult", self.vi_result).losses
         log_metric("elbo_loss", value=losses[-1])
 
         if log_models:
@@ -144,9 +149,13 @@ def autolog(
                     }
                 else:
                     input_example = {
-                        "X": np.asarray(X[:INPUT_EXAMPLE_SAMPLE_ROWS]),
+                        "X": np.asarray(
+                            cast("ArrayLike", X)[:INPUT_EXAMPLE_SAMPLE_ROWS],
+                        ),
                         **{
-                            k: np.asarray(v[:INPUT_EXAMPLE_SAMPLE_ROWS])
+                            k: np.asarray(
+                                cast("ArrayLike", v)[:INPUT_EXAMPLE_SAMPLE_ROWS],
+                            )
                             for k, v in kwargs.items()
                             if k != self.param_output and _is_arraylike(v)
                         },

--- a/aimz/mlflow/load.py
+++ b/aimz/mlflow/load.py
@@ -51,7 +51,7 @@ def load_model(model_uri: str, dst_path: str | None = None) -> "ImpactModel":
             path will be created.
 
     Returns:
-        An aimz model (an instance of :py:class:`~aimz.ImpactModel`).
+        An aimz model (an instance of :class:`~aimz.ImpactModel`).
 
     """
     local_model_path = _download_artifact_from_uri(model_uri, output_path=dst_path)

--- a/aimz/mlflow/log.py
+++ b/aimz/mlflow/log.py
@@ -34,7 +34,7 @@ def log_model(
     conda_env: dict | None = None,
     code_paths: list | None = None,
     registered_model_name: str | None = None,
-    signature: ModelSignature = None,
+    signature: ModelSignature | None = None,
     input_example: ModelInputExample = None,
     await_registration_for: int | None = DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
     pip_requirements: Iterable[str] | str | None = None,

--- a/aimz/mlflow/log.py
+++ b/aimz/mlflow/log.py
@@ -50,7 +50,7 @@ def log_model(
     """Log an aimz model as an MLflow artifact for the current run..
 
     Args:
-        model: An aimz model (an instance of :py:class:`~aimz.ImpactModel`) to be saved.
+        model: An aimz model (an instance of :class:`~aimz.ImpactModel`) to be saved.
         conda_env: {{ conda_env }}
         code_paths: {{ code_paths }}
         registered_model_name: If given, each time a model is trained, it is registered
@@ -60,7 +60,7 @@ def log_model(
         input_example: {{ input_example }}
         await_registration_for: Number of seconds to wait for the model version to
             finish being created and is in ``READY`` status. By default, the function
-            waits for five minutes. Specify ``0`` or :py:obj:`None` to skip waiting.
+            waits for five minutes. Specify ``0`` or :obj:`None` to skip waiting.
         pip_requirements: {{ pip_requirements }}
         extra_pip_requirements: {{ extra_pip_requirements }}
         metadata: {{ metadata }}
@@ -72,7 +72,7 @@ def log_model(
         tags: {{ tags }}
 
     Returns:
-        A :external:py:class:`~mlflow.models.model.ModelInfo` instance that contains the
+        A :external:class:`~mlflow.models.model.ModelInfo` instance that contains the
         metadata of the logged model.
     """
     import aimz.mlflow

--- a/aimz/mlflow/pyfunc.py
+++ b/aimz/mlflow/pyfunc.py
@@ -15,12 +15,15 @@
 """MLflow pyfunc wrapper for aimz models."""
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from mlflow.pyfunc import PyFuncModel
 
 if TYPE_CHECKING:
+    from jax.typing import ArrayLike
+
     from aimz.model.impact_model import ImpactModel
+    from aimz.utils.data import ArrayLoader
 
 
 class _ImpactModelWrapper(PyFuncModel):
@@ -37,7 +40,10 @@ class _ImpactModelWrapper(PyFuncModel):
         """Run predictions using the wrapped ImpactModel."""
         if isinstance(model_input, dict):
             return self.model.predict(**model_input, **(params or {}))
-        return self.model.predict(model_input, **(params or {}))
+        return self.model.predict(
+            cast("ArrayLike | ArrayLoader", model_input),
+            **(params or {}),
+        )
 
 
 def _load_pyfunc(path: str) -> _ImpactModelWrapper:

--- a/aimz/mlflow/save.py
+++ b/aimz/mlflow/save.py
@@ -111,11 +111,11 @@ def save_model(
     """Save an aimz model to a path on the local file system.
 
     Args:
-        model: An aimz model (an instance of :py:class:`~aimz.ImpactModel`) to be saved.
+        model: An aimz model (an instance of :class:`~aimz.ImpactModel`) to be saved.
         path (str | Path): Local path where the model is to be saved.
         conda_env: {{ conda_env }}
         code_paths: {{ code_paths }}
-        mlflow_model: :py:class:`mlflow.models.Model` this flavor is being added to.
+        mlflow_model: :class:`mlflow.models.Model` this flavor is being added to.
         signature: {{ signature }}
         input_example: {{ input_example }}
         pip_requirements: {{ pip_requirements }}

--- a/aimz/mlflow/save.py
+++ b/aimz/mlflow/save.py
@@ -102,7 +102,7 @@ def save_model(
     conda_env: dict | None = None,
     code_paths: list | None = None,
     mlflow_model: Model | None = None,
-    signature: ModelSignature = None,
+    signature: ModelSignature | None = None,
     input_example: ModelInputExample = None,
     pip_requirements: Iterable[str] | str | None = None,
     extra_pip_requirements: Iterable[str] | str | None = None,
@@ -137,7 +137,11 @@ def save_model(
 
     if mlflow_model is None:
         mlflow_model = Model()
-    saved_example = _save_example(mlflow_model, input_example=input_example, path=path)
+    saved_example = _save_example(
+        mlflow_model,
+        input_example=input_example,
+        path=str(path),
+    )
     if signature is None and saved_example is not None:
         with tempfile.TemporaryDirectory() as temp_dir:
             signature = infer_signature(

--- a/aimz/model/__init__.py
+++ b/aimz/model/__init__.py
@@ -15,5 +15,6 @@
 """Model implementations."""
 
 from aimz.model.impact_model import ImpactModel
+from aimz.model.kernel_spec import KernelSpec
 
-__all__ = ["ImpactModel"]
+__all__ = ["ImpactModel", "KernelSpec"]

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -16,14 +16,14 @@
 
 import contextlib
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Sized
 from datetime import UTC, datetime
 from inspect import signature
 from os import cpu_count
 from pathlib import Path
 from shutil import rmtree
 from tempfile import TemporaryDirectory
-from typing import Self, cast
+from typing import TYPE_CHECKING, Self, cast
 from warnings import warn
 
 import jax.numpy as jnp
@@ -50,6 +50,7 @@ from xarray import open_zarr
 from zarr import open_group
 
 from aimz.model._core import BaseModel
+from aimz.model.kernel_spec import KernelSpec
 from aimz.sampling._forward import _sample_forward
 from aimz.utils._format import _dict_to_datatree, _make_attrs
 from aimz.utils._kwargs import _group_kwargs
@@ -70,6 +71,9 @@ from aimz.utils.data._sharding import (
     _create_sharded_log_likelihood,
     _create_sharded_sampler,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 logger = logging.getLogger(__name__)
 
@@ -92,18 +96,19 @@ class ImpactModel(BaseModel):
             kernel: A probabilistic model with NumPyro primitives.
             rng_key (ArrayLike): A pseudo-random number generator key.
             inference: An inference method supported by NumPyro, such as an instance of
-                :external:py:class:`numpyro.infer.svi.SVI` or
-                :external:py:class:`numpyro.infer.mcmc.MCMC`.
+                :external:class:`~numpyro.infer.svi.SVI` or
+                :external:class:`~numpyro.infer.mcmc.MCMC`.
             param_input: Name of the parameter in the ``kernel`` for the main input
                 data.
             param_output: Name of the parameter in the ``kernel`` for the output data.
 
         Warning:
             The ``rng_key`` parameter should be provided as a **typed key array**
-            created with :external:py:func:`jax.random.key`, rather than a legacy
-            ``uint32`` key created with :external:py:func:`jax.random.PRNGKey`.
+            created with :external:func:`jax.random.key`, rather than a legacy
+            ``uint32`` key created with :external:func:`jax.random.PRNGKey`.
         """
         super().__init__(kernel, param_input, param_output)
+        self._kernel_spec: KernelSpec | None = None
         if isinstance(rng_key, Array) and rng_key.dtype == jnp.uint32:
             msg = "Legacy `uint32` PRNGKey detected; converting to a typed key array."
             warn(msg, category=UserWarning, stacklevel=2)
@@ -163,7 +168,7 @@ class ImpactModel(BaseModel):
             for k, v in self.__dict__.items()
             if not (
                 k.startswith("_fn")
-                or k in {"_device", "_mesh", "_num_devices", "temp_dir"}
+                or k in {"_device", "_mesh", "_num_devices", "_temp_dir"}
             )
         }
 
@@ -180,6 +185,11 @@ class ImpactModel(BaseModel):
     def kernel(self) -> Callable:
         """A probabilistic model with NumPyro primitives."""
         return self._kernel
+
+    @property
+    def kernel_spec(self) -> KernelSpec | None:
+        """The cached :class:`~aimz.model.KernelSpec` or ``None`` if not yet built."""
+        return self._kernel_spec
 
     @property
     def rng_key(self) -> ArrayLike:
@@ -200,9 +210,9 @@ class ImpactModel(BaseModel):
     def vi_result(self) -> SVIRunResult | None:
         """Variational inference result, or ``None`` if not set.
 
-        :setter: This sets :external:py:data:`numpyro.infer.svi.SVIRunResult` and marks
+        :setter: This sets :external:data:`~numpyro.infer.svi.SVIRunResult` and marks
             the model as fitted. It does not perform posterior sampling — use
-            :py:meth:`~aimz.ImpactModel.sample` separately to obtain samples.
+            :meth:`~aimz.ImpactModel.sample` separately to obtain samples.
         """
         return self._vi_result
 
@@ -235,1245 +245,55 @@ class ImpactModel(BaseModel):
         """Temporary directory path, or ``None`` if not set."""
         return self._temp_dir.name if self._temp_dir else None
 
-    def sample_prior_predictive_on_batch(
+    def _build_kernel_spec(
         self,
-        X: ArrayLike,
+        args_bound: "Mapping[str, object]",
         *,
-        num_samples: int = 1000,
-        rng_key: ArrayLike | None = None,
-        return_sites: tuple[str] | None = None,
-        return_datatree: bool = True,
-        **kwargs: object,
-    ) -> xr.DataTree | dict[str, npt.NDArray]:
-        """Draw samples from the prior predictive distribution.
+        with_output: bool,
+    ) -> None:
+        """Trace the kernel (if needed) and cache default return sites.
+
+        This method is idempotent: if a compatible spec already exists it is a no-op.
+        A compatible spec means: ``with_output`` is ``False`` and we already traced
+        once, or ``with_output`` is ``True`` and the existing spec was built with an
+        observed output (``output_observed=True``).
 
         Args:
-            X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
-            num_samples: The number of samples to draw.
-            rng_key (ArrayLike | None): A pseudo-random number generator key. By
-                default, an internal key is used and split as needed.
-            return_sites: Names of variables (sites) to return. If ``None``, samples all
-                latent, observed, and deterministic sites.
-            return_datatree: If ``True``, return a
-                :external:py:class:`~xarray.DataTree`; otherwise return a
-                :py:class:`dict`.
-            **kwargs: Additional arguments passed to the model. All array-like values
-                are expected to be JAX arrays.
-
-        Returns:
-            Prior predictive samples.
-
-        Raises:
-            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
-                argument.
+            args_bound: Mapping of fully bound keyword arguments to invoke the kernel
+                (includes the input and, when ``with_output`` is ``True``, the observed
+                output variable).
+            with_output: If ``True`` the trace is validated expecting the output site to
+                be observed. If ``False`` the trace may omit an observed output (e.g.,
+                prior predictive).
         """
-        X = cast("Array", _validate_X_y_to_jax(X))
-
-        # Validate the provided parameters against the kernel's signature
-        args_bound = (
-            signature(self.kernel).bind(**{self.param_input: X, **kwargs}).arguments
-        )
-        if self.param_output in args_bound:
-            msg = f"Specifying {self.param_output!r} is not allowed."
-            raise TypeError(msg)
-
-        if rng_key is None:
-            self._rng_key, rng_key = random.split(self._rng_key)
-
-        prior_predictive_samples = device_get(
-            _sample_forward(
-                self.kernel,
-                rng_key=rng_key,
-                num_samples=num_samples,
-                return_sites=return_sites,
-                samples=None,
-                model_kwargs=args_bound,
-            ),
-        )
-
-        if not return_datatree:
-            return prior_predictive_samples
-
-        out = xr.DataTree(name="root")
-        out["prior_predictive"] = _dict_to_datatree(prior_predictive_samples)
-
-        return out
-
-    def sample_prior_predictive(
-        self,
-        X: ArrayLike,
-        *,
-        num_samples: int = 1000,
-        rng_key: ArrayLike | None = None,
-        return_sites: tuple[str] | None = None,
-        batch_size: int | None = None,
-        output_dir: str | Path | None = None,
-        progress: bool = True,
-        **kwargs: object,
-    ) -> xr.DataTree:
-        """Draw samples from the prior predictive distribution.
-
-        Results are written to disk in the Zarr format, with computing and file writing
-        decoupled and executed concurrently.
-
-        Args:
-            X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
-            num_samples: The number of samples to draw.
-            rng_key (ArrayLike | None): A pseudo-random number generator key. By
-                default, an internal key is used and split as needed.
-            return_sites: Names of variables (sites) to return. If ``None``, samples
-                :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
-            batch_size: The batch size for data loading during prior predictive
-                sampling. It also determines the chunk size used to store the samples.
-                If ``None``, it is determined automatically based on the input data and
-                number of samples.
-            output_dir: The directory where the outputs will be saved. If the specified
-                directory does not exist, it will be created automatically. If ``None``,
-                a default temporary directory will be created. A timestamped
-                subdirectory will be generated within this directory to store the
-                outputs. Outputs are saved in the Zarr format.
-            progress: Whether to display a progress bar.
-            **kwargs: Additional arguments passed to the model. All array-like values
-                are expected to be JAX arrays.
-
-        Returns:
-            Prior predictive samples.
-
-        Raises:
-            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
-                argument.
-
-        See Also:
-            :py:meth:`~aimz.ImpactModel.cleanup` to remove the temporary directory if
-            created.
-        """
-        # Validate the provided parameters against the kernel's signature
-        args_bound = (
-            signature(self.kernel).bind(**{self.param_input: X, **kwargs}).arguments
-        )
-        if self.param_output in args_bound:
-            msg = f"Specifying {self.param_output!r} is not allowed."
-            raise TypeError(msg)
-
-        # Prior sampling
-        dataloader, _ = _setup_inputs(
-            X=X,
-            y=None,
-            rng_key=self.rng_key,
-            batch_size=self._device.num_devices if self._device is not None else 1,
-            num_samples=num_samples,
-            shuffle=False,
-            device=self._device,
-            **kwargs,
-        )
-        batch, _ = next(iter(dataloader))
-        model_trace = trace(seed(self.kernel, rng_seed=self.rng_key)).get_trace(**batch)
-        return_sites = return_sites or tuple(
-            k
-            for k, site in model_trace.items()
-            if site["type"] == "deterministic" or k == self.param_output
-        )
-        if rng_key is None:
-            self._rng_key, rng_key = random.split(self._rng_key)
-        rng_key, rng_subkey = random.split(rng_key)
-        prior_samples = _sample_forward(
-            self.kernel,
-            rng_key=rng_subkey,
-            num_samples=num_samples,
-            return_sites=None,
-            samples=None,
-            model_kwargs=batch,
-        )
-        prior_samples = {
-            k: v for k, v in prior_samples.items() if k not in return_sites
-        }
-
-        kwargs_array, kwargs_extra = _group_kwargs(kwargs)
-        if self._fn_sample_prior_predictive is None:
-            self._fn_sample_prior_predictive = _create_sharded_sampler(
-                self._mesh,
-                len(kwargs_array),
-                len(kwargs_extra),
-            )
-
-        output_dir, output_subdir = self._create_output_subdir(output_dir)
-
-        dataloader, _ = _setup_inputs(
-            X=X,
-            y=None,
-            rng_key=self.rng_key,
-            batch_size=batch_size,
-            num_samples=num_samples,
-            shuffle=False,
-            device=self._device,
-            **kwargs,
-        )
-
-        self._sample_and_write(
-            num_samples,
-            rng_key=rng_key,
-            return_sites=return_sites,
-            output_dir=output_subdir,
-            kernel=self.kernel,
-            sampler=self._fn_sample_prior_predictive,
-            samples=prior_samples,
-            dataloader=dataloader,
-            pbar=tqdm(
-                desc=(f"Prior predictive sampling [{', '.join(return_sites)}]"),
-                total=len(dataloader),
-                disable=not progress,
-                dynamic_ncols=True,
-            ),
-            **kwargs,
-        )
-
-        ds = open_zarr(output_subdir, consolidated=False).expand_dims(
-            dim="chain",
-            axis=0,
-        )
-        ds = ds.assign_coords(
-            {k: np.arange(ds.sizes[k]) for k in ds.sizes},
-        ).assign_attrs(_make_attrs())
-        out = xr.DataTree(name="root")
-        out["prior_predictive"] = xr.DataTree(ds)
-        out["prior_predictive"].attrs["output_dir"] = str(output_subdir)
-        out.attrs["output_dir"] = str(output_dir)
-
-        return out
-
-    def sample(
-        self,
-        *,
-        num_samples: int = 1000,
-        rng_key: ArrayLike | None = None,
-        return_sites: tuple[str] | None = None,
-        return_datatree: bool = True,
-        **kwargs: object,
-    ) -> xr.DataTree | dict[str, npt.NDArray]:
-        """Draw posterior samples from a fitted model.
-
-        Args:
-            num_samples: The number of posterior samples to draw.
-            rng_key (ArrayLike | None): A pseudo-random number generator key. By
-                default, an internal key is used and split as needed. Has no effect if
-                the inference method is MCMC, where the ``post_warmup_state`` property
-                will be used to continue sampling.
-            return_sites: Names of variables (sites) to return. If ``None``, samples
-                all latent sites. Has no effect if the inference method is MCMC.
-            return_datatree: If ``True``, return a
-                :external:py:class:`~xarray.DataTree`; otherwise return a
-                :py:class:`dict`.
-            **kwargs: Additional arguments passed to the model. All array-like values
-                are expected to be JAX arrays. Only relevant when the inference method
-                is MCMC.
-
-        Returns:
-            Posterior samples.
-
-        Raises:
-            TypeError: If :attr:`~aimz.ImpactModel.param_output` is not passed as an
-                argument when the inference method is MCMC.
-        """
-        _check_is_fitted(self)
-
-        if rng_key is None:
-            self._rng_key, rng_key = random.split(self._rng_key)
-
-        if isinstance(self.inference, MCMC):
-            # Validate the provided parameters against the kernel's signature
-            args_bound = signature(self.kernel).bind(**kwargs).arguments
-            if self.param_output not in args_bound:
-                msg = f"{self.param_output!r} must be provided in `.sample()`."
-                raise TypeError(msg)
-            self.inference.post_warmup_state = self.inference.last_state
-            self.inference.num_samples = num_samples
-            self.inference.run(self.inference.post_warmup_state.rng_key, **args_bound)
-            posterior_samples = device_get(self.inference.get_samples())
-        else:
-            posterior_samples = device_get(
-                _sample_forward(
-                    substitute(
-                        self.inference.guide,
-                        data=cast("SVIRunResult", self.vi_result).params,
-                    ),
-                    rng_key=rng_key,
-                    num_samples=num_samples,
-                    return_sites=return_sites,
-                    samples=None,
-                    model_kwargs=None,
-                ),
-            )
-
-        if not return_datatree:
-            return posterior_samples
-
-        out = xr.DataTree(name="root")
-        out["posterior"] = _dict_to_datatree(posterior_samples)
-
-        return out
-
-    def sample_posterior_predictive_on_batch(
-        self,
-        X: ArrayLike,
-        *,
-        intervention: dict | None = None,
-        rng_key: ArrayLike | None = None,
-        return_sites: tuple[str] | None = None,
-        return_datatree: bool = True,
-        **kwargs: object,
-    ) -> xr.DataTree | dict[str, npt.NDArray]:
-        """Draw samples from the posterior predictive distribution.
-
-        This method is a convenience alias for
-        :py:meth:`~aimz.ImpactModel.predict_on_batch`, with ``in_sample`` automatically
-        set to ``True``.
-
-        Args:
-            X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
-            intervention: A dictionary mapping sample sites to their corresponding
-                intervention values. Interventions enable counterfactual analysis by
-                modifying the specified sample sites during prediction (posterior
-                predictive sampling).
-            rng_key (ArrayLike | None): A pseudo-random number generator key. By
-                default, an internal key is used and split as needed.
-            return_sites: Names of variables (sites) to return. If ``None``, samples
-                :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
-            return_datatree: If ``True``, return a
-                :external:py:class:`~xarray.DataTree`; otherwise return a
-                :py:class:`dict`.
-            **kwargs: Additional arguments passed to the model. All array-like values
-                are expected to be JAX arrays.
-
-        Returns:
-            Posterior predictive samples. Posterior samples are included if available.
-
-        Raises:
-            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
-                argument.
-
-        See Also:
-            :py:meth:`~aimz.ImpactModel.predict_on_batch`.
-        """
-        return self.predict_on_batch(
-            X,
-            intervention=intervention,
-            rng_key=rng_key,
-            in_sample=True,
-            return_sites=return_sites,
-            return_datatree=return_datatree,
-            **kwargs,
-        )
-
-    def sample_posterior_predictive(
-        self,
-        X: ArrayLike | ArrayLoader,
-        *,
-        intervention: dict | None = None,
-        rng_key: ArrayLike | None = None,
-        return_sites: tuple[str] | None = None,
-        batch_size: int | None = None,
-        output_dir: str | Path | None = None,
-        progress: bool = True,
-        **kwargs: object,
-    ) -> xr.DataTree:
-        """Draw samples from the posterior predictive distribution.
-
-        This method is a convenience alias for :py:meth:`~aimz.ImpactModel.predict`,
-        with ``in_sample`` automatically set to ``True``.
-
-        Args:
-            X (ArrayLike | ArrayLoader): Input data, either an array-like of shape
-                ``(n_samples, n_features)`` or a data loader that holds all array-like
-                objects and handles batching internally; if a data loader is passed,
-                ``batch_size`` is ignored.
-            intervention: A dictionary mapping sample sites to their corresponding
-                intervention values. Interventions enable counterfactual analysis by
-                modifying the specified sample sites during prediction (posterior
-                predictive sampling).
-            rng_key (ArrayLike | None): A pseudo-random number generator key. By
-                default, an internal key is used and split as needed.
-            return_sites: Names of variables (sites) to return. If ``None``, samples
-                :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
-            batch_size: The batch size for data loading during posterior predictive
-                sampling. It also determines the chunk size used to store the samples.
-                If ``None``, it is determined automatically based on the input data and
-                number of samples.
-            output_dir: The directory where the outputs will be saved. If the specified
-                directory does not exist, it will be created automatically. If ``None``,
-                a default temporary directory will be created. A timestamped
-                subdirectory will be generated within this directory to store the
-                outputs. Outputs are saved in the Zarr format.
-            progress: Whether to display a progress bar.
-            **kwargs: Additional arguments passed to the model. All array-like values
-                are expected to be JAX arrays.
-
-        Returns:
-            Posterior predictive samples. Posterior samples are included if available.
-
-        Raises:
-            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
-                argument.
-
-        See Also:
-            :py:meth:`~aimz.ImpactModel.predict()`.
-        """
-        return self.predict(
-            X,
-            intervention=intervention,
-            rng_key=rng_key,
-            in_sample=True,
-            return_sites=return_sites,
-            batch_size=batch_size,
-            output_dir=output_dir,
-            progress=progress,
-            **kwargs,
-        )
-
-    def train_on_batch(
-        self,
-        X: ArrayLike,
-        y: ArrayLike,
-        rng_key: ArrayLike | None = None,
-        **kwargs: object,
-    ) -> tuple[SVIState, Array]:
-        """Run a single VI step on the given batch of data.
-
-        Args:
-            X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
-            y (ArrayLike): Output data with shape ``(n_samples_Y,)``.
-            rng_key (ArrayLike | None): A pseudo-random number generator key. By
-                default, an internal key is used and split as needed. The key is only
-                used for initialization if the internal SVI state is not yet set.
-            **kwargs: Additional arguments passed to the model. All array-like values
-                are expected to be JAX arrays.
-
-        Returns:
-            - Updated SVI state after the training step.
-
-            - Loss value as a scalar array.
-
-        Note:
-            This method updates the internal SVI state on every call, so it is not
-            necessary to capture the returned state externally unless explicitly needed.
-            However, the returned loss value can be used for monitoring or logging.
-        """
-        batch = {self.param_input: X, self.param_output: y, **kwargs}
-
-        if self._vi_state is None:
-            # Validate the provided parameters against the kernel's signature
-            model_trace = trace(seed(self.kernel, rng_seed=self.rng_key)).get_trace(
-                **signature(self.kernel).bind(**batch).arguments,
-            )
-            # Validate the kernel body for output sample site and naming conflicts
-            _validate_kernel_body(
-                self.kernel,
-                self.param_output,
-                model_trace,
-            )
-            self._return_sites = (
-                *(
-                    k
-                    for k, site in model_trace.items()
-                    if site["type"] == "deterministic"
-                ),
-                self.param_output,
-            )
-            if rng_key is None:
-                self._rng_key, rng_key = random.split(self._rng_key)
-            self._vi_state = self.inference.init(rng_key, **batch)
-        if self._fn_vi_update is None:
-            _, kwargs_extra = _group_kwargs(kwargs)
-            self._fn_vi_update = jit(
-                self.inference.update,
-                static_argnames=tuple(kwargs_extra._fields),
-            )
-
-        self._vi_state, loss = self._fn_vi_update(self._vi_state, **batch)
-
-        return self._vi_state, loss
-
-    def fit_on_batch(
-        self,
-        X: ArrayLike,
-        y: ArrayLike,
-        *,
-        num_steps: int = 10000,
-        num_samples: int = 1000,
-        rng_key: ArrayLike | None = None,
-        progress: bool = True,
-        **kwargs: object,
-    ) -> Self:
-        """Fit the impact model to the provided batch of data.
-
-        This method behaves differently depending on the inference method specified at
-        initialization of the ImpactModel instance:
-
-        - SVI
-            Runs variational inference on the provided batch by invoking the
-            :external:py:meth:`~numpyro.infer.svi.SVI.run` method of the
-            :external:py:class:`~numpyro.infer.svi.SVI` instance from NumPyro to
-            estimate the posterior distribution, then draws samples from it.
-
-        - MCMC
-            Runs posterior sampling by invoking the
-            :external:py:meth:`~numpyro.infer.mcmc.MCMC.run` method of the
-            :external:py:class:`~numpyro.infer.mcmc.MCMC` instance from NumPyro.
-
-        Args:
-            X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
-            y (ArrayLike): Output data with shape ``(n_samples_Y,)``.
-            num_steps: Number of steps for variational inference optimization. Has no
-                effect if the inference method is MCMC.
-            num_samples: The number of posterior samples to draw. Has no effect if the
-                inference method is MCMC.
-            rng_key (ArrayLike | None): A pseudo-random number generator key. By
-                default, an internal key is used and split as needed.
-            progress: Whether to display a progress bar. Has no effect
-                if the inference method is MCMC.
-            **kwargs: Additional arguments passed to the model. All array-like values
-                are expected to be JAX arrays.
-
-        Returns:
-            The fitted model instance, enabling method chaining.
-
-        Note:
-            This method continues training from the existing SVI state if available. To
-            start training from scratch, create a new model instance.
-        """
-        X, y = _validate_X_y_to_jax(X, y)
-
-        # Validate the provided parameters against the kernel's signature
-        args_bound = (
-            signature(self.kernel)
-            .bind(**{self.param_input: X, self.param_output: y, **kwargs})
-            .arguments
-        )
+        if self._kernel_spec:
+            if with_output:
+                if self._kernel_spec.output_observed:
+                    return
+            elif self._kernel_spec.traced:
+                return
         model_trace = trace(seed(self.kernel, rng_seed=self.rng_key)).get_trace(
             **args_bound,
         )
-        # Validate the kernel body for output sample site and naming conflicts
         _validate_kernel_body(
             self.kernel,
+            param_output=self.param_output,
+            model_trace=model_trace,
+            with_output=with_output,
+        )
+        return_sites = (
             self.param_output,
-            model_trace,
-        )
-        self._return_sites = (
-            *(k for k, site in model_trace.items() if site["type"] == "deterministic"),
-            self.param_output,
-        )
-
-        if rng_key is None:
-            self._rng_key, rng_key = random.split(self._rng_key)
-        rng_key, rng_subkey = random.split(rng_key)
-        if isinstance(self.inference, SVI):
-            self._num_samples = num_samples
-            logger.info("Performing variational inference optimization...")
-            self.vi_result = self.inference.run(
-                rng_subkey,
-                num_steps=num_steps,
-                progress_bar=progress,
-                init_state=self._vi_state,
-                **args_bound,
-            )
-            self._vi_state = self.vi_result.state
-            if np.any(np.isnan(self.vi_result.losses)):
-                warn(
-                    "Loss contains NaN or Inf, indicating numerical instability.",
-                    category=RuntimeWarning,
-                    stacklevel=2,
-                )
-            logger.info("Posterior sampling...")
-            rng_key, rng_subkey = random.split(rng_key)
-            self._posterior = _sample_forward(
-                substitute(self.inference.guide, data=self.vi_result.params),
-                rng_key=rng_subkey,
-                num_samples=self._num_samples,
-                return_sites=None,
-                samples=None,
-                model_kwargs=None,
-            )
-        elif isinstance(self.inference, MCMC):
-            logger.info("Posterior sampling...")
-            self.inference.run(rng_subkey, **args_bound)
-            self._posterior = device_get(self.inference.get_samples())
-            self._num_samples = (
-                next(iter(self._posterior.values())).shape[0] if self._posterior else 0
-            )
-
-        self._is_fitted = True
-
-        return self
-
-    def fit(
-        self,
-        X: ArrayLike | ArrayLoader,
-        y: ArrayLike | None = None,
-        *,
-        num_samples: int = 1000,
-        rng_key: ArrayLike | None = None,
-        progress: bool = True,
-        batch_size: int | None = None,
-        epochs: int = 1,
-        shuffle: bool = True,
-        **kwargs: object,
-    ) -> Self:
-        """Fit the impact model to the provided data using epoch-based training.
-
-        This method implements an epoch-based training loop, where the data is iterated
-        over in minibatches for a specified number of epochs. Variational inference is
-        performed by repeatedly updating the model parameters on each minibatch, and
-        then posterior samples are drawn from the fitted model.
-
-        Args:
-            X (ArrayLike | ArrayLoader): Input data, either an array-like of shape
-                ``(n_samples, n_features)`` or a data loader that holds all array-like
-                objects and handles batching internally; if a data loader is passed,
-                ``batch_size`` is ignored.
-            y (ArrayLike | None): Output data with shape ``(n_samples_Y,)``. Must be
-                ``None`` if ``X`` is a data loader.
-            num_samples: The number of posterior samples to draw.
-            rng_key (ArrayLike | None): A pseudo-random number generator key. By
-                default, an internal key is used and split as needed.
-            progress: Whether to display a progress bar.
-            batch_size: The number of data points processed at each step of variational
-                inference. If ``None``, the entire dataset is used as a single batch in
-                each epoch.
-            epochs: The number of epochs for variational inference optimization.
-            shuffle: Whether to shuffle the data at each epoch.
-            **kwargs: Additional arguments passed to the model. All array-like values
-                are expected to be JAX arrays.
-
-        Returns:
-            The fitted model instance, enabling method chaining.
-
-        Raises:
-            TypeError: If the inference method is MCMC.
-
-        Note:
-            This method continues training from the existing SVI state if available.
-            To start training from scratch, create a new model instance. It does not
-            check whether the model or guide is written to support subsampling semantics
-            (e.g., using NumPyro's :external:py:func:`~numpyro.primitives.subsample` or
-            similar constructs).
-        """
-        if isinstance(self.inference, MCMC):
-            msg = (
-                "`.fit()` is not supported for MCMC inference. Use `.fit_on_batch()` "
-                "instead."
-            )
-            raise TypeError(msg)
-
-        self._num_samples = num_samples
-
-        if rng_key is None:
-            self._rng_key, rng_key = random.split(self._rng_key)
-
-        rng_key, rng_subkey = random.split(rng_key)
-        dataloader, kwargs_extra = _setup_inputs(
-            X=X,
-            y=y,
-            rng_key=rng_subkey,
-            batch_size=batch_size if batch_size is not None else len(X),
-            num_samples=num_samples,
-            shuffle=shuffle,
-            device=None,
-            **kwargs,
-        )
-
-        logger.info("Performing variational inference optimization...")
-        losses: list[float] = []
-        rng_key, rng_subkey = random.split(rng_key)
-        for epoch in range(epochs):
-            losses_epoch: list[float] = []
-            pbar = tqdm(
-                dataloader,
-                desc=f"Epoch {epoch + 1}/{epochs}",
-                total=len(dataloader),
-                disable=not progress,
-                dynamic_ncols=True,
-            )
-            for batch, _ in pbar:
-                self._vi_state, loss = self.train_on_batch(
-                    **batch,
-                    **kwargs_extra._asdict(),
-                    rng_key=rng_subkey,
-                )
-                loss_batch = device_get(loss)
-                losses_epoch.append(loss_batch)
-                pbar.set_postfix({"loss": f"{float(loss_batch):.4f}"})
-            losses_epoch_arr = jnp.stack(losses_epoch)
-            losses.extend(losses_epoch_arr)
-            tqdm.write(
-                f"Epoch {epoch + 1}/{epochs} - "
-                f"Average loss: {float(jnp.mean(losses_epoch_arr)):.4f}",
-            )
-        self.vi_result = SVIRunResult(
-            params=self.inference.get_params(self._vi_state),
-            state=self._vi_state,
-            losses=jnp.asarray(losses),
-        )
-        if np.any(np.isnan(self.vi_result.losses)):
-            msg = "Loss contains NaN or Inf, indicating numerical instability."
-            warn(msg, category=RuntimeWarning, stacklevel=2)
-
-        self._is_fitted = True
-
-        logger.info("Posterior sampling...")
-        rng_key, rng_subkey = random.split(rng_key)
-        self._posterior = _sample_forward(
-            substitute(self.inference.guide, data=self.vi_result.params),
-            rng_key=rng_subkey,
-            num_samples=self._num_samples,
-            return_sites=None,
-            samples=None,
-            model_kwargs=None,
-        )
-
-        return self
-
-    def is_fitted(self) -> bool:
-        """Check fitted status.
-
-        Returns:
-            `True` if the model is fitted, `False` otherwise.
-
-        """
-        return hasattr(self, "_is_fitted") and self._is_fitted
-
-    def set_posterior_sample(
-        self,
-        posterior_sample: dict[str, Array],
-        return_sites: tuple[str] | None = None,
-    ) -> Self:
-        """Set posterior samples for the model.
-
-        This method sets externally obtained posterior samples on the model instance,
-        enabling downstream analysis without requiring a call to
-        :py:meth:`~aimz.ImpactModel.fit` or :py:meth:`~aimz.ImpactModel.fit_on_batch`.
-
-        It is primarily intended for workflows where posterior sampling is performed
-        manually—for example, using NumPyro's
-        :external:py:class:`~numpyro.infer.svi.SVI` (or
-        :external:py:class:`~numpyro.infer.mcmc.MCMC`) with the
-        :external:py:class:`~numpyro.infer.util.Predictive` API—and the resulting
-        posterior samples are injected into the model for further use.
-
-        Internally, ``batch_ndims`` is set to ``1`` by default to correctly handle the
-        batch dimensions of the posterior samples. For more information, refer to the
-        `NumPyro documentation <https://num.pyro.ai/en/stable/utilities.html#predictive>`__.
-
-        Args:
-            posterior_sample: Posterior samples to set for the model.
-            return_sites: Names of variable (sites) to return in
-                :py:meth:`~aimz.ImpactModel.predict`. By default, it is set to
-                :attr:`~aimz.ImpactModel.param_output`.
-
-        Returns:
-            The model instance, treated as fitted with posterior samples set, enabling
-            method chaining.
-
-        Raises:
-            ValueError: If the batch shapes in ``posterior_sample`` are inconsistent.
-        """
-        batch_ndims = 1
-        batch_shapes = {
-            sample.shape[:batch_ndims] for sample in posterior_sample.values()
-        }
-        if len(batch_shapes) > 1:
-            msg = f"Inconsistent batch shapes found in posterior_sample: {batch_shapes}"
-            raise ValueError(msg)
-        (self._num_samples,) = batch_shapes.pop()
-        self._posterior = posterior_sample
-        self._return_sites = return_sites or (self.param_output,)
-        self._is_fitted = True
-
-        return self
-
-    def predict_on_batch(
-        self,
-        X: ArrayLike,
-        *,
-        intervention: dict | None = None,
-        rng_key: ArrayLike | None = None,
-        in_sample: bool = True,
-        return_sites: tuple[str] | None = None,
-        return_datatree: bool = True,
-        **kwargs: object,
-    ) -> xr.DataTree | dict[str, npt.NDArray]:
-        """Predict the output based on the fitted model.
-
-        This method returns predictions for a single batch of input data and is better
-        suited for:
-
-            1) Models incompatible with :py:meth:`~aimz.ImpactModel.predict` due to
-            their posterior sample shapes.
-
-            2) Scenarios where writing results to to files (e.g., disk, cloud storage)
-            is not desired.
-
-            3) Smaller datasets, as this method may be slower due to limited
-            parallelism.
-
-        Args:
-            X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
-            intervention: A dictionary mapping sample sites to their corresponding
-                intervention values. Interventions enable counterfactual analysis by
-                modifying the specified sample sites during prediction (posterior
-                predictive sampling).
-            rng_key (ArrayLike | None): A pseudo-random number generator key. By
-                default, an internal key is used and split as needed.
-            in_sample: Specifies the group where posterior predictive samples are stored
-                in the returned output. If ``True``, samples are stored in the
-                ``posterior_predictive`` group, indicating they were generated based on
-                data used during model fitting. If ``False``, samples are stored in the
-                ``predictions`` group, indicating they were generated based on
-                out-of-sample data.
-            return_sites: Names of variables (sites) to return. If ``None``, samples
-                :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
-            return_datatree: If ``True``, return a
-                :external:py:class:`~xarray.DataTree`; otherwise return a
-                :py:class:`dict`.
-            **kwargs: Additional arguments passed to the model. All array-like values
-                are expected to be JAX arrays.
-
-        Returns:
-            Posterior predictive samples. Posterior samples are included if available.
-
-        Raises:
-            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
-                argument.
-        """
-        _check_is_fitted(self)
-
-        X = cast("Array", _validate_X_y_to_jax(X))
-
-        # Validate the provided parameters against the kernel's signature
-        args_bound = (
-            signature(self.kernel).bind(**{self.param_input: X, **kwargs}).arguments
-        )
-        if self.param_output in args_bound:
-            msg = f"Specifying {self.param_output!r} is not allowed."
-            raise TypeError(msg)
-
-        if rng_key is None:
-            self._rng_key, rng_key = random.split(self._rng_key)
-
-        if intervention is None:
-            kernel = self.kernel
-        else:
-            rng_key, rng_subkey = random.split(rng_key)
-            kernel = seed(do(self.kernel, data=intervention), rng_seed=rng_subkey)
-
-        samples = device_get(
-            _sample_forward(
-                kernel,
-                rng_key=rng_key,
-                num_samples=self._num_samples,
-                return_sites=return_sites or self._return_sites,
-                samples=self._posterior,
-                model_kwargs=args_bound,
+            *tuple(
+                k for k, site in model_trace.items() if site["type"] == "deterministic"
             ),
         )
-
-        if not return_datatree:
-            return samples
-
-        out = xr.DataTree(name="root")
-        if self._posterior:
-            out["posterior"] = _dict_to_datatree(self._posterior)
-        out["posterior_predictive" if in_sample else "predictions"] = _dict_to_datatree(
-            samples,
-        )
-
-        return out
-
-    def predict(
-        self,
-        X: ArrayLike | ArrayLoader,
-        *,
-        intervention: dict | None = None,
-        rng_key: ArrayLike | None = None,
-        in_sample: bool = True,
-        return_sites: tuple[str] | None = None,
-        batch_size: int | None = None,
-        output_dir: str | Path | None = None,
-        progress: bool = True,
-        **kwargs: object,
-    ) -> xr.DataTree:
-        """Predict the output based on the fitted model.
-
-        This method performs posterior predictive sampling to generate model-based
-        predictions. It is optimized for batch processing of large input data and is not
-        recommended for use in loops that process only a few inputs at a time. Results
-        are written to disk in the Zarr format, with sampling and file writing decoupled
-        and executed concurrently.
-
-        Args:
-            X (ArrayLike | ArrayLoader): Input data, either an array-like of shape
-                ``(n_samples, n_features)`` or a data loader that holds all array-like
-                objects and handles batching internally; if a data loader is passed,
-                ``batch_size`` is ignored.
-            intervention: A dictionary mapping sample sites to their corresponding
-                intervention values. Interventions enable counterfactual analysis by
-                modifying the specified sample sites during prediction (posterior
-                predictive sampling).
-            rng_key (ArrayLike | None): A pseudo-random number generator key. By
-                default, an internal key is used and split as needed.
-            in_sample: Specifies the group where posterior predictive samples are stored
-                in the returned output. If ``True``, samples are stored in the
-                ``posterior_predictive`` group, indicating they were generated based on
-                data used during model fitting. If ``False``, samples are stored in the
-                ``predictions`` group, indicating they were generated based on
-                out-of-sample data.
-            return_sites: Names of variables (sites) to return. If ``None``, samples
-                :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
-            batch_size: The batch size for data loading during posterior predictive
-                sampling. It also determines the chunk size used to store the samples.
-                If ``None``, it is determined automatically based on the input data
-                and number of samples.
-            output_dir: The directory where the outputs will be saved. If the specified
-                directory does not exist, it will be created automatically. If ``None``,
-                a default temporary directory will be created. A timestamped
-                subdirectory will be generated within this directory to store the
-                outputs. Outputs are saved in the Zarr format.
-            progress: Whether to display a progress bar.
-            **kwargs: Additional arguments passed to the model. All array-like values
-                are expected to be JAX arrays.
-
-        Returns:
-            Posterior predictive samples. Posterior samples are included if available.
-
-        Raises:
-            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
-                argument.
-
-        See Also:
-            :py:meth:`~aimz.ImpactModel.cleanup` to remove the temporary directory if
-            created.
-        """
-        _check_is_fitted(self)
-
-        if isinstance(X, ArrayLike):
-            ndim_posterior_sample = 2
-            if self._posterior and any(
-                v.ndim == ndim_posterior_sample and v.shape[1] == len(X)
-                for v in self._posterior.values()
-            ):
-                msg = (
-                    "One or more posterior sample shapes are not compatible with "
-                    "`.predict()` under sharded parallelism; falling back to "
-                    "`.predict_on_batch()`."
-                )
-                warn(msg, category=UserWarning, stacklevel=2)
-
-                return cast(
-                    "xr.DataTree",
-                    self.predict_on_batch(
-                        cast("ArrayLike", X),
-                        intervention=intervention,
-                        rng_key=rng_key,
-                        in_sample=in_sample,
-                        return_sites=return_sites or self._return_sites,
-                        return_datatree=True,
-                        **kwargs,
-                    ),
-                )
-            # Validate the provided parameters against the kernel's signature
-            args_bound = (
-                signature(self.kernel).bind(**{self.param_input: X, **kwargs}).arguments
-            )
-            if self.param_output in args_bound:
-                msg = f"Specifying {self.param_output!r} is not allowed."
-                raise TypeError(msg)
-
-        if rng_key is None:
-            self._rng_key, rng_key = random.split(self._rng_key)
-
-        if intervention is None:
-            kernel = self.kernel
-        else:
-            rng_key, rng_subkey = random.split(rng_key)
-            kernel = seed(do(self.kernel, data=intervention), rng_seed=rng_subkey)
-
-        return_sites = return_sites or self._return_sites
-
-        kwargs_array, kwargs_extra = _group_kwargs(kwargs)
-        if self._fn_sample_posterior_predictive is None:
-            self._fn_sample_posterior_predictive = _create_sharded_sampler(
-                self._mesh,
-                len(kwargs_array),
-                len(kwargs_extra),
-            )
-
-        output_dir, output_subdir = self._create_output_subdir(output_dir)
-
-        dataloader, _ = _setup_inputs(
-            X=X,
-            y=None,
-            rng_key=self.rng_key,
-            batch_size=batch_size,
-            num_samples=self._num_samples,
-            shuffle=False,
-            device=self._device,
-            **kwargs,
-        )
-
-        self._sample_and_write(
-            num_samples=self._num_samples,
-            rng_key=rng_key,
+        output_observed = bool(with_output)
+        self._kernel_spec = KernelSpec(
+            traced=True,
             return_sites=return_sites,
-            output_dir=output_subdir,
-            kernel=kernel,
-            sampler=self._fn_sample_posterior_predictive,
-            samples=cast("dict[str, Array]", self._posterior),
-            dataloader=dataloader,
-            pbar=tqdm(
-                desc=(f"Posterior predictive sampling [{', '.join(return_sites)}]"),
-                total=len(dataloader),
-                disable=not progress,
-                dynamic_ncols=True,
-            ),
-            **kwargs,
+            output_observed=output_observed,
         )
-
-        ds = open_zarr(output_subdir, consolidated=False).expand_dims(
-            dim="chain",
-            axis=0,
-        )
-        ds = ds.assign_coords(
-            {k: np.arange(ds.sizes[k]) for k in ds.sizes},
-        ).assign_attrs(_make_attrs())
-        out = xr.DataTree(name="root")
-        if self._posterior:
-            out["posterior"] = _dict_to_datatree(self._posterior)
-        group = "posterior_predictive" if in_sample else "predictions"
-        out[group] = xr.DataTree(ds)
-        out[group].attrs["output_dir"] = str(output_subdir)
-        out.attrs["output_dir"] = str(output_dir)
-
-        return out
-
-    def estimate_effect(
-        self,
-        output_baseline: xr.DataTree | None = None,
-        output_intervention: xr.DataTree | None = None,
-        args_baseline: dict | None = None,
-        args_intervention: dict | None = None,
-    ) -> xr.DataTree:
-        """Estimate the effect of an intervention.
-
-        Args:
-            output_baseline: Precomputed output for the baseline scenario.
-            output_intervention: Precomputed output for the intervention scenario.
-            args_baseline: Input arguments for the baseline scenario. Passed to the
-                :py:meth:`~aimz.ImpactModel.predict` to compute predictions if
-                ``output_baseline`` is not provided. Ignored if ``output_baseline`` is
-                already given.
-            args_intervention: Input arguments for the intervention scenario. Passed to
-                the :py:meth:`~aimz.ImpactModel.predict` to compute predictions if
-                ``output_intervention`` is not provided. Ignored if
-                ``output_intervention`` is already given.
-
-        Returns:
-            The estimated impact of an intervention.
-
-        Raises:
-            ValueError: If neither ``output_baseline`` nor ``args_baseline`` is
-                provided, or if neither ``output_intervention`` nor
-                ``args_intervention`` is provided.
-
-        See Also:
-            :py:meth:`~aimz.ImpactModel.cleanup` to remove the temporary directory if
-            created.
-        """
-        _check_is_fitted(self)
-
-        if output_baseline:
-            dt_baseline = output_baseline
-        elif args_baseline:
-            dt_baseline = self.predict(**args_baseline)
-        else:
-            msg = "Either `output_baseline` or `args_baseline` must be provided."
-            raise ValueError(msg)
-
-        if output_intervention:
-            dt_intervention = output_intervention
-        elif args_intervention:
-            dt_intervention = self.predict(**args_intervention)
-        else:
-            msg = (
-                "Either `output_intervention` or `args_intervention` must be provided."
-            )
-            raise ValueError(msg)
-
-        group = _validate_group(dt_baseline, dt_intervention)
-
-        out = xr.DataTree(name="root")
-        out[group] = dt_intervention[group] - dt_baseline[group]
-
-        return out
-
-    def log_likelihood(
-        self,
-        X: ArrayLike | ArrayLoader,
-        y: ArrayLike | None = None,
-        *,
-        batch_size: int | None = None,
-        output_dir: str | Path | None = None,
-        progress: bool = True,
-        **kwargs: object,
-    ) -> xr.DataTree:
-        """Compute the log-likelihood of the data under the given model.
-
-        Results are written to disk in the Zarr format, with computing and file writing
-        decoupled and executed concurrently.
-
-        Args:
-            X (ArrayLike | ArrayLoader): Input data, either an array-like of shape
-                ``(n_samples, n_features)`` or a data loader that holds all array-like
-                objects and handles batching internally; if a data loader is passed,
-                ``batch_size`` is ignored.
-            y (ArrayLike | None): Output data with shape ``(n_samples_Y,)``. Must be
-                ``None`` if ``X`` is a data loader.
-            batch_size: The batch size for data loading during log-likelihood
-                computation. It also determines the chunk size used to store the
-                samples. If ``None``, it is determined automatically based on the input
-                data and number of samples.
-            output_dir: The directory where the outputs will be saved. If the specified
-                directory does not exist, it will be created automatically. If ``None``,
-                a default temporary directory will be created. A timestamped
-                subdirectory will be generated within this directory to store the
-                outputs. Outputs are saved in the Zarr format.
-            progress: Whether to display a progress bar.
-            **kwargs: Additional arguments passed to the model. All array-like values
-                are expected to be JAX arrays.
-
-        Returns:
-            Log-likelihood values. Posterior samples are included if available.
-
-        See Also:
-            :py:meth:`~aimz.ImpactModel.cleanup` to remove the temporary directory if
-            created.
-        """
-        _check_is_fitted(self)
-
-        kwargs_array, kwargs_extra = _group_kwargs(kwargs)
-        if self._fn_log_likelihood is None:
-            self._fn_log_likelihood = _create_sharded_log_likelihood(
-                self._mesh,
-                len(kwargs_array),
-                len(kwargs_extra),
-            )
-
-        output_dir, output_subdir = self._create_output_subdir(output_dir)
-
-        dataloader, _ = _setup_inputs(
-            X=X,
-            y=y,
-            rng_key=self.rng_key,
-            batch_size=batch_size,
-            num_samples=self._num_samples,
-            shuffle=False,
-            device=self._device,
-            **kwargs,
-        )
-
-        site = self.param_output
-        pbar = tqdm(
-            desc=(f"Computing log-likelihood of {site}..."),
-            total=len(dataloader),
-            disable=not progress,
-            dynamic_ncols=True,
-        )
-
-        zarr_group = open_group(output_subdir, mode="w")
-        zarr_arr = {}
-        threads, queues, error_queue = _start_writer_threads(
-            (site,),
-            group_path=output_subdir,
-            writer=_writer,
-            queue_size=min(cpu_count() or 1, 4),
-        )
-        try:
-            for batch, n_pad in dataloader:
-                kwargs_batch = [
-                    v
-                    for k, v in batch.items()
-                    if k not in (self.param_input, self.param_output)
-                ]
-                arr = device_get(
-                    self._fn_log_likelihood(
-                        # Although computing the log-likelihood is deterministic, the
-                        # model still needs to be seeded in order to trace its graph.
-                        seed(self.kernel, rng_seed=self.rng_key),
-                        self._posterior,
-                        self.param_input,
-                        site,
-                        kwargs_array._fields + kwargs_extra._fields,
-                        batch[self.param_input],
-                        batch[self.param_output],
-                        *(*kwargs_batch, *kwargs_extra),
-                    ),
-                )
-                if site not in zarr_arr:
-                    draws = self._num_samples if self.posterior else 1
-                    zarr_arr[site] = zarr_group.create_array(
-                        name=site,
-                        shape=(draws, 0, *arr.shape[2:]),
-                        dtype="float32" if arr.dtype == "bfloat16" else arr.dtype,
-                        chunks=(draws, dataloader.batch_size, *arr.shape[2:]),
-                        dimension_names=(
-                            "draw",
-                            *tuple(f"{site}_dim_{i}" for i in range(arr.ndim - 1)),
-                        ),
-                    )
-                queues[site].put(arr[:, : -n_pad or None])
-                if not error_queue.empty():
-                    _, exc, tb = error_queue.get()
-                    raise exc.with_traceback(tb)
-                pbar.update()
-            pbar.set_description("Computation complete, writing in progress...")
-            _shutdown_writer_threads(threads, queues=queues)
-        except:
-            _shutdown_writer_threads(threads, queues=queues)
-            logger.exception(
-                "Exception encountered. Cleaning up output directory: %s",
-                output_subdir,
-            )
-            rmtree(output_subdir, ignore_errors=True)
-            raise
-        finally:
-            pbar.close()
-
-        ds = open_zarr(output_subdir, consolidated=False).expand_dims(
-            dim="chain",
-            axis=0,
-        )
-        ds = ds.assign_coords(
-            {k: np.arange(ds.sizes[k]) for k in ds.sizes},
-        ).assign_attrs(_make_attrs())
-        out = xr.DataTree(name="root")
-        if self._posterior:
-            out["posterior"] = _dict_to_datatree(self._posterior)
-        out["log_likelihood"] = xr.DataTree(ds)
-        out["log_likelihood"].attrs["output_dir"] = str(output_subdir)
-        out.attrs["output_dir"] = str(output_dir)
-
-        return out
-
-    def cleanup(self) -> None:
-        """Clean up the temporary directory created for storing outputs.
-
-        If the temporary directory was never created or has already been cleaned up,
-        this method does nothing. It does not delete any explicitly specified output
-        directory. While the temporary directory is typically removed automatically
-        during garbage collection, this behavior is not guaranteed. Therefore, calling
-        this method explicitly is recommended to ensure timely resource release.
-        """
-        if hasattr(self, "_temp_dir") and self._temp_dir is not None:
-            logger.info("Temporary directory cleaned up at: %s", self._temp_dir.name)
-            self._temp_dir.cleanup()
-            self._temp_dir = None
+        self._return_sites = self._kernel_spec.return_sites
 
     def _create_output_subdir(self, output_dir: str | Path | None) -> tuple[Path, Path]:
         """Create a subdirectory for storing output.
@@ -1508,7 +328,7 @@ class ImpactModel(BaseModel):
         self,
         num_samples: int,
         rng_key: ArrayLike,
-        return_sites: tuple[str],
+        return_sites: tuple[str, ...],
         output_dir: Path,
         kernel: Callable,
         sampler: Callable,
@@ -1618,3 +438,1219 @@ class ImpactModel(BaseModel):
             raise
         finally:
             pbar.close()
+
+    def sample_prior_predictive_on_batch(
+        self,
+        X: ArrayLike,
+        *,
+        num_samples: int = 1000,
+        rng_key: ArrayLike | None = None,
+        return_sites: tuple[str, ...] | None = None,
+        return_datatree: bool = True,
+        **kwargs: object,
+    ) -> xr.DataTree | dict[str, npt.NDArray]:
+        """Draw samples from the prior predictive distribution.
+
+        Args:
+            X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
+            num_samples: The number of samples to draw.
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            return_sites: Names of variables (sites) to return. If ``None``, samples all
+                latent, observed, and deterministic sites.
+            return_datatree: If ``True``, return a :external:class:`~xarray.DataTree`;
+                otherwise return a :class:`dict`.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
+
+        Returns:
+            Prior predictive samples.
+
+        Raises:
+            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
+                argument.
+        """
+        X = cast("Array", _validate_X_y_to_jax(X))
+
+        # Validate the provided parameters against the kernel's signature
+        args_bound = (
+            signature(self.kernel).bind(**{self.param_input: X, **kwargs}).arguments
+        )
+        if self.param_output in args_bound:
+            msg = f"Specifying {self.param_output!r} is not allowed."
+            raise TypeError(msg)
+        self._build_kernel_spec(args_bound, with_output=False)
+
+        if rng_key is None:
+            self._rng_key, rng_key = random.split(self._rng_key)
+
+        prior_predictive_samples = device_get(
+            _sample_forward(
+                self.kernel,
+                rng_key=rng_key,
+                num_samples=num_samples,
+                return_sites=return_sites,
+                samples=None,
+                model_kwargs=args_bound,
+            ),
+        )
+
+        if not return_datatree:
+            return prior_predictive_samples
+
+        out = xr.DataTree(name="root")
+        out["prior_predictive"] = _dict_to_datatree(prior_predictive_samples)
+
+        return out
+
+    def sample_prior_predictive(
+        self,
+        X: ArrayLike,
+        *,
+        num_samples: int = 1000,
+        rng_key: ArrayLike | None = None,
+        return_sites: tuple[str, ...] | None = None,
+        batch_size: int | None = None,
+        output_dir: str | Path | None = None,
+        progress: bool = True,
+        **kwargs: object,
+    ) -> xr.DataTree:
+        """Draw samples from the prior predictive distribution.
+
+        Results are written to disk in the Zarr format, with computing and file writing
+        decoupled and executed concurrently.
+
+        Args:
+            X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
+            num_samples: The number of samples to draw.
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            return_sites: Names of variables (sites) to return. If ``None``, samples
+                :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
+            batch_size: The batch size for data loading during prior predictive
+                sampling. It also determines the chunk size used to store the samples.
+                If ``None``, it is determined automatically based on the input data and
+                number of samples.
+            output_dir: The directory where the outputs will be saved. If the specified
+                directory does not exist, it will be created automatically. If ``None``,
+                a default temporary directory will be created. A timestamped
+                subdirectory will be generated within this directory to store the
+                outputs. Outputs are saved in the Zarr format.
+            progress: Whether to display a progress bar.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
+
+        Returns:
+            Prior predictive samples.
+
+        Raises:
+            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
+                argument.
+
+        See Also:
+            :meth:`~aimz.ImpactModel.cleanup` to remove the temporary directory if
+            created.
+        """
+        # Validate the provided parameters against the kernel's signature
+        args_bound = (
+            signature(self.kernel).bind(**{self.param_input: X, **kwargs}).arguments
+        )
+        if self.param_output in args_bound:
+            msg = f"Specifying {self.param_output!r} is not allowed."
+            raise TypeError(msg)
+
+        # Prior sampling
+        dataloader, _ = _setup_inputs(
+            X=X,
+            y=None,
+            rng_key=self.rng_key,
+            batch_size=self._device.num_devices if self._device is not None else 1,
+            num_samples=num_samples,
+            shuffle=False,
+            device=self._device,
+            **kwargs,
+        )
+        batch, _ = next(iter(dataloader))
+        self._build_kernel_spec(batch, with_output=False)
+        return_sites = (
+            return_sites or cast("KernelSpec", self._kernel_spec).return_sites
+        )
+        if rng_key is None:
+            self._rng_key, rng_key = random.split(self._rng_key)
+        rng_key, rng_subkey = random.split(rng_key)
+        prior_samples = _sample_forward(
+            self.kernel,
+            rng_key=rng_subkey,
+            num_samples=num_samples,
+            return_sites=None,
+            samples=None,
+            model_kwargs=batch,
+        )
+        prior_samples = {
+            k: v for k, v in prior_samples.items() if k not in return_sites
+        }
+
+        kwargs_array, kwargs_extra = _group_kwargs(kwargs)
+        if self._fn_sample_prior_predictive is None:
+            self._fn_sample_prior_predictive = _create_sharded_sampler(
+                self._mesh,
+                len(kwargs_array),
+                len(kwargs_extra),
+            )
+
+        output_dir, output_subdir = self._create_output_subdir(output_dir)
+
+        dataloader, _ = _setup_inputs(
+            X=X,
+            y=None,
+            rng_key=self.rng_key,
+            batch_size=batch_size,
+            num_samples=num_samples,
+            shuffle=False,
+            device=self._device,
+            **kwargs,
+        )
+
+        self._sample_and_write(
+            num_samples,
+            rng_key=rng_key,
+            return_sites=return_sites,
+            output_dir=output_subdir,
+            kernel=self.kernel,
+            sampler=self._fn_sample_prior_predictive,
+            samples=prior_samples,
+            dataloader=dataloader,
+            pbar=tqdm(
+                desc=(f"Prior predictive sampling [{', '.join(return_sites)}]"),
+                total=len(dataloader),
+                disable=not progress,
+                dynamic_ncols=True,
+            ),
+            **kwargs,
+        )
+
+        ds = open_zarr(output_subdir, consolidated=False).expand_dims(
+            dim="chain",
+            axis=0,
+        )
+        ds = ds.assign_coords(
+            {k: np.arange(ds.sizes[k]) for k in ds.sizes},
+        ).assign_attrs(_make_attrs())
+        out = xr.DataTree(name="root")
+        out["prior_predictive"] = xr.DataTree(ds)
+        out["prior_predictive"].attrs["output_dir"] = str(output_subdir)
+        out.attrs["output_dir"] = str(output_dir)
+
+        return out
+
+    def sample(
+        self,
+        *,
+        num_samples: int = 1000,
+        rng_key: ArrayLike | None = None,
+        return_sites: tuple[str, ...] | None = None,
+        return_datatree: bool = True,
+        **kwargs: object,
+    ) -> xr.DataTree | dict[str, npt.NDArray]:
+        """Draw posterior samples from a fitted model.
+
+        Args:
+            num_samples: The number of posterior samples to draw.
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed. Has no effect if
+                the inference method is MCMC, where the ``post_warmup_state`` property
+                will be used to continue sampling.
+            return_sites: Names of variables (sites) to return. If ``None``, samples
+                all latent sites. Has no effect if the inference method is MCMC.
+            return_datatree: If ``True``, return a :external:class:`~xarray.DataTree`;
+                otherwise return a :class:`dict`.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays. Only relevant when the inference method
+                is MCMC.
+
+        Returns:
+            Posterior samples.
+
+        Raises:
+            TypeError: If :attr:`~aimz.ImpactModel.param_output` is not passed as an
+                argument when the inference method is MCMC.
+        """
+        _check_is_fitted(self)
+
+        if rng_key is None:
+            self._rng_key, rng_key = random.split(self._rng_key)
+
+        if isinstance(self.inference, MCMC):
+            # Validate the provided parameters against the kernel's signature
+            args_bound = signature(self.kernel).bind(**kwargs).arguments
+            if self.param_output not in args_bound:
+                msg = f"{self.param_output!r} must be provided in `.sample()`."
+                raise TypeError(msg)
+            self.inference.post_warmup_state = self.inference.last_state
+            self.inference.num_samples = num_samples
+            self.inference.run(self.inference.post_warmup_state.rng_key, **args_bound)
+            posterior_samples = device_get(self.inference.get_samples())
+        else:
+            posterior_samples = device_get(
+                _sample_forward(
+                    substitute(
+                        self.inference.guide,
+                        data=cast("SVIRunResult", self.vi_result).params,
+                    ),
+                    rng_key=rng_key,
+                    num_samples=num_samples,
+                    return_sites=return_sites,
+                    samples=None,
+                    model_kwargs=None,
+                ),
+            )
+
+        if not return_datatree:
+            return posterior_samples
+
+        out = xr.DataTree(name="root")
+        out["posterior"] = _dict_to_datatree(posterior_samples)
+
+        return out
+
+    def sample_posterior_predictive_on_batch(
+        self,
+        X: ArrayLike,
+        *,
+        intervention: dict | None = None,
+        rng_key: ArrayLike | None = None,
+        return_sites: tuple[str, ...] | None = None,
+        return_datatree: bool = True,
+        **kwargs: object,
+    ) -> xr.DataTree | dict[str, npt.NDArray]:
+        """Draw samples from the posterior predictive distribution.
+
+        This method is a convenience alias for
+        :meth:`~aimz.ImpactModel.predict_on_batch`, with ``in_sample`` automatically
+        set to ``True``.
+
+        Args:
+            X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
+            intervention: A dictionary mapping sample sites to their corresponding
+                intervention values. Interventions enable counterfactual analysis by
+                modifying the specified sample sites during prediction (posterior
+                predictive sampling).
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            return_sites: Names of variables (sites) to return. If ``None``, samples
+                :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
+            return_datatree: If ``True``, return a :external:class:`~xarray.DataTree`;
+                otherwise return a :class:`dict`.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
+
+        Returns:
+            Posterior predictive samples. Posterior samples are included if available.
+
+        Raises:
+            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
+                argument.
+
+        See Also:
+            :meth:`~aimz.ImpactModel.predict_on_batch`.
+        """
+        return self.predict_on_batch(
+            X,
+            intervention=intervention,
+            rng_key=rng_key,
+            in_sample=True,
+            return_sites=return_sites,
+            return_datatree=return_datatree,
+            **kwargs,
+        )
+
+    def sample_posterior_predictive(
+        self,
+        X: ArrayLike | ArrayLoader,
+        *,
+        intervention: dict | None = None,
+        rng_key: ArrayLike | None = None,
+        return_sites: tuple[str, ...] | None = None,
+        batch_size: int | None = None,
+        output_dir: str | Path | None = None,
+        progress: bool = True,
+        **kwargs: object,
+    ) -> xr.DataTree:
+        """Draw samples from the posterior predictive distribution.
+
+        This method is a convenience alias for :meth:`~aimz.ImpactModel.predict`, with
+        ``in_sample`` automatically set to ``True``.
+
+        Args:
+            X (ArrayLike | ArrayLoader): Input data, either an array-like of shape
+                ``(n_samples, n_features)`` or a data loader that holds all array-like
+                objects and handles batching internally.
+            intervention: A dictionary mapping sample sites to their corresponding
+                intervention values. Interventions enable counterfactual analysis by
+                modifying the specified sample sites during prediction (posterior
+                predictive sampling).
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            return_sites: Names of variables (sites) to return. If ``None``, samples
+                :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
+            batch_size: The batch size for data loading during posterior predictive
+                sampling. It also determines the chunk size used to store the samples.
+                If ``None``, it is determined automatically based on the input data and
+                number of samples. Ignored if ``X`` is a data loader, in which case the
+                data loader is expected to handle batching internally.
+            output_dir: The directory where the outputs will be saved. If the specified
+                directory does not exist, it will be created automatically. If ``None``,
+                a default temporary directory will be created. A timestamped
+                subdirectory will be generated within this directory to store the
+                outputs. Outputs are saved in the Zarr format.
+            progress: Whether to display a progress bar.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
+
+        Returns:
+            Posterior predictive samples. Posterior samples are included if available.
+
+        Raises:
+            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
+                argument.
+
+        See Also:
+            :meth:`~aimz.ImpactModel.predict()`.
+        """
+        return self.predict(
+            X,
+            intervention=intervention,
+            rng_key=rng_key,
+            in_sample=True,
+            return_sites=return_sites,
+            batch_size=batch_size,
+            output_dir=output_dir,
+            progress=progress,
+            **kwargs,
+        )
+
+    def train_on_batch(
+        self,
+        X: ArrayLike,
+        y: ArrayLike,
+        rng_key: ArrayLike | None = None,
+        **kwargs: object,
+    ) -> tuple[SVIState, Array]:
+        """Run a single VI step on the given batch of data.
+
+        Args:
+            X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
+            y (ArrayLike): Output data with shape ``(n_samples_Y,)``.
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed. The key is only
+                used for initialization if the internal SVI state is not yet set.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
+
+        Returns:
+            - Updated SVI state after the training step.
+
+            - Loss value as a scalar array.
+
+        Note:
+            This method updates the internal SVI state on every call, so it is not
+            necessary to capture the returned state externally unless explicitly needed.
+            However, the returned loss value can be used for monitoring or logging.
+        """
+        batch = {self.param_input: X, self.param_output: y, **kwargs}
+
+        if self._vi_state is None:
+            self._build_kernel_spec(
+                signature(self.kernel).bind(**batch).arguments,
+                with_output=True,
+            )
+            if rng_key is None:
+                self._rng_key, rng_key = random.split(self._rng_key)
+            self._vi_state = self.inference.init(rng_key, **batch)
+        if self._fn_vi_update is None:
+            _, kwargs_extra = _group_kwargs(kwargs)
+            self._fn_vi_update = jit(
+                self.inference.update,
+                static_argnames=tuple(kwargs_extra._fields),
+            )
+
+        self._vi_state, loss = self._fn_vi_update(self._vi_state, **batch)
+
+        return self._vi_state, loss
+
+    def fit_on_batch(
+        self,
+        X: ArrayLike,
+        y: ArrayLike,
+        *,
+        num_steps: int = 10000,
+        num_samples: int = 1000,
+        rng_key: ArrayLike | None = None,
+        progress: bool = True,
+        **kwargs: object,
+    ) -> Self:
+        """Fit the impact model to the provided batch of data.
+
+        This method behaves differently depending on the inference method specified at
+        initialization of the ImpactModel instance:
+
+        - SVI
+            Runs variational inference on the provided batch by invoking the
+            :external:meth:`~numpyro.infer.svi.SVI.run` method of the
+            :external:class:`~numpyro.infer.svi.SVI` instance from NumPyro to
+            estimate the posterior distribution, then draws samples from it.
+
+        - MCMC
+            Runs posterior sampling by invoking the
+            :external:meth:`~numpyro.infer.mcmc.MCMC.run` method of the
+            :external:class:`~numpyro.infer.mcmc.MCMC` instance from NumPyro.
+
+        Args:
+            X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
+            y (ArrayLike): Output data with shape ``(n_samples_Y,)``.
+            num_steps: Number of steps for variational inference optimization. Has no
+                effect if the inference method is MCMC.
+            num_samples: The number of posterior samples to draw. Has no effect if the
+                inference method is MCMC.
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            progress: Whether to display a progress bar. Has no effect
+                if the inference method is MCMC.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
+
+        Returns:
+            The fitted model instance, enabling method chaining.
+
+        Note:
+            This method continues training from the existing SVI state if available. To
+            start training from scratch, create a new model instance.
+        """
+        X, y = _validate_X_y_to_jax(X, y)
+
+        # Validate the provided parameters against the kernel's signature
+        args_bound = (
+            signature(self.kernel)
+            .bind(**{self.param_input: X, self.param_output: y, **kwargs})
+            .arguments
+        )
+        self._build_kernel_spec(args_bound, with_output=True)
+        if rng_key is None:
+            self._rng_key, rng_key = random.split(self._rng_key)
+        rng_key, rng_subkey = random.split(rng_key)
+        if isinstance(self.inference, SVI):
+            self._num_samples = num_samples
+            logger.info("Performing variational inference optimization...")
+            self.vi_result = self.inference.run(
+                rng_subkey,
+                num_steps=num_steps,
+                progress_bar=progress,
+                init_state=self._vi_state,
+                **args_bound,
+            )
+            self._vi_state = self.vi_result.state
+            if np.any(np.isnan(self.vi_result.losses)):
+                warn(
+                    "Loss contains NaN or Inf, indicating numerical instability.",
+                    category=RuntimeWarning,
+                    stacklevel=2,
+                )
+            logger.info("Posterior sampling...")
+            rng_key, rng_subkey = random.split(rng_key)
+            self._posterior = _sample_forward(
+                substitute(self.inference.guide, data=self.vi_result.params),
+                rng_key=rng_subkey,
+                num_samples=self._num_samples,
+                return_sites=None,
+                samples=None,
+                model_kwargs=None,
+            )
+        elif isinstance(self.inference, MCMC):
+            logger.info("Posterior sampling...")
+            self.inference.run(rng_subkey, **args_bound)
+            self._posterior = device_get(self.inference.get_samples())
+            self._num_samples = (
+                next(iter(self.posterior.values())).shape[0] if self.posterior else 0
+            )
+
+        self._is_fitted = True
+
+        return self
+
+    def fit(
+        self,
+        X: ArrayLike | ArrayLoader,
+        y: ArrayLike | None = None,
+        *,
+        num_samples: int = 1000,
+        rng_key: ArrayLike | None = None,
+        progress: bool = True,
+        batch_size: int | None = None,
+        epochs: int = 1,
+        shuffle: bool = True,
+        **kwargs: object,
+    ) -> Self:
+        """Fit the impact model to the provided data using epoch-based training.
+
+        This method implements an epoch-based training loop, where the data is iterated
+        over in minibatches for a specified number of epochs. Variational inference is
+        performed by repeatedly updating the model parameters on each minibatch, and
+        then posterior samples are drawn from the fitted model.
+
+        Args:
+            X (ArrayLike | ArrayLoader): Input data, either an array-like of shape
+                ``(n_samples, n_features)`` or a data loader that holds all array-like
+                objects and handles batching internally.
+            y (ArrayLike | None): Output data with shape ``(n_samples_Y,)``. Must be
+                ``None`` if ``X`` is a data loader.
+            num_samples: The number of posterior samples to draw.
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            progress: Whether to display a progress bar.
+            batch_size: The number of data points processed at each step of variational
+                inference. If ``None``, the entire dataset is used as a single batch in
+                each epoch. Ignored if ``X`` is a data loader, in which case the data
+                loader is expected to handle batching internally.
+            epochs: The number of epochs for variational inference optimization.
+            shuffle: Whether to shuffle the data at each epoch.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
+
+        Returns:
+            The fitted model instance, enabling method chaining.
+
+        Raises:
+            TypeError: If the inference method is MCMC.
+
+        Note:
+            This method continues training from the existing SVI state if available.
+            To start training from scratch, create a new model instance. It does not
+            check whether the model or guide is written to support subsampling semantics
+            (e.g., using NumPyro's :external:func:`~numpyro.primitives.subsample` or
+            similar constructs).
+        """
+        if isinstance(self.inference, MCMC):
+            msg = (
+                "`.fit()` is not supported for MCMC inference. Use `.fit_on_batch()` "
+                "instead."
+            )
+            raise TypeError(msg)
+
+        self._num_samples = num_samples
+
+        if rng_key is None:
+            self._rng_key, rng_key = random.split(self._rng_key)
+
+        rng_key, rng_subkey = random.split(rng_key)
+        dataloader, kwargs_extra = _setup_inputs(
+            X=X,
+            y=y,
+            rng_key=rng_subkey,
+            batch_size=batch_size if batch_size is not None else len(cast("Sized", X)),
+            num_samples=num_samples,
+            shuffle=shuffle,
+            device=None,
+            **kwargs,
+        )
+
+        logger.info("Performing variational inference optimization...")
+        losses: list[float] = []
+        rng_key, rng_subkey = random.split(rng_key)
+        for epoch in range(epochs):
+            losses_epoch: list[float] = []
+            pbar = tqdm(
+                dataloader,
+                desc=f"Epoch {epoch + 1}/{epochs}",
+                total=len(dataloader),
+                disable=not progress,
+                dynamic_ncols=True,
+            )
+            for batch, _ in pbar:
+                self._vi_state, loss = self.train_on_batch(
+                    **batch,
+                    **kwargs_extra._asdict(),
+                    rng_key=rng_subkey,
+                )
+                loss_batch = device_get(loss)
+                losses_epoch.append(loss_batch)
+                pbar.set_postfix({"loss": f"{float(loss_batch):.4f}"})
+            losses_epoch_arr = jnp.stack(losses_epoch)
+            losses.extend(losses_epoch_arr)
+            tqdm.write(
+                f"Epoch {epoch + 1}/{epochs} - "
+                f"Average loss: {float(jnp.mean(losses_epoch_arr)):.4f}",
+            )
+        self.vi_result = SVIRunResult(
+            params=self.inference.get_params(self._vi_state),
+            state=self._vi_state,
+            losses=jnp.asarray(losses),
+        )
+        if np.any(np.isnan(self.vi_result.losses)):
+            msg = "Loss contains NaN or Inf, indicating numerical instability."
+            warn(msg, category=RuntimeWarning, stacklevel=2)
+
+        self._is_fitted = True
+
+        logger.info("Posterior sampling...")
+        rng_key, rng_subkey = random.split(rng_key)
+        self._posterior = _sample_forward(
+            substitute(self.inference.guide, data=self.vi_result.params),
+            rng_key=rng_subkey,
+            num_samples=self._num_samples,
+            return_sites=None,
+            samples=None,
+            model_kwargs=None,
+        )
+
+        return self
+
+    def is_fitted(self) -> bool:
+        """Check fitted status.
+
+        Returns:
+            `True` if the model is fitted, `False` otherwise.
+
+        """
+        return hasattr(self, "_is_fitted") and self._is_fitted
+
+    def set_posterior_sample(
+        self,
+        posterior_sample: dict[str, Array],
+        return_sites: tuple[str, ...] | None = None,
+    ) -> Self:
+        """Set posterior samples for the model.
+
+        This method sets externally obtained posterior samples on the model instance,
+        enabling downstream analysis without requiring a call to
+        :meth:`~aimz.ImpactModel.fit` or :meth:`~aimz.ImpactModel.fit_on_batch`.
+
+        It is primarily intended for workflows where posterior sampling is performed
+        manually—for example, using NumPyro's :external:class:`~numpyro.infer.svi.SVI`
+        (or :external:class:`~numpyro.infer.mcmc.MCMC`) with the
+        :external:class:`~numpyro.infer.util.Predictive` API—and the resulting
+        posterior samples are injected into the model for further use.
+
+        Internally, ``batch_ndims`` is set to ``1`` by default to correctly handle the
+        batch dimensions of the posterior samples. For more information, refer to the
+        `NumPyro documentation <https://num.pyro.ai/en/stable/utilities.html#predictive>`__.
+
+        Args:
+            posterior_sample: Posterior samples to set for the model.
+            return_sites: Names of variable (sites) to return in
+                :meth:`~aimz.ImpactModel.predict`. By default, it is set to
+                :attr:`~aimz.ImpactModel.param_output`.
+
+        Returns:
+            The model instance, treated as fitted with posterior samples set, enabling
+            method chaining.
+
+        Raises:
+            ValueError: If the batch shapes in ``posterior_sample`` are inconsistent.
+        """
+        batch_ndims = 1
+        batch_shapes = {
+            sample.shape[:batch_ndims] for sample in posterior_sample.values()
+        }
+        if len(batch_shapes) > 1:
+            msg = f"Inconsistent batch shapes found in posterior_sample: {batch_shapes}"
+            raise ValueError(msg)
+        (self._num_samples,) = batch_shapes.pop()
+        self._posterior = posterior_sample
+        self._return_sites = return_sites or (self.param_output,)
+        self._kernel_spec = KernelSpec(
+            traced=False,
+            return_sites=return_sites or (self.param_output,),
+            output_observed=False,
+        )
+        self._is_fitted = True
+
+        return self
+
+    def predict_on_batch(
+        self,
+        X: ArrayLike,
+        *,
+        intervention: dict | None = None,
+        rng_key: ArrayLike | None = None,
+        in_sample: bool = True,
+        return_sites: tuple[str, ...] | None = None,
+        return_datatree: bool = True,
+        **kwargs: object,
+    ) -> xr.DataTree | dict[str, npt.NDArray]:
+        """Predict the output based on the fitted model.
+
+        This method returns predictions for a single batch of input data and is better
+        suited for:
+
+            1) Models incompatible with :meth:`~aimz.ImpactModel.predict` due to their
+            posterior sample shapes.
+
+            2) Scenarios where writing results to to files (e.g., disk, cloud storage)
+            is not desired.
+
+            3) Smaller datasets, as this method may be slower due to limited
+            parallelism.
+
+        Args:
+            X (ArrayLike): Input data with shape ``(n_samples_X, n_features)``.
+            intervention: A dictionary mapping sample sites to their corresponding
+                intervention values. Interventions enable counterfactual analysis by
+                modifying the specified sample sites during prediction (posterior
+                predictive sampling).
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            in_sample: Specifies the group where posterior predictive samples are stored
+                in the returned output. If ``True``, samples are stored in the
+                ``posterior_predictive`` group, indicating they were generated based on
+                data used during model fitting. If ``False``, samples are stored in the
+                ``predictions`` group, indicating they were generated based on
+                out-of-sample data.
+            return_sites: Names of variables (sites) to return. If ``None``, samples
+                :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
+            return_datatree: If ``True``, return a :external:class:`~xarray.DataTree`;
+                otherwise return a :class:`dict`.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
+
+        Returns:
+            Posterior predictive samples. Posterior samples are included if available.
+
+        Raises:
+            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
+                argument.
+        """
+        _check_is_fitted(self)
+
+        X = cast("Array", _validate_X_y_to_jax(X))
+
+        # Validate the provided parameters against the kernel's signature
+        args_bound = (
+            signature(self.kernel).bind(**{self.param_input: X, **kwargs}).arguments
+        )
+        if self.param_output in args_bound:
+            msg = f"Specifying {self.param_output!r} is not allowed."
+            raise TypeError(msg)
+
+        if rng_key is None:
+            self._rng_key, rng_key = random.split(self._rng_key)
+
+        if intervention is None:
+            kernel = self.kernel
+        else:
+            rng_key, rng_subkey = random.split(rng_key)
+            kernel = seed(do(self.kernel, data=intervention), rng_seed=rng_subkey)
+
+        samples = device_get(
+            _sample_forward(
+                kernel,
+                rng_key=rng_key,
+                num_samples=self._num_samples,
+                return_sites=return_sites
+                or cast("KernelSpec", self._kernel_spec).return_sites,
+                samples=self.posterior,
+                model_kwargs=args_bound,
+            ),
+        )
+
+        if not return_datatree:
+            return samples
+
+        out = xr.DataTree(name="root")
+        if self.posterior:
+            out["posterior"] = _dict_to_datatree(self.posterior)
+        out["posterior_predictive" if in_sample else "predictions"] = _dict_to_datatree(
+            samples,
+        )
+
+        return out
+
+    def predict(
+        self,
+        X: ArrayLike | ArrayLoader,
+        *,
+        intervention: dict | None = None,
+        rng_key: ArrayLike | None = None,
+        in_sample: bool = True,
+        return_sites: tuple[str, ...] | None = None,
+        batch_size: int | None = None,
+        output_dir: str | Path | None = None,
+        progress: bool = True,
+        **kwargs: object,
+    ) -> xr.DataTree:
+        """Predict the output based on the fitted model.
+
+        This method performs posterior predictive sampling to generate model-based
+        predictions. It is optimized for batch processing of large input data and is not
+        recommended for use in loops that process only a few inputs at a time. Results
+        are written to disk in the Zarr format, with sampling and file writing decoupled
+        and executed concurrently.
+
+        Args:
+            X (ArrayLike | ArrayLoader): Input data, either an array-like of shape
+                ``(n_samples, n_features)`` or a data loader that holds all array-like
+                objects and handles batching internally.
+            intervention: A dictionary mapping sample sites to their corresponding
+                intervention values. Interventions enable counterfactual analysis by
+                modifying the specified sample sites during prediction (posterior
+                predictive sampling).
+            rng_key (ArrayLike | None): A pseudo-random number generator key. By
+                default, an internal key is used and split as needed.
+            in_sample: Specifies the group where posterior predictive samples are stored
+                in the returned output. If ``True``, samples are stored in the
+                ``posterior_predictive`` group, indicating they were generated based on
+                data used during model fitting. If ``False``, samples are stored in the
+                ``predictions`` group, indicating they were generated based on
+                out-of-sample data.
+            return_sites: Names of variables (sites) to return. If ``None``, samples
+                :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
+            batch_size: The batch size for data loading during posterior predictive
+                sampling. It also determines the chunk size used to store the samples.
+                If ``None``, it is determined automatically based on the input data
+                and number of samples. Ignored if ``X`` is a data loader, in which case
+                the data loader is expected to handle batching internally.
+            output_dir: The directory where the outputs will be saved. If the specified
+                directory does not exist, it will be created automatically. If ``None``,
+                a default temporary directory will be created. A timestamped
+                subdirectory will be generated within this directory to store the
+                outputs. Outputs are saved in the Zarr format.
+            progress: Whether to display a progress bar.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
+
+        Returns:
+            Posterior predictive samples. Posterior samples are included if available.
+
+        Raises:
+            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
+                argument.
+
+        See Also:
+            :meth:`~aimz.ImpactModel.cleanup` to remove the temporary directory if
+            created.
+        """
+        _check_is_fitted(self)
+
+        if isinstance(X, ArrayLike):
+            ndim_posterior_sample = 2
+            if self.posterior and any(
+                v.ndim == ndim_posterior_sample and v.shape[1] == len(cast("Sized", X))
+                for v in self.posterior.values()
+            ):
+                msg = (
+                    "One or more posterior sample shapes are not compatible with "
+                    "`.predict()` under sharded parallelism; falling back to "
+                    "`.predict_on_batch()`."
+                )
+                warn(msg, category=UserWarning, stacklevel=2)
+
+                return cast(
+                    "xr.DataTree",
+                    self.predict_on_batch(
+                        cast("ArrayLike", X),
+                        intervention=intervention,
+                        rng_key=rng_key,
+                        in_sample=in_sample,
+                        return_sites=return_sites
+                        or cast("KernelSpec", self._kernel_spec).return_sites,
+                        return_datatree=True,
+                        **kwargs,
+                    ),
+                )
+            # Validate the provided parameters against the kernel's signature
+            args_bound = (
+                signature(self.kernel).bind(**{self.param_input: X, **kwargs}).arguments
+            )
+            if self.param_output in args_bound:
+                msg = f"Specifying {self.param_output!r} is not allowed."
+                raise TypeError(msg)
+
+        if rng_key is None:
+            self._rng_key, rng_key = random.split(self._rng_key)
+
+        if intervention is None:
+            kernel = self.kernel
+        else:
+            rng_key, rng_subkey = random.split(rng_key)
+            kernel = seed(do(self.kernel, data=intervention), rng_seed=rng_subkey)
+
+        return_sites = (
+            return_sites or cast("KernelSpec", self._kernel_spec).return_sites
+        )
+
+        kwargs_array, kwargs_extra = _group_kwargs(kwargs)
+        if self._fn_sample_posterior_predictive is None:
+            self._fn_sample_posterior_predictive = _create_sharded_sampler(
+                self._mesh,
+                len(kwargs_array),
+                len(kwargs_extra),
+            )
+
+        output_dir, output_subdir = self._create_output_subdir(output_dir)
+
+        dataloader, _ = _setup_inputs(
+            X=X,
+            y=None,
+            rng_key=self.rng_key,
+            batch_size=batch_size,
+            num_samples=self._num_samples,
+            shuffle=False,
+            device=self._device,
+            **kwargs,
+        )
+
+        self._sample_and_write(
+            num_samples=self._num_samples,
+            rng_key=rng_key,
+            return_sites=return_sites,
+            output_dir=output_subdir,
+            kernel=kernel,
+            sampler=self._fn_sample_posterior_predictive,
+            samples=cast("dict[str, Array]", self.posterior),
+            dataloader=dataloader,
+            pbar=tqdm(
+                desc=(f"Posterior predictive sampling [{', '.join(return_sites)}]"),
+                total=len(dataloader),
+                disable=not progress,
+                dynamic_ncols=True,
+            ),
+            **kwargs,
+        )
+
+        ds = open_zarr(output_subdir, consolidated=False).expand_dims(
+            dim="chain",
+            axis=0,
+        )
+        ds = ds.assign_coords(
+            {k: np.arange(ds.sizes[k]) for k in ds.sizes},
+        ).assign_attrs(_make_attrs())
+        out = xr.DataTree(name="root")
+        if self.posterior:
+            out["posterior"] = _dict_to_datatree(self.posterior)
+        group = "posterior_predictive" if in_sample else "predictions"
+        out[group] = xr.DataTree(ds)
+        out[group].attrs["output_dir"] = str(output_subdir)
+        out.attrs["output_dir"] = str(output_dir)
+
+        return out
+
+    def estimate_effect(
+        self,
+        output_baseline: xr.DataTree | None = None,
+        output_intervention: xr.DataTree | None = None,
+        args_baseline: dict | None = None,
+        args_intervention: dict | None = None,
+    ) -> xr.DataTree:
+        """Estimate the effect of an intervention.
+
+        Args:
+            output_baseline: Precomputed output for the baseline scenario.
+            output_intervention: Precomputed output for the intervention scenario.
+            args_baseline: Input arguments for the baseline scenario. Passed to the
+                :meth:`~aimz.ImpactModel.predict` to compute predictions if
+                ``output_baseline`` is not provided. Ignored if ``output_baseline`` is
+                already given.
+            args_intervention: Input arguments for the intervention scenario. Passed to
+                the :meth:`~aimz.ImpactModel.predict` to compute predictions if
+                ``output_intervention`` is not provided. Ignored if
+                ``output_intervention`` is already given.
+
+        Returns:
+            The estimated impact of an intervention.
+
+        Raises:
+            ValueError: If neither ``output_baseline`` nor ``args_baseline`` is
+                provided, or if neither ``output_intervention`` nor
+                ``args_intervention`` is provided.
+
+        See Also:
+            :meth:`~aimz.ImpactModel.cleanup` to remove the temporary directory if
+            created.
+        """
+        _check_is_fitted(self)
+
+        if output_baseline:
+            dt_baseline = output_baseline
+        elif args_baseline:
+            dt_baseline = self.predict(**args_baseline)
+        else:
+            msg = "Either `output_baseline` or `args_baseline` must be provided."
+            raise ValueError(msg)
+
+        if output_intervention:
+            dt_intervention = output_intervention
+        elif args_intervention:
+            dt_intervention = self.predict(**args_intervention)
+        else:
+            msg = (
+                "Either `output_intervention` or `args_intervention` must be provided."
+            )
+            raise ValueError(msg)
+
+        group = _validate_group(dt_baseline, dt_intervention)
+
+        out = xr.DataTree(name="root")
+        out[group] = dt_intervention[group] - dt_baseline[group]
+
+        return out
+
+    def log_likelihood(
+        self,
+        X: ArrayLike | ArrayLoader,
+        y: ArrayLike | None = None,
+        *,
+        batch_size: int | None = None,
+        output_dir: str | Path | None = None,
+        progress: bool = True,
+        **kwargs: object,
+    ) -> xr.DataTree:
+        """Compute the log-likelihood of the data under the given model.
+
+        Results are written to disk in the Zarr format, with computing and file writing
+        decoupled and executed concurrently.
+
+        Args:
+            X (ArrayLike | ArrayLoader): Input data, either an array-like of shape
+                ``(n_samples, n_features)`` or a data loader that holds all array-like
+                objects and handles batching internally.
+            y (ArrayLike | None): Output data with shape ``(n_samples_Y,)``. Must be
+                ``None`` if ``X`` is a data loader.
+            batch_size: The batch size for data loading during log-likelihood
+                computation. It also determines the chunk size used to store the
+                samples. If ``None``, it is determined automatically based on the input
+                data and number of samples. Ignored if ``X`` is a data loader, in which
+                case the data loader is expected to handle batching internally.
+            output_dir: The directory where the outputs will be saved. If the specified
+                directory does not exist, it will be created automatically. If ``None``,
+                a default temporary directory will be created. A timestamped
+                subdirectory will be generated within this directory to store the
+                outputs. Outputs are saved in the Zarr format.
+            progress: Whether to display a progress bar.
+            **kwargs: Additional arguments passed to the model. All array-like values
+                are expected to be JAX arrays.
+
+        Returns:
+            Log-likelihood values. Posterior samples are included if available.
+
+        See Also:
+            :meth:`~aimz.ImpactModel.cleanup` to remove the temporary directory if
+            created.
+        """
+        _check_is_fitted(self)
+
+        kwargs_array, kwargs_extra = _group_kwargs(kwargs)
+        if self._fn_log_likelihood is None:
+            self._fn_log_likelihood = _create_sharded_log_likelihood(
+                self._mesh,
+                len(kwargs_array),
+                len(kwargs_extra),
+            )
+
+        output_dir, output_subdir = self._create_output_subdir(output_dir)
+
+        dataloader, _ = _setup_inputs(
+            X=X,
+            y=y,
+            rng_key=self.rng_key,
+            batch_size=batch_size,
+            num_samples=self._num_samples,
+            shuffle=False,
+            device=self._device,
+            **kwargs,
+        )
+
+        site = self.param_output
+        pbar = tqdm(
+            desc=(f"Computing log-likelihood of {site}..."),
+            total=len(dataloader),
+            disable=not progress,
+            dynamic_ncols=True,
+        )
+
+        zarr_group = open_group(output_subdir, mode="w")
+        zarr_arr = {}
+        threads, queues, error_queue = _start_writer_threads(
+            (site,),
+            group_path=output_subdir,
+            writer=_writer,
+            queue_size=min(cpu_count() or 1, 4),
+        )
+        try:
+            for batch, n_pad in dataloader:
+                kwargs_batch = [
+                    v
+                    for k, v in batch.items()
+                    if k not in (self.param_input, self.param_output)
+                ]
+                arr = device_get(
+                    self._fn_log_likelihood(
+                        # Although computing the log-likelihood is deterministic, the
+                        # model still needs to be seeded in order to trace its graph.
+                        seed(self.kernel, rng_seed=self.rng_key),
+                        self.posterior,
+                        self.param_input,
+                        site,
+                        kwargs_array._fields + kwargs_extra._fields,
+                        batch[self.param_input],
+                        batch[self.param_output],
+                        *(*kwargs_batch, *kwargs_extra),
+                    ),
+                )
+                if site not in zarr_arr:
+                    draws = self._num_samples if self.posterior else 1
+                    zarr_arr[site] = zarr_group.create_array(
+                        name=site,
+                        shape=(draws, 0, *arr.shape[2:]),
+                        dtype="float32" if arr.dtype == "bfloat16" else arr.dtype,
+                        chunks=(draws, dataloader.batch_size, *arr.shape[2:]),
+                        dimension_names=(
+                            "draw",
+                            *tuple(f"{site}_dim_{i}" for i in range(arr.ndim - 1)),
+                        ),
+                    )
+                queues[site].put(arr[:, : -n_pad or None])
+                if not error_queue.empty():
+                    _, exc, tb = error_queue.get()
+                    raise exc.with_traceback(tb)
+                pbar.update()
+            pbar.set_description("Computation complete, writing in progress...")
+            _shutdown_writer_threads(threads, queues=queues)
+        except:
+            _shutdown_writer_threads(threads, queues=queues)
+            logger.exception(
+                "Exception encountered. Cleaning up output directory: %s",
+                output_subdir,
+            )
+            rmtree(output_subdir, ignore_errors=True)
+            raise
+        finally:
+            pbar.close()
+
+        ds = open_zarr(output_subdir, consolidated=False).expand_dims(
+            dim="chain",
+            axis=0,
+        )
+        ds = ds.assign_coords(
+            {k: np.arange(ds.sizes[k]) for k in ds.sizes},
+        ).assign_attrs(_make_attrs())
+        out = xr.DataTree(name="root")
+        if self.posterior:
+            out["posterior"] = _dict_to_datatree(self.posterior)
+        out["log_likelihood"] = xr.DataTree(ds)
+        out["log_likelihood"].attrs["output_dir"] = str(output_subdir)
+        out.attrs["output_dir"] = str(output_dir)
+
+        return out
+
+    def cleanup(self) -> None:
+        """Clean up the temporary directory created for storing outputs.
+
+        If the temporary directory was never created or has already been cleaned up,
+        this method does nothing. It does not delete any explicitly specified output
+        directory. While the temporary directory is typically removed automatically
+        during garbage collection, this behavior is not guaranteed. Therefore, calling
+        this method explicitly is recommended to ensure timely resource release.
+        """
+        if hasattr(self, "_temp_dir") and self._temp_dir is not None:
+            logger.info("Temporary directory cleaned up at: %s", self._temp_dir.name)
+            self._temp_dir.cleanup()
+            self._temp_dir = None

--- a/aimz/model/kernel_spec.py
+++ b/aimz/model/kernel_spec.py
@@ -1,0 +1,45 @@
+# Copyright 2025 Eli Lilly and Company
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dataclass for kernel metadata."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class KernelSpec:
+    """A dataclass describing the kernel structure.
+
+    Stores only the minimal information needed for downstream operations without
+    re-tracing the NumPyro model.
+
+    Attributes:
+        traced:
+            ``True`` once at least one successful trace has been performed.
+        return_sites:
+            Default return site names. Always includes the output first, followed by any
+            deterministic sites. Latent sample sites are excluded.
+        output_observed:
+            ``True`` if the output site was observed in the validating trace, used to
+            distinguish prior-only from observed traces.
+
+    Notes:
+        Re-tracing only upgrades a prior-only spec (``output_observed`` is ``False``) to
+        one that includes an observed output; the user kernel is assumed immutable after
+        construction.
+    """
+
+    traced: bool
+    return_sites: tuple[str, ...]
+    output_observed: bool

--- a/aimz/sampling/_forward.py
+++ b/aimz/sampling/_forward.py
@@ -22,16 +22,16 @@ from numpyro.handlers import mask, seed, substitute, trace
 
 if TYPE_CHECKING:
     from collections import OrderedDict
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
 
 
 def _sample_forward(
     model: "Callable",
     num_samples: int,
     rng_key: ArrayLike,
-    return_sites: tuple[str] | None,
+    return_sites: tuple[str, ...] | None,
     samples: dict[str, Array] | None,
-    model_kwargs: dict[str, Array] | None,
+    model_kwargs: "Mapping[str, object] | None",
 ) -> dict[str, Array]:
     """Generates forward samples from a model conditioned on parameter draws.
 

--- a/aimz/utils/_output.py
+++ b/aimz/utils/_output.py
@@ -74,7 +74,7 @@ def _writer(site: str, queue: Queue, group_path: Path, error_queue: Queue) -> No
 
 
 def _start_writer_threads(
-    sites: tuple[str],
+    sites: tuple[str, ...],
     group_path: Path,
     writer: "Callable[[str, Queue, Path, Queue], None]",
     queue_size: int,

--- a/aimz/utils/_validation.py
+++ b/aimz/utils/_validation.py
@@ -132,8 +132,10 @@ def _validate_kernel_signature(
 
 def _validate_kernel_body(
     kernel: "Callable",
+    *,
     param_output: str,
     model_trace: "OrderedDict[str, dict]",
+    with_output: bool,
 ) -> None:
     """Validate the body of a kernel function.
 
@@ -141,6 +143,7 @@ def _validate_kernel_body(
         kernel: The kernel function to validate.
         param_output: Name of the parameter in ``kernel`` corresponding to the output.
         model_trace: The model trace containing the sites.
+        with_output: Whether the kernel is expected to have observed output.
 
     Raises:
         KernelValidationError: If the kernel body does not meet the required
@@ -161,7 +164,7 @@ def _validate_kernel_body(
     if site["type"] != "sample":
         msg = f"Expected {param_output!r} to have type 'sample', got {site['type']!r}."
         raise KernelValidationError(msg)
-    if not site.get("is_observed", False):
+    if with_output and not site.get("is_observed", False):
         msg = (
             f"{param_output!r} must be observed (i.e., defined with `obs=` in the "
             "kernel)."

--- a/aimz/utils/data/_input_setup.py
+++ b/aimz/utils/data/_input_setup.py
@@ -25,6 +25,8 @@ from aimz.utils._kwargs import _group_kwargs
 from aimz.utils.data import ArrayDataset, ArrayLoader
 
 if TYPE_CHECKING:
+    from collections.abc import Sized
+
     from jax.sharding import Sharding
 
 logger = logging.getLogger(__name__)
@@ -78,8 +80,8 @@ def _setup_inputs(
             X, y = check_X_y(X, y, force_writeable=True, y_numeric=True)
         num_devices = device.num_devices if device else 1
         if batch_size is None:
-            if len(X) * num_samples < MAX_ELEMENTS:
-                batch_size = len(X)
+            if len(cast("Sized", X)) * num_samples < MAX_ELEMENTS:
+                batch_size = len(cast("Sized", X))
             else:
                 batch_size = MAX_ELEMENTS // num_samples
                 batch_size -= batch_size % num_devices

--- a/aimz/utils/data/_sharding.py
+++ b/aimz/utils/data/_sharding.py
@@ -51,14 +51,14 @@ def _create_sharded_sampler(
 
     Returns:
         A sharded function that takes the following arguments:
-            - rng_key (Array): A pseudo-random number generator key.
+            - rng_key (ArrayLike): A pseudo-random number generator key.
             - kernel (Callable): A probabilistic model with NumPyro primitives.
             - samples (dict): A dictionary of samples to condition on.
             - batch_shape (tuple[int]): The shape of the batch dimension, specifically
                 ``(num_samples,)``.
             - param_input (str): The name of the parameter in the ``kernel`` for the
                 input data.
-            - kwargs_key (tuple[str]): A tuple of keyword argument names.
+            - kwargs_key (tuple[str, ...]): A tuple of keyword argument names.
             - X (Array): Input data.
             - *args (tuple): Additional arguments constructed from the original keyword
                 arguments (both sharded and non-sharded).
@@ -69,12 +69,12 @@ def _create_sharded_sampler(
         kernel: "Callable",
         num_samples: int,
         rng_key: ArrayLike,
-        return_sites: tuple[str],
+        return_sites: tuple[str, ...],
         samples: dict[str, Array],
         param_input: str,
-        kwargs_key: tuple[str],
+        kwargs_key: tuple[str, ...],
         X: Array,
-        *args: ArrayLike,
+        *args: object,
     ) -> dict[str, Array]:
         return _sample_forward(
             model=kernel,
@@ -158,7 +158,7 @@ def _create_sharded_log_likelihood(
                 input data.
             - param_output (str): The name of the parameter in the ``kernel`` for the
                 output data.
-            - kwargs_key (tuple[str]): A tuple of keyword argument names.
+            - kwargs_key (tuple[str, ...]): A tuple of keyword argument names.
             - X (Array): Input data.
             - y (Array): Output data.
             - *args (tuple): Additional arguments constructed from the original keyword
@@ -171,7 +171,7 @@ def _create_sharded_log_likelihood(
         posterior_samples: dict,
         param_input: str,
         param_output: str,
-        kwargs_key: tuple[str],
+        kwargs_key: tuple[str, ...],
         X: Array,
         y: Array,
         *args: tuple,

--- a/aimz/utils/data/array_dataset.py
+++ b/aimz/utils/data/array_dataset.py
@@ -14,9 +14,14 @@
 
 """Module for custom dataset for JAX arrays."""
 
+from typing import TYPE_CHECKING, cast
+
 import jax.numpy as jnp
 from jax import Array
 from jax.typing import ArrayLike
+
+if TYPE_CHECKING:
+    from collections.abc import Sized
 
 
 class ArrayDataset:
@@ -38,7 +43,7 @@ class ArrayDataset:
         if not arrays:
             msg = "At least one array must be provided."
             raise ValueError(msg)
-        lengths = {len(arr) for arr in arrays.values()}
+        lengths = {len(cast("Sized", arr)) for arr in arrays.values()}
         if len(lengths) != 1:
             msg = "All arrays must have the same length."
             raise ValueError(msg)

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -8,6 +8,7 @@ API Reference
 .. toctree::
    :maxdepth: 1
 
+   api/kernel_spec
    api/impact_model
    api/array_dataset
    api/array_loader

--- a/docs/source/api/impact_model.rst
+++ b/docs/source/api/impact_model.rst
@@ -16,6 +16,7 @@ Attributes
    :toctree: generated/
 
    ImpactModel.kernel
+   ImpactModel.kernel_spec
    ImpactModel.rng_key
    ImpactModel.param_input
    ImpactModel.param_output

--- a/docs/source/api/kernel_spec.rst
+++ b/docs/source/api/kernel_spec.rst
@@ -1,0 +1,6 @@
+.. currentmodule:: aimz.model
+
+KernelSpec
+==========
+
+.. autoclass:: KernelSpec

--- a/docs/source/development/contributing.rst
+++ b/docs/source/development/contributing.rst
@@ -69,7 +69,7 @@ All public APIs should have Google-style docstrings.
 For larger additions:
 
 * Add or extend documentation under ``docs/source/``.
-* Use cross references for API objects, e.g. ``:py:meth:`~aimz.ImpactModel.predict```.
+* Use cross references for API objects, e.g. ``:meth:`~aimz.ImpactModel.predict```.
 * Build the Sphinx docs locally (requires ``[docs]`` extra)::
 
    uv pip install -e ."[docs]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-dev = ["cloudpickle>=3", "pytest>=8.4", "pytest-cov>=7"]
+dev = ["pre-commit>=4.3", "pytest>=8.4", "pytest-cov>=7", "ruff>=0.13"]
 gpu = ["jax[cuda12]>=0.7"]
 mlflow = ["mlflow>=3"]
 docs = [
@@ -43,7 +43,6 @@ docs = [
     "sphinx-design>=0.6",
     "pydata-sphinx-theme>=0.16",
     "mlflow>=3",
-    "cloudpickle>=3",
     "arviz-plots[matplotlib]>=0.6",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -34,13 +34,13 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "cloudpickle" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 docs = [
     { name = "arviz-plots", extra = ["matplotlib"] },
-    { name = "cloudpickle" },
     { name = "jupyter-sphinx" },
     { name = "mlflow" },
     { name = "myst-parser" },
@@ -59,8 +59,6 @@ mlflow = [
 [package.metadata]
 requires-dist = [
     { name = "arviz-plots", extras = ["matplotlib"], marker = "extra == 'docs'", specifier = ">=0.6" },
-    { name = "cloudpickle", marker = "extra == 'dev'", specifier = ">=3" },
-    { name = "cloudpickle", marker = "extra == 'docs'", specifier = ">=3" },
     { name = "dask", specifier = ">=2025.5" },
     { name = "jax", specifier = ">=0.7" },
     { name = "jax", extras = ["cuda12"], marker = "extra == 'gpu'", specifier = ">=0.7" },
@@ -69,9 +67,11 @@ requires-dist = [
     { name = "mlflow", marker = "extra == 'mlflow'", specifier = ">=3" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0" },
     { name = "numpyro", specifier = ">=0.19.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.3" },
     { name = "pydata-sphinx-theme", marker = "extra == 'docs'", specifier = ">=0.16" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.13" },
     { name = "scikit-learn", specifier = ">=1.6.1" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.2" },
     { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5" },
@@ -315,6 +315,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469, upload-time = "2024-09-04T20:44:41.616Z" },
     { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475, upload-time = "2024-09-04T20:44:43.733Z" },
     { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009, upload-time = "2024-09-04T20:44:45.309Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
 ]
 
 [[package]]
@@ -675,7 +684,7 @@ wheels = [
 
 [[package]]
 name = "dask"
-version = "2025.9.0"
+version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -687,9 +696,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "toolz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/40/7376a4bbcb2fe336460774bcf8d5aaee6e2b67a234c96a66decb9f87b91e/dask-2025.9.0.tar.gz", hash = "sha256:37a3e73f3bba43e2b9de38a33b315c18a881d2108aba078685bab8e5c2cff7a0", size = 10972916, upload-time = "2025-09-10T10:16:10.49Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/87/87af914aaf5bfaa0ee8b9da060a836477d8cc49fe4978637da8b6a47d8a3/dask-2025.9.1.tar.gz", hash = "sha256:718df73e1fd3d7e2b8546e0f04ce08e1ed7f9aa3da1eecd0c1f44c8b6d52f7e0", size = 10973663, upload-time = "2025-09-16T10:54:59.452Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/56/55dda22a8dbe291032735f7025dd69d9a70e4c440279ae98cc7c3888aa70/dask-2025.9.0-py3-none-any.whl", hash = "sha256:cb8d74476dda10c558234c02d1639386cc5c9cef0252245cf77043fb1f2495d1", size = 1477763, upload-time = "2025-09-10T10:16:06.474Z" },
+    { url = "https://files.pythonhosted.org/packages/25/60/3fcd548bed6d25016933e4b2984c9b82e4c1e760380e03d4100b1b4726e0/dask-2025.9.1-py3-none-any.whl", hash = "sha256:2a8a7dc933caaea2f47745a65a6ec93d9e616e12aab53b4f03ee161d31939110", size = 1479274, upload-time = "2025-09-16T10:54:46.159Z" },
 ]
 
 [[package]]
@@ -742,6 +751,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
 ]
 
 [[package]]
@@ -812,6 +830,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
+]
+
+[[package]]
 name = "flask"
 version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -879,11 +906,11 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2025.7.0"
+version = "2025.9.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8b/02/0835e6ab9cfc03916fe3f78c0956cfcdb6ff2669ffa6651065d5ebf7fc98/fsspec-2025.7.0.tar.gz", hash = "sha256:786120687ffa54b8283d942929540d8bc5ccfa820deb555a2b5d0ed2b737bf58", size = 304432, upload-time = "2025-07-15T16:05:21.19Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/e0/bab50af11c2d75c9c4a2a26a5254573c0bd97cea152254401510950486fa/fsspec-2025.9.0.tar.gz", hash = "sha256:19fd429483d25d28b65ec68f9f4adc16c17ea2c7c7bf54ec61360d478fb19c19", size = 304847, upload-time = "2025-09-02T19:10:49.215Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/e0/014d5d9d7a4564cf1c40b5039bc882db69fd881111e03ab3657ac0b218e2/fsspec-2025.7.0-py3-none-any.whl", hash = "sha256:8b012e39f63c7d5f10474de957f3ab793b47b45ae7d39f2fb735f8bbe25c0e21", size = 199597, upload-time = "2025-07-15T16:05:19.529Z" },
+    { url = "https://files.pythonhosted.org/packages/47/71/70db47e4f6ce3e5c37a607355f80da8860a33226be640226ac52cb05ef2e/fsspec-2025.9.0-py3-none-any.whl", hash = "sha256:530dc2a2af60a414a832059574df4a6e10cce927f6f4a78209390fe38955cfb7", size = 199289, upload-time = "2025-09-02T19:10:47.708Z" },
 ]
 
 [[package]]
@@ -1021,6 +1048,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/c4/62963f25a678f6a050fb0505a65e9e726996171e6dbe1547f79619eefb15/identify-2.6.14.tar.gz", hash = "sha256:663494103b4f717cb26921c52f8751363dc89db64364cd836a9bf1535f53cd6a", size = 99283, upload-time = "2025-09-06T19:30:52.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ae/2ad30f4652712c82f1c23423d79136fbce338932ad166d70c1efb86a5998/identify-2.6.14-py2.py3-none-any.whl", hash = "sha256:11a073da82212c6646b1f39bb20d4483bfb9543bd5566fec60053c4bb309bf2e", size = 99172, upload-time = "2025-09-06T19:30:51.759Z" },
 ]
 
 [[package]]
@@ -1874,6 +1910,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
+]
+
+[[package]]
 name = "numba"
 version = "0.61.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2360,6 +2405,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/29/7cf5bbc236333876e4b41f56e06857a87937ce4bf91e117a6991a2dbb02a/pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16", size = 193792, upload-time = "2025-08-09T18:56:14.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/a5/987a405322d78a73b66e39e4a90e4ef156fd7141bf71df987e50717c321b/pre_commit-4.3.0-py2.py3-none-any.whl", hash = "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8", size = 220965, upload-time = "2025-08-09T18:56:13.192Z" },
 ]
 
 [[package]]
@@ -2925,6 +2986,32 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/33/c8e89216845615d14d2d42ba2bee404e7206a8db782f33400754f3799f05/ruff-0.13.1.tar.gz", hash = "sha256:88074c3849087f153d4bb22e92243ad4c1b366d7055f98726bc19aa08dc12d51", size = 5397987, upload-time = "2025-09-18T19:52:44.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/41/ca37e340938f45cfb8557a97a5c347e718ef34702546b174e5300dbb1f28/ruff-0.13.1-py3-none-linux_armv6l.whl", hash = "sha256:b2abff595cc3cbfa55e509d89439b5a09a6ee3c252d92020bd2de240836cf45b", size = 12304308, upload-time = "2025-09-18T19:51:56.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/84/ba378ef4129415066c3e1c80d84e539a0d52feb250685091f874804f28af/ruff-0.13.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4ee9f4249bf7f8bb3984c41bfaf6a658162cdb1b22e3103eabc7dd1dc5579334", size = 12937258, upload-time = "2025-09-18T19:52:00.184Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b6/ec5e4559ae0ad955515c176910d6d7c93edcbc0ed1a3195a41179c58431d/ruff-0.13.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5c5da4af5f6418c07d75e6f3224e08147441f5d1eac2e6ce10dcce5e616a3bae", size = 12214554, upload-time = "2025-09-18T19:52:02.753Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d6/cb3e3b4f03b9b0c4d4d8f06126d34b3394f6b4d764912fe80a1300696ef6/ruff-0.13.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:80524f84a01355a59a93cef98d804e2137639823bcee2931f5028e71134a954e", size = 12448181, upload-time = "2025-09-18T19:52:05.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ea/bf60cb46d7ade706a246cd3fb99e4cfe854efa3dfbe530d049c684da24ff/ruff-0.13.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ff7f5ce8d7988767dd46a148192a14d0f48d1baea733f055d9064875c7d50389", size = 12104599, upload-time = "2025-09-18T19:52:07.497Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/3e/05f72f4c3d3a69e65d55a13e1dd1ade76c106d8546e7e54501d31f1dc54a/ruff-0.13.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c55d84715061f8b05469cdc9a446aa6c7294cd4bd55e86a89e572dba14374f8c", size = 13791178, upload-time = "2025-09-18T19:52:10.189Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e7/01b1fc403dd45d6cfe600725270ecc6a8f8a48a55bc6521ad820ed3ceaf8/ruff-0.13.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:ac57fed932d90fa1624c946dc67a0a3388d65a7edc7d2d8e4ca7bddaa789b3b0", size = 14814474, upload-time = "2025-09-18T19:52:12.866Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/92/d9e183d4ed6185a8df2ce9faa3f22e80e95b5f88d9cc3d86a6d94331da3f/ruff-0.13.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c366a71d5b4f41f86a008694f7a0d75fe409ec298685ff72dc882f882d532e36", size = 14217531, upload-time = "2025-09-18T19:52:15.245Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4a/6ddb1b11d60888be224d721e01bdd2d81faaf1720592858ab8bac3600466/ruff-0.13.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f4ea9d1b5ad3e7a83ee8ebb1229c33e5fe771e833d6d3dcfca7b77d95b060d38", size = 13265267, upload-time = "2025-09-18T19:52:17.649Z" },
+    { url = "https://files.pythonhosted.org/packages/81/98/3f1d18a8d9ea33ef2ad508f0417fcb182c99b23258ec5e53d15db8289809/ruff-0.13.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0f70202996055b555d3d74b626406476cc692f37b13bac8828acff058c9966a", size = 13243120, upload-time = "2025-09-18T19:52:20.332Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/86/b6ce62ce9c12765fa6c65078d1938d2490b2b1d9273d0de384952b43c490/ruff-0.13.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:f8cff7a105dad631085d9505b491db33848007d6b487c3c1979dd8d9b2963783", size = 13443084, upload-time = "2025-09-18T19:52:23.032Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/6e/af7943466a41338d04503fb5a81b2fd07251bd272f546622e5b1599a7976/ruff-0.13.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9761e84255443316a258dd7dfbd9bfb59c756e52237ed42494917b2577697c6a", size = 12295105, upload-time = "2025-09-18T19:52:25.263Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/97/0249b9a24f0f3ebd12f007e81c87cec6d311de566885e9309fcbac5b24cc/ruff-0.13.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:3d376a88c3102ef228b102211ef4a6d13df330cb0f5ca56fdac04ccec2a99700", size = 12072284, upload-time = "2025-09-18T19:52:27.478Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/85/0b64693b2c99d62ae65236ef74508ba39c3febd01466ef7f354885e5050c/ruff-0.13.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:cbefd60082b517a82c6ec8836989775ac05f8991715d228b3c1d86ccc7df7dae", size = 12970314, upload-time = "2025-09-18T19:52:30.212Z" },
+    { url = "https://files.pythonhosted.org/packages/96/fc/342e9f28179915d28b3747b7654f932ca472afbf7090fc0c4011e802f494/ruff-0.13.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:dd16b9a5a499fe73f3c2ef09a7885cb1d97058614d601809d37c422ed1525317", size = 13422360, upload-time = "2025-09-18T19:52:32.676Z" },
+    { url = "https://files.pythonhosted.org/packages/37/54/6177a0dc10bce6f43e392a2192e6018755473283d0cf43cc7e6afc182aea/ruff-0.13.1-py3-none-win32.whl", hash = "sha256:55e9efa692d7cb18580279f1fbb525146adc401f40735edf0aaeabd93099f9a0", size = 12178448, upload-time = "2025-09-18T19:52:35.545Z" },
+    { url = "https://files.pythonhosted.org/packages/64/51/c6a3a33d9938007b8bdc8ca852ecc8d810a407fb513ab08e34af12dc7c24/ruff-0.13.1-py3-none-win_amd64.whl", hash = "sha256:3a3fb595287ee556de947183489f636b9f76a72f0fa9c028bdcabf5bab2cc5e5", size = 13286458, upload-time = "2025-09-18T19:52:38.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/04/afc078a12cf68592345b1e2d6ecdff837d286bac023d7a22c54c7a698c5b/ruff-0.13.1-py3-none-win_arm64.whl", hash = "sha256:c0bae9ffd92d54e03c2bf266f466da0a65e145f298ee5b5846ed435f6a00518a", size = 12437893, upload-time = "2025-09-18T19:52:41.283Z" },
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3417,6 +3504,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/42/e0e305207bb88c6b8d3061399c6a961ffe5fbb7e2aa63c9234df7259e9cd/uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01", size = 78473, upload-time = "2025-06-28T16:15:46.058Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a", size = 66406, upload-time = "2025-06-28T16:15:44.816Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "20.34.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz", hash = "sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a", size = 6003808, upload-time = "2025-08-13T14:24:07.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/06/04c8e804f813cf972e3262f3f8584c232de64f0cde9f703b46cf53a45090/virtualenv-20.34.0-py3-none-any.whl", hash = "sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026", size = 5983279, upload-time = "2025-08-13T14:24:05.111Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Introduce the `KernelSpec` dataclass to encapsulate kernel structure metadata, allowing the `ImpactModel` to cache kernel specifications and avoid redundant model tracing during training and prediction. Update documentation and tests to reflect these changes and ensure proper validation of kernels without output sites. Improve type hints and update dependencies for better clarity and consistency.

Fixes #98