### PR TITLE
Enhance ImpactModel to accept string or iterable for return_sites parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This exposes a lazily-built, cached structural specification of the user kernel 
 - {meth}`~aimz.ImpactModel.set_posterior_sample` no longer accepts a `return_sites` parameter; downstream methods can now set it explicitly ([#100](https://github.com/markean/aimz/issues/100)).
 - {meth}`~aimz.ImpactModel.set_posterior_sample` now raises an error when an empty posterior dictionary (`{}`) is provided ([#101](https://github.com/markean/aimz/issues/101)).
 - {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch` and {meth}`~aimz.ImpactModel.sample_prior_predictive` now include posterior samples in the returned results if available ([#103](https://github.com/markean/aimz/issues/103)).
+- {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch`, {meth}`~aimz.ImpactModel.sample_prior_predictive`, {meth}`~aimz.ImpactModel.sample`, {meth}`~aimz.ImpactModel.sample_posterior_predictive_on_batch`, {meth}`~aimz.ImpactModel.sample_posterior_predictive`, {meth}`~aimz.ImpactModel.predict_on_batch`, and {meth}`~aimz.ImpactModel.predict` can now accept a single `str` or an iterable of `str` values for the `return_sites` parameter ([#107](https://github.com/markean/aimz/issues/107)).
+- {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch` returns the default output site along with deterministic sites when `return_sites` is not specified, to be consistent with the behavior of other sampling methods ([#108](https://github.com/markean/aimz/issues/108)).
 
 ### Fixed
 

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -14,6 +14,8 @@
 
 """Tests for the `.predict()` method."""
 
+from tempfile import TemporaryDirectory
+
 import numpyro.distributions as dist
 import pytest
 from conftest import latent_variable_model, lm
@@ -153,7 +155,23 @@ def test_predict_after_cleanup(
 
     assert temp_dir_before != temp_dir_after
 
-    # `.sample_posterior_predictive()` is an alias for `.predict()`
     im.cleanup()
-    with pytest.warns(UserWarning, match=msg):
-        im.sample_posterior_predictive(X=X, batch_size=len(X) // 2, progress=False)
+
+    # `.sample_posterior_predictive()` is an alias for `.predict()`.
+    # Test with `return_sites`.
+    with pytest.warns(UserWarning, match=msg), TemporaryDirectory() as tmp_dir:
+        im.sample_posterior_predictive(
+            X=X,
+            return_sites="y",
+            batch_size=len(X) // 2,
+            output_dir=tmp_dir,
+            progress=False,
+        )
+    with pytest.warns(UserWarning, match=msg), TemporaryDirectory() as tmp_dir:
+        im.sample_posterior_predictive(
+            X=X,
+            return_sites=["y"],
+            batch_size=len(X) // 2,
+            output_dir=tmp_dir,
+            progress=False,
+        )

--- a/tests/test_predict_on_batch.py
+++ b/tests/test_predict_on_batch.py
@@ -109,6 +109,12 @@ def test_predict_on_batch_lm_with_kwargs_array(
     X, y = synthetic_data
     im = ImpactModel(lm_with_kwargs_array, rng_key=random.key(42), inference=vi)
     im.fit(X=X, y=y, c=y, batch_size=3)
-    im.predict_on_batch(X=X, c=y)
-    # `.sample_posterior_predictive_on_batch()` is an alias for `.predict_on_batch()`
-    im.sample_posterior_predictive_on_batch(X=X, c=y, return_datatree=False)
+    im.predict_on_batch(X=X, c=y, return_sites="y")
+
+    # `.sample_posterior_predictive_on_batch()` is an alias for `.predict_on_batch()`.
+    im.sample_posterior_predictive_on_batch(
+        X=X,
+        c=y,
+        return_sites=["y"],
+        return_datatree=False,
+    )

--- a/tests/test_sample_prior_predictive.py
+++ b/tests/test_sample_prior_predictive.py
@@ -14,6 +14,7 @@
 
 """Tests for the `.sample_prior_predictive()` method."""
 
+from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 
 import pytest
@@ -65,3 +66,24 @@ def test_sample_prior_predictive_lm(
 
     assert isinstance(samples, xr.DataTree)
     assert samples.prior_predictive["y"].values.shape == (1, 99, len(X))
+
+    # Test with `return_sites`
+    with pytest.warns(UserWarning, match=msg), TemporaryDirectory() as tmp_dir:
+        assert im.sample_prior_predictive(
+            X=X,
+            num_samples=99,
+            batch_size=len(X) // 2,
+            return_sites="y",
+            output_dir=tmp_dir,
+        ).prior_predictive["y"].values.shape == (1, 99, len(X))
+
+    with pytest.warns(UserWarning, match=msg), TemporaryDirectory() as tmp_dir:
+        assert im.sample_prior_predictive(
+            X=X,
+            num_samples=99,
+            batch_size=len(X) // 2,
+            return_sites=["y"],
+            output_dir=tmp_dir,
+        ).prior_predictive["y"].values.shape == (1, 99, len(X))
+
+    im.cleanup()

--- a/tests/test_sample_prior_predictive_on_batch.py
+++ b/tests/test_sample_prior_predictive_on_batch.py
@@ -77,7 +77,7 @@ def test_sample_prior_predictive_on_batch_lm(
     X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
     im.fit_on_batch(X, y)
-    samples = im.sample_prior_predictive_on_batch(X=X, num_samples=99)
+    samples = im.sample_prior_predictive_on_batch(X=X, num_samples=99, return_sites="y")
 
     assert isinstance(samples, xr.DataTree)
     assert samples.prior_predictive["y"].values.shape == (1, 99, len(X))
@@ -86,6 +86,7 @@ def test_sample_prior_predictive_on_batch_lm(
         X=X,
         num_samples=99,
         return_datatree=False,
+        return_sites=["b", "y", "sigma"],
     )
 
     assert isinstance(samples_dict, dict)


### PR DESCRIPTION
Update the sampling methods of ImpactModel to additionally accept either a single string or an iterable of strings for the return_sites parameter. Adjust tests to validate this new functionality.

Change `.sample_prior_predictive_on_batch()` to return output site and deterministic site when `return_sites` is not provided.

Fixes #107, #108