### PR TITLE
Add posterior group to predictive sampling outputs and enhance documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@ This exposes a lazily-built, cached structural specification of the user kernel 
 ### Changed
 
 - All `tqdm` progress bars now use `dynamic_ncols=True` to adjust column width dynamically ([#93](https://github.com/markean/aimz/issues/93)).
-
 - {meth}`~aimz.ImpactModel.fit_on_batch`, {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch`, {meth}`~aimz.ImpactModel.sample_prior_predictive`, and {meth}`~aimz.ImpactModel.train_on_batch` now reuse the cached {attr}`~aimz.ImpactModel.kernel_spec` and avoid redundant model tracing ([#98](https://github.com/markean/aimz/issues/98)).
-- {meth}`~aimz.ImpactModel.set_posterior_sample` now raises an error when an empty posterior dictionary (`{}`) is provided.
-- {meth}`~aimz.ImpactModel.set_posterior_sample` no longer accepts a `return_sites` parameter; downstream methods can now set it explicitly.
+- {meth}`~aimz.ImpactModel.set_posterior_sample` no longer accepts a `return_sites` parameter; downstream methods can now set it explicitly ([#100](https://github.com/markean/aimz/issues/100)).
+- {meth}`~aimz.ImpactModel.set_posterior_sample` now raises an error when an empty posterior dictionary (`{}`) is provided ([#101](https://github.com/markean/aimz/issues/101)).
+- {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch` and {meth}`~aimz.ImpactModel.sample_prior_predictive` now include posterior samples in the returned results if available ([#103](https://github.com/markean/aimz/issues/103)).
 
 ### Fixed
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -463,7 +463,7 @@ class ImpactModel(BaseModel):
                 are expected to be JAX arrays.
 
         Returns:
-            Prior predictive samples.
+            Prior predictive samples. Posterior samples are included if available.
 
         Raises:
             TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
@@ -499,6 +499,8 @@ class ImpactModel(BaseModel):
 
         out = xr.DataTree(name="root")
         out["prior_predictive"] = _dict_to_datatree(prior_predictive_samples)
+        if self.posterior:
+            out["posterior"] = _dict_to_datatree(self.posterior)
 
         return out
 
@@ -540,7 +542,7 @@ class ImpactModel(BaseModel):
                 are expected to be JAX arrays.
 
         Returns:
-            Prior predictive samples.
+            Prior predictive samples. Posterior samples are included if available.
 
         Raises:
             TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
@@ -638,6 +640,8 @@ class ImpactModel(BaseModel):
         out = xr.DataTree(name="root")
         out["prior_predictive"] = xr.DataTree(ds)
         out["prior_predictive"].attrs["output_dir"] = str(output_subdir)
+        if self.posterior:
+            out["posterior"] = _dict_to_datatree(self.posterior)
         out.attrs["output_dir"] = str(output_dir)
 
         return out

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,6 +65,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/docs", None),
     "xarray": ("https://docs.xarray.dev/en/stable/", None),
+    "arviz": ("https://python.arviz.org/en/stable/", None),
     "mlflow": ("https://mlflow.org/docs/latest/api_reference/", None),
 }
 tls_verify = False
@@ -126,6 +127,7 @@ html_theme_options = {
     "navbar_align": "left",
     "use_edit_page_button": True,
     "footer_end": None,
+    "header_links_before_dropdown": 4,
 }
 html_show_sourcelink = False
 html_show_sphinx = False

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -1,0 +1,70 @@
+.. _NumPyro: https://num.pyro.ai/
+
+Frequently Asked Questions
+==========================
+
+What is a `kernel`?
+-------------------
+A kernel in aimz is a user-defined NumPyro_ model (a stochastic function or :class:`~collections.abc.Callable`) built with primitives like :external:func:`~numpyro.primitives.sample` and :external:func:`~numpyro.primitives.deterministic`.
+Its signature and body define the inputs and output (e.g., ``X``, ``y``, ...), encoding the probabilistic structure—priors, likelihood, and latent variables.
+
+
+Can I use posterior samples generated elsewhere?
+------------------------------------------------
+Yes—you do not need to train a model from scratch and sample posteriors.
+After initializing an :class:`~aimz.ImpactModel` with your model, call :meth:`~aimz.ImpactModel.set_posterior_sample` with a dictionary mapping site names to arrays.
+Each array must share the same leading dimension (number of draws), and the dictionary must not be empty.
+Once injected, the model is treated as fitted, and the prediction, log-likelihood, and posterior predictive methods will use the supplied samples.
+
+
+When should I use the ``*_on_batch`` variants?
+----------------------------------------------
+Use the batch-specific variants only when you need explicit, single-batch control (e.g., custom training loops, micro‑benchmarking, or integrating with external schedulers).
+The higher-level methods handle internal batching, iteration, shuffling, streaming, and aggregation automatically and are preferred for typical workflows.
+See :doc:`user_guide/disk_and_on_batch` for a detailed comparison of both approaches and guidance on when to use each.
+
+
+How do I control which variables (sites) are sampled?
+-----------------------------------------------------
+By default, prediction and sampling methods use the set of return sites cached in :attr:`~aimz.model.KernelSpec.return_sites`—typically the model output plus any deterministic sites discovered during the first trace.
+To override this behavior, pass ``return_sites=(...)`` explicitly to the relevant methods.
+
+
+How to ensure reproducible results?
+-----------------------------------
+:class:`~aimz.ImpactModel` requires an explicit JAX pseudo-random number generator key for initialization.
+Using the same initial key ensures that all subsequent stochastic operations are reproducible.
+Stochastic methods accept an optional ``rng_key`` for per-call determinism.
+If provided, it affects only that call and does not modify the model’s internal key.
+If omitted, a new subkey is derived internally, so repeated calls may produce different results.
+To fully reproduce results, log the initial seed along with other artifacts.
+
+
+Why do some methods return :class:`~xarray.DataTree`?
+-----------------------------------------------------
+A :class:`~xarray.DataTree` organizes heterogeneous groups (``posterior``, ``posterior_predictive``, ``predictions``) with labeled dimensions and coordinates, facilitating I/O, slicing, and downstream analysis.
+It can also be easily converted to an :external:class:`arviz.InferenceData` object using :external:func:`arviz.from_datatree`.
+If desired, you can pass ``return_datatree=False`` to methods such as :meth:`~aimz.ImpactModel.predict_on_batch` to return a plain dictionary instead.
+
+
+Why do I not see a ``posterior`` group in the output?
+-----------------------------------------------------
+It appears in the returned :class:`~xarray.DataTree` only if posterior samples are available (fitted or injected).
+
+
+Where is the on-disk output written?
+------------------------------------
+All outputs are written under the directory passed via ``output_dir``.
+If ``output_dir=None``, a temporary directory is created (accessible via
+:attr:`~aimz.ImpactModel.temp_dir`) and removed when the model is cleaned up
+(either explicitly with :meth:`~aimz.ImpactModel.cleanup` or when the instance is
+garbage collected).
+Each group in the returned :class:`~xarray.DataTree` stores its own artifact path
+in an ``output_dir`` attribute, and the root tree includes the top-level path.
+
+
+Does serialization persist the posterior samples?
+-------------------------------------------------
+Yes.
+Pickling (or MLflow integration via :mod:`aimz.mlflow`) preserves the posterior samples (if set) and the cached :class:`~aimz.model.KernelSpec` so retracing / re-fitting is unnecessary upon load.
+See :doc:`user_guide/model_persistence` or :doc:`user_guide/mlflow` for more details.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,12 +48,26 @@ Navigation
 
       Explore tutorials and practical examples.
 
+   .. grid-item-card:: Frequently Asked Questions
+      :class-card: intro-card
+      :link: faq
+      :link-type: doc
+
+      Browse common questions and troubleshooting tips.
+
    .. grid-item-card:: API Reference
       :class-card: intro-card
       :link: api
       :link-type: doc
 
       Browse the documentation for all public functions and classes.
+
+   .. grid-item-card:: Development
+      :class-card: intro-card
+      :link: development/index
+      :link-type: doc
+
+      Access the development documentation and guidelines.
 
    .. grid-item-card:: Changelog
       :class-card: intro-card
@@ -62,12 +76,14 @@ Navigation
 
       View the changelog for release notes and version history.
 
+
 .. toctree::
    :hidden:
    :maxdepth: 1
 
    Getting Started <getting_started/index>
    User Guide <user_guide/index>
+   FAQs <faq>
    API Reference <api>
    Development <development/index>
    Changelog <changelog>

--- a/tests/test_sample_prior_predictive.py
+++ b/tests/test_sample_prior_predictive.py
@@ -50,8 +50,9 @@ def test_sample_prior_predictive_lm(
     vi: "SVI",
 ) -> None:
     """Test the `.sample_prior_predictive()` method of ImpactModel."""
-    X, _ = synthetic_data
+    X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
+    im.fit_on_batch(X, y)
     msg = (
         r"The `batch_size` \(\d+\) is not divisible by the number of devices \(\d+\)\."
     )

--- a/tests/test_sample_prior_predictive_on_batch.py
+++ b/tests/test_sample_prior_predictive_on_batch.py
@@ -74,8 +74,9 @@ def test_sample_prior_predictive_on_batch_lm(
     vi: "SVI",
 ) -> None:
     """Test the `.sample_prior_predictive_on_batch()` method of ImpactModel."""
-    X, _ = synthetic_data
+    X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
+    im.fit_on_batch(X, y)
     samples = im.sample_prior_predictive_on_batch(X=X, num_samples=99)
 
     assert isinstance(samples, xr.DataTree)
@@ -90,4 +91,4 @@ def test_sample_prior_predictive_on_batch_lm(
     assert isinstance(samples_dict, dict)
     assert samples_dict["y"].shape == (99, len(X))
     assert im.kernel_spec.traced
-    assert not im.kernel_spec.output_observed
+    assert im.kernel_spec.output_observed


### PR DESCRIPTION
Include posterior samples in the output of `.sample_prior_predictive_on_batch()` and `.sample_prior_predictive()` when available, addressing issue #103. Additionally, introduce an FAQ section in the documentation to assist users with common questions and troubleshooting tips.