### PR TITLE
Remove `return_sites` parameter from `set_posterior_sample` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `output_dir` attribute to the root and group nodes of {class}`xarray.DataTree` objects returned by {meth}`~aimz.ImpactModel.sample_prior_predictive`, {meth}`~aimz.ImpactModel.predict`, and {meth}`~aimz.ImpactModel.log_likelihood`, specifying the directory where results are saved ([#85](https://github.com/markean/aimz/issues/85)).
-
 - Introduced the public {class}`~aimz.model.KernelSpec` dataclass and the {attr}`~aimz.ImpactModel.kernel_spec` attribute on {class}`~aimz.ImpactModel`.
 This exposes a lazily-built, cached structural specification of the user kernel (fields: ``traced``, ``return_sites``, ``output_observed``) so training and predictive methods avoid redundant model tracing ([#98](https://github.com/markean/aimz/issues/98)).
 
@@ -19,6 +18,8 @@ This exposes a lazily-built, cached structural specification of the user kernel 
 - All `tqdm` progress bars now use `dynamic_ncols=True` to adjust column width dynamically ([#93](https://github.com/markean/aimz/issues/93)).
 
 - {meth}`~aimz.ImpactModel.fit_on_batch`, {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch`, {meth}`~aimz.ImpactModel.sample_prior_predictive`, and {meth}`~aimz.ImpactModel.train_on_batch` now reuse the cached {attr}`~aimz.ImpactModel.kernel_spec` and avoid redundant model tracing ([#98](https://github.com/markean/aimz/issues/98)).
+- {meth}`~aimz.ImpactModel.set_posterior_sample` now raises an error when an empty posterior dictionary (`{}`) is provided.
+- {meth}`~aimz.ImpactModel.set_posterior_sample` no longer accepts a `return_sites` parameter; downstream methods can now set it explicitly.
 
 ### Fixed
 
@@ -33,7 +34,6 @@ This exposes a lazily-built, cached structural specification of the user kernel 
 ### Changed
 
 - Methods in {class}`~aimz.ImpactModel` now automatically determine the `batch_size` if it is not provided, based on the input data and number of samples ([#70](https://github.com/markean/aimz/issues/70)).
-
 - {meth}`~aimz.ImpactModel.sample_posterior_predictive_on_batch` and {meth}`~aimz.ImpactModel.sample_posterior_predictive` no longer accept the `in_sample` argument. Results are now always written to the `posterior_predictive` group.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This exposes a lazily-built, cached structural specification of the user kernel 
 ### Added
 
 - {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch`, {meth}`~aimz.ImpactModel.sample`, {meth}`~aimz.ImpactModel.sample_posterior_predictive_on_batch`, and {meth}`~aimz.ImpactModel.predict_on_batch` methods in {class}`~aimz.ImpactModel` now support a `return_datatree` parameter. When set to `True` (by default), results are returned as an {class}`xarray.DataTree`; otherwise, a `dict` is returned ([#74](https://github.com/markean/aimz/issues/74)).
+- MLflow integration for {class}`~aimz.ImpactModel` ([#71](https://github.com/markean/aimz/issues/71)).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 [![DOI](https://zenodo.org/badge/1009062911.svg)](https://doi.org/10.5281/zenodo.16101876)
 
 [**Installation**](https://aimz.readthedocs.io/stable/getting_started/installation.html) |
-[**Documentation**](https://aimz.readthedocs.io/)
+[**Documentation**](https://aimz.readthedocs.io/) |
+[**Changelog**](https://aimz.readthedocs.io/latest/changelog.html)
 
 ## Overview
 

--- a/docs/source/user_guide/disk_and_on_batch.rst
+++ b/docs/source/user_guide/disk_and_on_batch.rst
@@ -12,8 +12,8 @@ Disk-Backed vs. On-Batch Methods
 
 This page explains and compares the two complementary execution styles provided by :class:`~aimz.ImpactModel`:
 
-* **Disk-backed** (default) methods iterate over the input in chunks, materialize results incrementally, and persist structured artifacts (Zarr‑backed :external:py:class:`xarray.DataTree` plus metadata) to a temporary or user-specified output directory.
-* **On-batch** (``*_on_batch`` suffix) methods execute a single, fully in-memory pass and can optionally return a plain :class:`dict` instead of a :external:py:class:`xarray.DataTree`. The naming mirrors the Keras convention to signal an immediate, single-batch, memory-resident operation.
+* **Disk-backed** (default) methods iterate over the input in chunks, materialize results incrementally, and persist structured artifacts (Zarr‑backed :external:class:`xarray.DataTree` plus metadata) to a temporary or user-specified output directory.
+* **On-batch** (``*_on_batch`` suffix) methods execute a single, fully in-memory pass and can optionally return a plain :class:`dict` instead of a :external:class:`xarray.DataTree`. The naming mirrors the Keras convention to signal an immediate, single-batch, memory-resident operation.
 
 
 Why Disk-Backed by Default
@@ -24,7 +24,7 @@ The non-``*_on_batch`` methods default to a disk-backed (chunked) execution mode
   Even moderate increases in any axis (time, spatial units, parameter samples) can exceed host or accelerator RAM.
 * Using ``batch_size`` with chunked iteration limits peak memory and prevents out-of-memory errors.
 * Persisted Zarr arrays with metadata (coords, dims, attrs) create an artifact you can reopen without rerunning inference.
-* The :external:py:class:`xarray.DataTree` + Zarr format integrates with scientific Python tools such as Dask_ and ArviZ_.
+* The :external:class:`xarray.DataTree` + Zarr format integrates with scientific Python tools such as Dask_ and ArviZ_.
 * Summaries (means, HDIs, residual PPC stats) can be computed lazily over chunked storage without first materializing dense arrays.
 * One API works for both small experiments and large-scale use cases.
 
@@ -33,7 +33,7 @@ Comparison
 ----------
 Disk-backed variants target larger datasets, enable chunked processing, multi-device parallelism, and stable artifact generation.
 These methods build internal data loaders, iterate in chunks, and decouple sampling from file I/O, enabling concurrent execution.
-Outputs consolidate into a single :external:py:class:`xarray.DataTree` backed by Zarr files for post-hoc analysis.
+Outputs consolidate into a single :external:class:`xarray.DataTree` backed by Zarr files for post-hoc analysis.
 On-batch variants, in contrast, favor minimal overhead, immediate return, and greater flexibility when posterior sample shapes are not shard-friendly.
 
 Feature Summary
@@ -45,7 +45,7 @@ Typical dataset size          Medium → large                       Small → m
 Supported use cases           Standard models                      Broader model support
 Peak memory usage             Chunk-bounded                        Full batch resident
 Writes to disk                Yes                                  No
-Return type                   :external:py:class:`xarray.DataTree` :external:py:class:`xarray.DataTree` or :py:class:`dict`
+Return type                   :external:class:`xarray.DataTree`    :external:class:`xarray.DataTree` or :class:`dict`
                                                                    (via ``return_datatree=False``)
 Custom batch sizing           Yes (``batch_size``)                 No (single pass)
 Device parallelism (sharding) Yes                                  No
@@ -77,7 +77,7 @@ Quick Recommendations
   This occurs when the model or posterior sample shapes are incompatible with shard-based chunked execution.
 * Custom training loop: iterate with :meth:`~aimz.ImpactModel.train_on_batch`.
 * Need multi-device (sharding) execution: disk-backed.
-* Need raw NumPy/dict outputs (no :external:py:class:`xarray.DataTree`): on-batch with ``return_datatree=False``.
+* Need raw NumPy/dict outputs (no :external:class:`xarray.DataTree`): on-batch with ``return_datatree=False``.
 
 .. note::
 

--- a/docs/source/user_guide/mcmc.rst
+++ b/docs/source/user_guide/mcmc.rst
@@ -7,7 +7,7 @@ MCMC Support
 
 \
 
-While aimz is primarily designed around variational inference and predictive sampling, it also provides support for MCMC methods via the `NumPyro backend <https://num.pyro.ai/en/stable/mcmc.html#numpyro.infer.mcmc.MCMC>`__, using the same aimz interface (e.g., :py:meth:`~aimz.ImpactModel.fit_on_batch` and :py:meth:`~aimz.ImpactModel.predict_on_batch`).
+While aimz is primarily designed around variational inference and predictive sampling, it also provides support for MCMC methods via the `NumPyro backend <https://num.pyro.ai/en/stable/mcmc.html#numpyro.infer.mcmc.MCMC>`__, using the same aimz interface (e.g., :meth:`~aimz.ImpactModel.fit_on_batch` and :meth:`~aimz.ImpactModel.predict_on_batch`).
 This enables users to apply MCMC to more complex models where variational inference may be less effective and dataset sizes are relatively small.
 
 .. jupyter-execute::
@@ -52,14 +52,14 @@ We set up a linear regression model and create synthetic data for both features 
 MCMC Sampling and Prediction
 ----------------------------
 
-MCMC sampling can be performed using the :py:class:`~aimz.ImpactModel` class by setting the ``inference`` argument to :external:py:class:`~numpyro.infer.mcmc.MCMC`.
+MCMC sampling can be performed using the :class:`~aimz.ImpactModel` class by setting the ``inference`` argument to :external:class:`~numpyro.infer.mcmc.MCMC`.
 Users can configure the sampler, warm-up steps, and other MCMC-specific parameters.
-Calling :py:meth:`~aimz.ImpactModel.fit_on_batch()` initiates the sampling process.
-Internally, aimz executes the sampler via the :external:py:meth:`~numpyro.infer.mcmc.MCMC.run` method and stores the posterior samples using :external:py:meth:`~numpyro.infer.mcmc.MCMC.get_samples`.
+Calling :meth:`~aimz.ImpactModel.fit_on_batch()` initiates the sampling process.
+Internally, aimz executes the sampler via the :external:meth:`~numpyro.infer.mcmc.MCMC.run` method and stores the posterior samples using :external:meth:`~numpyro.infer.mcmc.MCMC.get_samples`.
 
-Note that calling :py:meth:`~aimz.ImpactModel.fit` with :external:py:class:`~numpyro.infer.mcmc.MCMC` as the inference method will raise a :exc:`TypeError`, as this method is intended for mini-batch training or subsampling.
+Note that calling :meth:`~aimz.ImpactModel.fit` with :external:class:`~numpyro.infer.mcmc.MCMC` as the inference method will raise a :exc:`TypeError`, as this method is intended for mini-batch training or subsampling.
 Regardless of the number of chains (``num_chains``) used, the posterior samples are combined across chains to ensure compatibility with the rest of the aimz interface.
-Posterior predictive sampling can be performed using the :py:meth:`~aimz.ImpactModel.predict` or :py:meth:`~aimz.ImpactModel.predict_on_batch` methods.
+Posterior predictive sampling can be performed using the :meth:`~aimz.ImpactModel.predict` or :meth:`~aimz.ImpactModel.predict_on_batch` methods.
 
 .. jupyter-execute::
 
@@ -77,7 +77,7 @@ Posterior predictive sampling can be performed using the :py:meth:`~aimz.ImpactM
 Using External MCMC Samples
 ---------------------------
 
-Users can run MCMC sampling directly using NumPyro and then insert the posterior samples into an :py:class:`~aimz.ImpactModel` instance using the :py:meth:`~aimz.ImpactModel.set_posterior_sample` method for downstream analysis.
+Users can run MCMC sampling directly using NumPyro and then insert the posterior samples into an :class:`~aimz.ImpactModel` instance using the :meth:`~aimz.ImpactModel.set_posterior_sample` method for downstream analysis.
 For example:
 
 .. jupyter-execute::

--- a/docs/source/user_guide/model_persistence.rst
+++ b/docs/source/user_guide/model_persistence.rst
@@ -8,7 +8,7 @@ Model Persistence
 \
 
 Model persistence allows you to save a trained model to disk and reload it later for inference or continued training.
-This documentation shows how to serialize and deserialize an :py:class:`~aimz.ImpactModel` instance using `cloudpickle <https://pypi.org/project/cloudpickle/>`__, which extends the standard ``pickle`` module to handle a wide range of Python objects, including closures and local functions.
+This documentation shows how to serialize and deserialize an :class:`~aimz.ImpactModel` instance using `cloudpickle <https://pypi.org/project/cloudpickle/>`__, which extends the standard ``pickle`` module to handle a wide range of Python objects, including closures and local functions.
 An alternative is `dill <https://pypi.org/project/dill/>`__, which offers similar functionality.
 
 .. note::
@@ -70,7 +70,7 @@ Model Training
 Serialization
 -------------
 
-Save a trained :py:class:`~aimz.ImpactModel` (and optionally its input data) to disk for later use:
+Save a trained :class:`~aimz.ImpactModel` (and optionally its input data) to disk for later use:
 
 .. jupyter-execute::
 
@@ -80,9 +80,9 @@ Save a trained :py:class:`~aimz.ImpactModel` (and optionally its input data) to 
 Deserialization
 ---------------
 
-Load a previously saved :py:class:`~aimz.ImpactModel` (and optionally its input data) from disk in a fresh new session or different runtime environment.
+Load a previously saved :class:`~aimz.ImpactModel` (and optionally its input data) from disk in a fresh new session or different runtime environment.
 To use the loaded model correctly, the same dependencies, imports, and any constants or variables that the ``model`` relied on when it was saved must be available.
-Any JAX array—whether part of the :py:class:`~aimz.ImpactModel` or the input data—will be placed on the default device.
+Any JAX array—whether part of the :class:`~aimz.ImpactModel` or the input data—will be placed on the default device.
 
 .. jupyter-execute::
     :hide-output:

--- a/docs/source/user_guide/sampling.rst
+++ b/docs/source/user_guide/sampling.rst
@@ -7,22 +7,22 @@ Explicit Sampling
 
 \
 
-aimz provides three sets of explicit sampling methods from the :py:class:`~aimz.ImpactModel` class, similar to `PyMC samplers <https://www.pymc.io/projects/docs/en/stable/api/samplers.html>`__:
+aimz provides three sets of explicit sampling methods from the :class:`~aimz.ImpactModel` class, similar to `PyMC samplers <https://www.pymc.io/projects/docs/en/stable/api/samplers.html>`__:
 
-1. **Prior Predictive Sampling**: :py:meth:`~aimz.ImpactModel.sample_prior_predictive_on_batch` and :py:meth:`~aimz.ImpactModel.sample_prior_predictive`.
-2. **Posterior Sampling**: :py:meth:`~aimz.ImpactModel.sample`.
-3. **Posterior Predictive Sampling**: :py:meth:`~aimz.ImpactModel.sample_posterior_predictive_on_batch` and :py:meth:`~aimz.ImpactModel.sample_posterior_predictive`.
+1. **Prior Predictive Sampling**: :meth:`~aimz.ImpactModel.sample_prior_predictive_on_batch` and :meth:`~aimz.ImpactModel.sample_prior_predictive`.
+2. **Posterior Sampling**: :meth:`~aimz.ImpactModel.sample`.
+3. **Posterior Predictive Sampling**: :meth:`~aimz.ImpactModel.sample_posterior_predictive_on_batch` and :meth:`~aimz.ImpactModel.sample_posterior_predictive`.
 
-By default, these methods return results as an :external:py:class:`xarray.DataTree`, with the relevant group labeled as ``prior_predictive``, ``posterior``, or ``posterior_predictive``.
-For some methods, setting ``return_datatree=False`` instead returns a :py:class:`dict`.
+By default, these methods return results as an :external:class:`xarray.DataTree`, with the relevant group labeled as ``prior_predictive``, ``posterior``, or ``posterior_predictive``.
+For some methods, setting ``return_datatree=False`` instead returns a :class:`dict`.
 
-The prior predictive sampling methods perform forward sampling based on the model’s prior specification in the ``kernel`` and are not part of the standard training and inference workflow (:py:meth:`~aimz.ImpactModel.fit`/:py:meth:`~aimz.ImpactModel.predict`), making them particularly useful for conducting prior predictive checks.
+The prior predictive sampling methods perform forward sampling based on the model’s prior specification in the ``kernel`` and are not part of the standard training and inference workflow (:meth:`~aimz.ImpactModel.fit`/:meth:`~aimz.ImpactModel.predict`), making them particularly useful for conducting prior predictive checks.
 
-Unlike :py:meth:`~aimz.ImpactModel.fit` or :py:meth:`~aimz.ImpactModel.fit_on_batch`, :py:meth:`~aimz.ImpactModel.sample` does not modify the internal ``posterior`` attribute.
+Unlike :meth:`~aimz.ImpactModel.fit` or :meth:`~aimz.ImpactModel.fit_on_batch`, :meth:`~aimz.ImpactModel.sample` does not modify the internal ``posterior`` attribute.
 It is primarily intended for drawing posterior samples from a fitted model using variational inference.
-Users can update the internal posterior manually by passing the samples obtained from :py:meth:`~aimz.ImpactModel.sample` to :py:meth:`~aimz.ImpactModel.set_posterior_sample` without retraining the model.
+Users can update the internal posterior manually by passing the samples obtained from :meth:`~aimz.ImpactModel.sample` to :meth:`~aimz.ImpactModel.set_posterior_sample` without retraining the model.
 
-The posterior predictive sampling methods serve as convenient aliases for :py:meth:`~aimz.ImpactModel.predict_on_batch` and :py:meth:`~aimz.ImpactModel.predict`, respectively.
+The posterior predictive sampling methods serve as convenient aliases for :meth:`~aimz.ImpactModel.predict_on_batch` and :meth:`~aimz.ImpactModel.predict`, respectively.
 
 .. jupyter-execute::
     :hide-output:
@@ -96,8 +96,8 @@ Posterior Sampling
 ------------------
 
 We first train the model using variational inference, drawing only a single posterior sample for demonstration purposes.
-After fitting, we call :py:meth:`~aimz.ImpactModel.sample` to generate 100 posterior samples for further analysis.
-Setting ``return_datatree=False`` ensures that the results are returned as a dictionary rather than an :external:py:class:`xarray.DataTree`.
+After fitting, we call :meth:`~aimz.ImpactModel.sample` to generate 100 posterior samples for further analysis.
+Setting ``return_datatree=False`` ensures that the results are returned as a dictionary rather than an :external:class:`xarray.DataTree`.
 
 .. jupyter-execute::
 
@@ -106,7 +106,7 @@ Setting ``return_datatree=False`` ensures that the results are returned as a dic
 
 \
 
-We pass posterior samples to :py:meth:`~aimz.ImpactModel.set_posterior_sample` to update the model’s internal ``posterior``:
+We pass posterior samples to :meth:`~aimz.ImpactModel.set_posterior_sample` to update the model’s internal ``posterior``:
 
 .. jupyter-execute::
 
@@ -116,7 +116,7 @@ We pass posterior samples to :py:meth:`~aimz.ImpactModel.set_posterior_sample` t
 Posterior Predictive Sampling
 -----------------------------
 
-We draw posterior predictive samples from the fitted model using :py:meth:`~aimz.ImpactModel.sample_posterior_predictive_on_batch`, though the same results can be obtained with :py:meth:`~aimz.ImpactModel.predict_on_batch` (or :py:meth:`~aimz.ImpactModel.predict`).
+We draw posterior predictive samples from the fitted model using :meth:`~aimz.ImpactModel.sample_posterior_predictive_on_batch`, though the same results can be obtained with :meth:`~aimz.ImpactModel.predict_on_batch` (or :meth:`~aimz.ImpactModel.predict`).
 The posterior group now contains 100 posterior samples.
 
 .. jupyter-execute::

--- a/tests/test_set_posterior_sample.py
+++ b/tests/test_set_posterior_sample.py
@@ -33,6 +33,15 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
+def test_empty_posterior_sample(vi: "SVI") -> None:
+    """Empty posterior sample raises ValueError."""
+    im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
+    msg = "`posterior_sample` cannot be empty."
+    with pytest.raises(ValueError, match=msg):
+        im.set_posterior_sample({})
+
+
+@pytest.mark.parametrize("vi", [lm], indirect=True)
 def test_set_posterior_sample(
     synthetic_data: tuple[ArrayLike, ArrayLike],
     vi: "SVI",

--- a/tests/test_set_posterior_sample.py
+++ b/tests/test_set_posterior_sample.py
@@ -79,6 +79,6 @@ def test_inconsistent_batch_shapes(vi: "SVI") -> None:
     im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
     with pytest.raises(
         ValueError,
-        match="Inconsistent batch shapes found in posterior_sample",
+        match="Inconsistent batch shapes found in `posterior_sample`",
     ):
         im.set_posterior_sample({"a": jnp.ones((100, 10)), "b": jnp.ones((200,))})


### PR DESCRIPTION
The `set_posterior_sample` method now raises an error for empty posterior samples and no longer accepts the `return_sites` parameter, as downstream methods handle this functionality. Documentation has been updated to reflect these changes.

Fixes #100
Fixes #101