### PR TITLE
Enhance `.estimate_effect()` to include posterior group and output directory attribute

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
       # Ruff version.
-      rev: v0.13.1
+      rev: v0.13.2
       hooks:
           # Run the linter.
           - id: ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This exposes a lazily-built, cached structural specification of the user kernel 
 - {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch`, {meth}`~aimz.ImpactModel.sample_prior_predictive`, {meth}`~aimz.ImpactModel.sample`, {meth}`~aimz.ImpactModel.sample_posterior_predictive_on_batch`, {meth}`~aimz.ImpactModel.sample_posterior_predictive`, {meth}`~aimz.ImpactModel.predict_on_batch`, and {meth}`~aimz.ImpactModel.predict` can now accept a single `str` or an iterable of `str` values for the `return_sites` parameter ([#107](https://github.com/markean/aimz/issues/107)).
 - {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch` returns the default output site along with deterministic sites when `return_sites` is not specified, to be consistent with the behavior of other sampling methods ([#108](https://github.com/markean/aimz/issues/108)).
 - {meth}`~aimz.ImpactModel.estimate_effect` returns a `posterior` group node in the {class}`xarray.DataTree` object when posterior samples are available, to be consistent with other methods ([#110](https://github.com/markean/aimz/issues/110)).
+- Subdirectories under {attr}`~aimz.ImpactModel.temp_dir` now include microseconds in their names to avoid duplicates and file-exists errors ([#110](https://github.com/markean/aimz/issues/110)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `output_dir` attribute to the root and group nodes of {class}`xarray.DataTree` objects returned by {meth}`~aimz.ImpactModel.sample_prior_predictive`, {meth}`~aimz.ImpactModel.predict`, and {meth}`~aimz.ImpactModel.log_likelihood`, specifying the directory where results are saved ([#85](https://github.com/markean/aimz/issues/85)).
 - Introduced the public {class}`~aimz.model.KernelSpec` dataclass and the {attr}`~aimz.ImpactModel.kernel_spec` attribute on {class}`~aimz.ImpactModel`.
 This exposes a lazily-built, cached structural specification of the user kernel (fields: ``traced``, ``return_sites``, ``output_observed``) so training and predictive methods avoid redundant model tracing ([#98](https://github.com/markean/aimz/issues/98)).
+- When available, an `output_dir` attribute is added to the root node of {class}`xarray.DataTree` object returned by {meth}`~aimz.ImpactModel.estimate_effect`, specifying the directory where results are saved ([#110](https://github.com/markean/aimz/issues/110)).
 
 ### Changed
 
@@ -22,6 +23,7 @@ This exposes a lazily-built, cached structural specification of the user kernel 
 - {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch` and {meth}`~aimz.ImpactModel.sample_prior_predictive` now include posterior samples in the returned results if available ([#103](https://github.com/markean/aimz/issues/103)).
 - {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch`, {meth}`~aimz.ImpactModel.sample_prior_predictive`, {meth}`~aimz.ImpactModel.sample`, {meth}`~aimz.ImpactModel.sample_posterior_predictive_on_batch`, {meth}`~aimz.ImpactModel.sample_posterior_predictive`, {meth}`~aimz.ImpactModel.predict_on_batch`, and {meth}`~aimz.ImpactModel.predict` can now accept a single `str` or an iterable of `str` values for the `return_sites` parameter ([#107](https://github.com/markean/aimz/issues/107)).
 - {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch` returns the default output site along with deterministic sites when `return_sites` is not specified, to be consistent with the behavior of other sampling methods ([#108](https://github.com/markean/aimz/issues/108)).
+- {meth}`~aimz.ImpactModel.estimate_effect` returns a `posterior` group node in the {class}`xarray.DataTree` object when posterior samples are available, to be consistent with other methods ([#110](https://github.com/markean/aimz/issues/110)).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 [**Installation**](https://aimz.readthedocs.io/stable/getting_started/installation.html) |
 [**Documentation**](https://aimz.readthedocs.io/) |
+[**FAQs**](https://aimz.readthedocs.io/latest/faq.html) |
 [**Changelog**](https://aimz.readthedocs.io/latest/changelog.html)
 
 ## Overview
@@ -35,7 +36,7 @@ Designed to work with user-defined models with probabilistic primitives, the lib
 2. Translate the model into a **kernel** (i.e., a function) using NumPyro and JAX.
 3. Integrate the kernel into the provided API to train the model and perform inference.
 
-### Example 1: Regression Using a scikit-learn-like Workflow
+### Example: Regression Using a scikit-learn-like Workflow
 
 This example demonstrates a simple regression model following a typical ML workflow. The `ImpactModel` class provides `.fit()` and `.fit_on_batch()` for variational inference and posterior sampling, and `.predict()` and `.predict_on_batch()` for posterior predictive sampling. The optional `.cleanup()` removes posterior predictive samples saved as temporary files.
 
@@ -97,127 +98,6 @@ im.cleanup()
 ```
 
 > The training step can be skipped if pre-trained variational inference results or posterior samples are available. These can be integrated into the `ImpactModel`, allowing `.predict()` to be available subsequently.
-
-### Example 2: Causal Network with Confounder
-
-This example illustrates a simple causal network. The variable `Z` has a direct causal effect on the outcome `Y`, while both are influenced by a shared confounder, `C`. An additional variable, `X`, is an observed exogenous factor that influences `Z` but has no direct effect on `Y`.
-
-Our objective is to estimate the causal effect of `Z` (or alternatively `X`) on `Y`, while properly accounting for the confounding influence of `C`. We assume the following generative model for the observed data:
-
-```python
-import jax.numpy as jnp
-import numpyro.distributions as dist
-from jax import nn, random
-from jax.typing import ArrayLike
-from numpyro import optim, plate, sample
-from numpyro.infer import SVI, Trace_ELBO, init_to_feasible
-from numpyro.infer.autoguide import AutoNormal
-
-from aimz import ImpactModel
-
-
-# NumPyro model: Z and y are influenced by C and X, with Z mediating part of y
-def model(X: ArrayLike, C: ArrayLike, y: ArrayLike | None = None) -> None:
-    # Observed confounder
-    c = sample("c", dist.Exponential(), obs=C)
-
-    # Priors for coefficients in the structural model
-    # C -> Z and C -> Y
-    beta_cz = sample("beta_cz", dist.Normal())
-    beta_cy = sample("beta_cy", dist.Normal())
-
-    # X -> Z and Z -> Y
-    beta_xz = sample("beta_xz", dist.Normal())
-    beta_zy = sample("beta_zy", dist.Normal())
-
-    # Intercepts
-    beta_z = sample("beta_z", dist.Normal())
-    beta_y = sample("beta_y", dist.Normal())
-
-    # Observation noise for Z
-    sigma = sample("sigma", dist.Exponential())
-
-    # Plate over data
-    with plate("data", X.shape[0]):
-        mu_z = beta_z + beta_cz * c + beta_xz * X.squeeze(axis=1)
-        z = sample("z", dist.LogNormal(mu_z, sigma))
-
-        logits = beta_y + beta_cy * c + beta_zy * z
-        sample("y", dist.Bernoulli(logits=logits), obs=y)
-```
-
-#### Simulating data under a known structural model
-
-We generate synthetic data consistent with the assumed causal structure:
-
-- `C` is drawn from an exponential distribution.
-- `X` is a count variable from a Poisson distribution.
-- `Z` is generated as a noisy exponential function of `C` and `X`.
-- `Y` is a binary outcome influenced by both `C` and `Z` through a logistic model.
-
-```python
-# Create a pseudo-random number generator key for JAX
-rng_key = random.key(42)
-
-# Sample C from an Exponential distribution
-rng_key, rng_subkey = random.split(rng_key)
-C = random.exponential(rng_subkey, shape=(100,))
-
-# Sample X from a Poisson distribution
-rng_key, rng_subkey = random.split(rng_key)
-X = random.poisson(rng_subkey, lam=1, shape=(100, 1))
-
-# Generate Z influenced by C and X
-rng_key, rng_subkey = random.split(rng_key)
-mu_z = -1.0 + 0.5 * C - 1.5 * X.squeeze()
-sigma_z = 10.0  # Add substantial noise to reduce correlation between C and Z
-Z = jnp.exp(random.normal(rng_subkey, shape=(100,)) * sigma_z + mu_z)
-
-# Generate Y from a logistic regression on C and Z
-rng_key, rng_subkey = random.split(rng_key)
-logits = -2.0 + 5.0 * C + 0.1 * Z
-p = nn.sigmoid(logits)
-y = random.bernoulli(rng_subkey, p=p).astype(jnp.int32)
-```
-
-#### Fitting the model and estimating causal effects
-
-We fit the model using stochastic variational inference. Once trained, we perform a counterfactual analysis to isolate the effect of `Z` on `Y`.
-
-- `idata_factual` represents predictions under the factual setting (with observed `Z`).
-- `idata_counterfactual` represents predictions under a counterfactual intervention where `Z` is set to zero.
-Comparing these two distributions allows us to estimate the causal effect of `Z` on `Y`, adjusted for the influence of `C`.
-
-```python
-# Fit the model with SVI
-im = ImpactModel(
-    model,
-    rng_key=rng_key,
-    inference=SVI(
-        model,
-        guide=AutoNormal(model, init_loc_fn=init_to_feasible()),
-        optim=optim.Adam(step_size=1e-3),
-        loss=Trace_ELBO(),
-    ),
-)
-im.fit_on_batch(X, y, C=C)
-
-# Predict under factual (Z) and counterfactual (zeroed Z) scenarios
-idata_factual = im.predict_on_batch(X, C=C, intervention={"z": Z})
-idata_counterfactual = im.predict_on_batch(
-    X,
-    C=C,
-    intervention={"z": jnp.zeros_like(Z)},
-)
-
-# Estimate causal effect of intervening on Z while conditioning on C
-impact = im.estimate_effect(
-    output_baseline=idata_factual,
-    output_intervention=idata_counterfactual,
-)
-```
-
-> Local latent variable requires `.predict_on_batch()` here. Prefer `.predict()` whenever it is compatible with the model.
 
 ## Contributing
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -337,7 +337,7 @@ class ImpactModel(BaseModel):
             )
         output_dir = Path(output_dir).expanduser().resolve()
         output_dir.mkdir(parents=True, exist_ok=True)
-        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
         output_subdir = output_dir / timestamp
         output_subdir.mkdir(parents=False, exist_ok=False)
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -1460,6 +1460,14 @@ class ImpactModel(BaseModel):
     ) -> xr.DataTree:
         """Estimate the effect of an intervention.
 
+        .. _NumPyro: https://num.pyro.ai/
+
+        This computes (intervention - baseline) for every variable in the shared
+        predictive group, preserving sampling (chain/draw) dimensions. When
+        interventions are used in prediction they are applied internally through
+        NumPyro_'s :external:class:`~numpyro.handlers.do` effect handler (graph surgery)
+        without requiring model rewrites.
+
         Args:
             output_baseline: Precomputed output for the baseline scenario.
             output_intervention: Precomputed output for the intervention scenario.
@@ -1473,7 +1481,8 @@ class ImpactModel(BaseModel):
                 ``output_intervention`` is already given.
 
         Returns:
-            The estimated impact of an intervention.
+            The estimated impact of an intervention. Posterior samples are included if
+            available.
 
         Raises:
             ValueError: If neither ``output_baseline`` nor ``args_baseline`` is
@@ -1508,6 +1517,20 @@ class ImpactModel(BaseModel):
 
         out = xr.DataTree(name="root")
         out[group] = dt_intervention[group] - dt_baseline[group]
+        if self.posterior:
+            out["posterior"] = _dict_to_datatree(self.posterior)
+        # Propagate an output directory attribute to the effect result.
+        # Precedence:
+        #   1) intervention output_dir (if present)
+        #   2) baseline output_dir (if present)
+        #   3) model temporary directory (if it exists)
+        output_dir_attr = (
+            dt_intervention.attrs.get("output_dir")
+            or dt_baseline.attrs.get("output_dir")
+            or (self.temp_dir if self.temp_dir is not None else None)
+        )
+        if output_dir_attr is not None:
+            out.attrs["output_dir"] = output_dir_attr
 
         return out
 

--- a/docs/source/api/impact_model.rst
+++ b/docs/source/api/impact_model.rst
@@ -39,8 +39,6 @@ Inference
    ImpactModel.predict_on_batch
    ImpactModel.predict
    ImpactModel.log_likelihood
-   ImpactModel.estimate_effect
-   ImpactModel.cleanup
 
 
 Explicit Sampling
@@ -54,3 +52,13 @@ Explicit Sampling
    ImpactModel.sample
    ImpactModel.sample_posterior_predictive_on_batch
    ImpactModel.sample_posterior_predictive
+
+
+Miscellaneous
+-------------
+
+.. autosummary::
+   :toctree: generated/
+
+   ImpactModel.estimate_effect
+   ImpactModel.cleanup

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -4,14 +4,39 @@ Frequently Asked Questions
 ==========================
 
 
-What is a `kernel`?
+What is a kernel?
 -------------------
 A kernel in aimz is a user-defined NumPyro_ model (a stochastic function or :class:`~collections.abc.Callable`) built with primitives like :external:func:`~numpyro.primitives.sample` and :external:func:`~numpyro.primitives.deterministic`.
 Its signature and body define the inputs and output (e.g., ``X``, ``y``, ...), encoding the probabilistic structure—priors, likelihood, and latent variables.
 
 
+How do I use different argument names than ``X`` and ``y``?
+-----------------------------------------------------------
+By default, aimz expects your kernel signature to include parameters named ``X`` (input) and ``y`` (output).
+If you use different names—e.g. ``features`` / ``target`` or ``covariates`` / ``outcome``—declare them when instantiating :class:`~aimz.ImpactModel`:
+
+.. code-block:: python
+
+	def kernel(features, extra, target=None):
+	    ...
+
+	im = ImpactModel(
+	    kernel,
+            ...,
+	    param_input="features",
+	    param_output="target",
+	)
+
+If you see an error like:
+
+``Kernel must accept 'X' and 'y' as argument(s). Modify the kernel signature or set `param_input` and `param_output` accordingly.``
+
+it means you neither matched the defaults nor overrode them.
+Fix it by renaming your arguments to ``X`` / ``y`` or supplying ``param_input`` / ``param_output`` as shown above.
+
+
 Do I need to know NumPyro_ to use aimz?
---------------------------------------
+---------------------------------------
 Yes.
 aimz builds on NumPyro_’s primitives and effect handlers.
 You should be comfortable writing a model function, defining a guide (for SVI) or configuring MCMC, and reading model traces.

--- a/docs/source/user_guide/cleanup.rst
+++ b/docs/source/user_guide/cleanup.rst
@@ -15,9 +15,9 @@ This root directory is stored in the :attr:`~aimz.ImpactModel.temp_dir` attribut
 Example Layout (implicit temp root)::
 
     /tmp/tmpz00u5kxk/       # model.temp_dir (root, reused until cleanup)
-        20250917T013040Z/
-        20250917T014538Z/
-        20250917T014955Z/
+        20250926T185250223698Z/
+        20250926T185359570134Z/
+        20250926T185419208087Z/
 
 If the user provides ``output_dir``, that directory becomes the root, and it will be created if it does not already exist.
 The same timestamped subdirectory pattern is used there (e.g., ``my_runs/20250917T013040Z``).

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -4,10 +4,11 @@ User Guide
 .. toctree::
    :maxdepth: 1
 
-   sampling
    disk_and_on_batch
-   model_persistence
+   sampling
    cleanup
+   model_persistence
    mlflow
+   intervention
    dataloader
    mcmc

--- a/docs/source/user_guide/intervention.rst
+++ b/docs/source/user_guide/intervention.rst
@@ -1,0 +1,239 @@
+.. _NumPyro: https://num.pyro.ai/
+
+Interventions & Effect Estimation
+=================================
+This guide covers two closely related functionalities:
+
+* The ``intervention`` argument available in predictive methods like :meth:`~aimz.ImpactModel.predict`, :meth:`~aimz.ImpactModel.predict_on_batch`, and their posterior predictive counterparts.
+  Internally, this enables hard (``do``) interventions on specified sample sites using NumPyro_'s :external:class:`~numpyro.handlers.do` effect handler to generate counterfactual draws without rewriting the model.
+
+* The :meth:`~aimz.ImpactModel.estimate_effect` method, which computes the elementwise difference between an intervention (counterfactual) scenario and a baseline (factual) scenario to quantify causal or policy impact.
+
+Typical workflow:
+
+1. Generate one predictive result under factual conditions (optionally also using ``intervention`` if you want to hold certain sites at specific values).
+2. Generate another predictive result under a modified ``intervention`` mapping.
+3. Pass both results (or the argument dictionaries to generate them lazily) to :meth:`~aimz.ImpactModel.estimate_effect` to obtain the effect output.
+
+Each scenario is a :class:`~xarray.DataTree` produced by the prediction API or materialized on-demand via argument dictionaries.
+
+
+Interventions
+-------------
+The ``intervention`` argument is a mapping (``dict[str, ArrayLike]``) from sample site name to a replacement value; during predictive sampling each listed site is fixed, enabling counterfactual or policy analysis.
+Values must broadcast to the site’s per‑observation shape (e.g., intervening on a length‑``N`` vector site generally requires shape ``(N,)``).
+You can modify multiple sites at once; any not specified follow their posterior (or prior) distribution.
+
+Setting ``in_sample=True`` stores draws under ``posterior_predictive`` while ``in_sample=False`` stores them under ``predictions``—the group must match between baseline and intervention scenarios when computing effects.
+Deterministic downstream sites automatically reflect the intervened values.
+
+.. code-block:: python
+
+    # Minimal sketch of a model exposing a stochastic site 'z'
+    def model(X, Z, y=None):
+        ...
+        # site we may choose to override at prediction time
+        z = numpyro.sample("z", ...)
+        ...
+
+    # Fit (details elided);
+    im = ImpactModel(model, ...).fit_on_batch(...)
+
+    # Baseline scenario: set 'z' to its observed/factual value Z
+    baseline = im.predict_on_batch(X, intervention={"z": Z})
+
+    # Modified scenario: counterfactual where we overwrite 'z' with zeros
+    modified = im.predict_on_batch(
+        X,
+        intervention={"z": jnp.zeros_like(Z)},
+    )
+
+
+Effect Estimation
+-----------------
+The :meth:`~aimz.ImpactModel.estimate_effect` method computes an elementwise difference between two predictive scenarios (``intervention - baseline``) and returns a single-group :class:`~xarray.DataTree` that preserves sampling dimensions.
+
+One baseline and one intervention scenario must be provided, either eagerly (``output_baseline`` / ``output_intervention``) or lazily through argument dictionaries (``args_baseline`` / ``args_intervention``).
+Mixing is allowed; for example, a precomputed baseline can be supplied with ``output_baseline`` while the intervention is generated lazily with ``args_intervention`` (or the reverse).
+Both scenarios must come from the same predictive group (both ``posterior_predictive`` or both ``predictions``) with matching variable sets and shapes.
+
+The result contains that shared group name and each variable is the elementwise difference
+
+.. math:: \text{intervention} - \text{baseline}
+
+retaining leading ``draw`` / ``chain`` dimensions.
+
+Eager (precomputed scenarios)::
+
+    impact = im.estimate_effect(
+        output_baseline=baseline,
+        output_intervention=modified,
+    )
+
+Lazy (defer prediction)::
+
+    impact = im.estimate_effect(
+        args_baseline={
+            "X": X,
+            "intervention": {"z": Z},
+            "in_sample": False,
+        },
+        args_intervention={
+            "X": X,
+            "intervention": {"z": jnp.zeros_like(Z)},
+            "in_sample": False,
+        },
+    )
+
+Mixed (precomputed baseline, lazy intervention)::
+
+    impact = im.estimate_effect(
+        output_baseline=baseline,
+        args_intervention={
+            "X": X,
+            "intervention": {"z": jnp.zeros_like(Z)},
+            "in_sample": False,
+        },
+    )
+
+The returned :class:`~xarray.DataTree` captures the elementwise difference for every variable present in the predictive group.
+Any subsequent summary (e.g. mean, intervals) can be computed using Xarray, ArviZ, or standard NumPy / JAX utilities.
+
+
+Example: Causal Network with Confounder
+---------------------------------------
+This example illustrates a simple causal network. The variable ``Z`` has a direct causal effect on the outcome ``Y``, while both are influenced by a shared confounder, ``C``.
+An additional variable, ``X``, is an observed exogenous factor that influences ``Z`` but has no direct effect on ``Y``.
+
+Our objective is to estimate the causal effect of ``Z`` (or alternatively ``X``) on ``Y``, while properly accounting for the confounding influence of ``C``.
+We assume the following generative model for the observed data:
+
+Model
+~~~~~
+
+.. jupyter-execute::
+
+    import jax.numpy as jnp
+    import numpyro.distributions as dist
+    from jax import nn, random
+    from jax.typing import ArrayLike
+    from numpyro import optim, plate, sample
+    from numpyro.infer import SVI, Trace_ELBO, init_to_feasible
+    from numpyro.infer.autoguide import AutoNormal
+
+    from aimz import ImpactModel
+
+
+    def model(X: ArrayLike, C: ArrayLike, y: ArrayLike | None = None) -> None:
+        # Observed confounder
+        c = sample("c", dist.Exponential(), obs=C)
+
+        # Priors for coefficients in the structural model
+        # C -> Z and C -> Y
+        beta_cz = sample("beta_cz", dist.Normal())
+        beta_cy = sample("beta_cy", dist.Normal())
+
+        # X -> Z and Z -> Y
+        beta_xz = sample("beta_xz", dist.Normal())
+        beta_zy = sample("beta_zy", dist.Normal())
+
+        # Intercepts
+        beta_z = sample("beta_z", dist.Normal())
+        beta_y = sample("beta_y", dist.Normal())
+
+        # Observation noise for Z
+        sigma = sample("sigma", dist.Exponential())
+
+        # Plate over data
+        with plate("data", X.shape[0]):
+            mu_z = beta_z + beta_cz * c + beta_xz * X.squeeze(axis=1)
+            z = sample("z", dist.LogNormal(mu_z, sigma))
+
+            logits = beta_y + beta_cy * c + beta_zy * z
+            sample("y", dist.Bernoulli(logits=logits), obs=y)
+
+
+Simulating Data under a Known Structural Model
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+We generate synthetic data consistent with the assumed structure:
+
+- `C` is drawn from an exponential distribution.
+- `X` is a count variable from a Poisson distribution.
+- `Z` is generated as a noisy exponential function of `C` and `X`.
+- `Y` is a binary outcome influenced by both `C` and `Z` through a logistic model.
+
+.. jupyter-execute::
+
+    # Create a pseudo-random number generator key for JAX
+    rng_key = random.key(42)
+
+    # Sample C from an Exponential distribution
+    rng_key, rng_subkey = random.split(rng_key)
+    C = random.exponential(rng_subkey, shape=(100,))
+
+    # Sample X from a Poisson distribution
+    rng_key, rng_subkey = random.split(rng_key)
+    X = random.poisson(rng_subkey, lam=1, shape=(100, 1))
+
+    # Generate Z influenced by C and X
+    rng_key, rng_subkey = random.split(rng_key)
+    mu_z = -1.0 + 0.5 * C - 1.5 * X.squeeze()
+    sigma_z = 10.0  # Add substantial noise to reduce correlation between C and Z
+    Z = jnp.exp(random.normal(rng_subkey, shape=(100,)) * sigma_z + mu_z)
+
+    # Generate Y from a logistic regression on C and Z
+    rng_key, rng_subkey = random.split(rng_key)
+    logits = -2.0 + 5.0 * C + 0.1 * Z
+    p = nn.sigmoid(logits)
+    y = random.bernoulli(rng_subkey, p=p).astype(jnp.int32)
+
+
+Fitting the Model and Estimating Effects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+We fit the model using stochastic variational inference.
+Once trained, we perform a counterfactual analysis to isolate the effect of `Z` on `Y`.
+
+- `dt_factual` represents predictions under the factual setting (with observed `Z`).
+- `dt_counterfactual` represents predictions under a counterfactual intervention where `Z` is set to zero.
+
+.. note::
+
+    Local latent variable requires :meth:`~aimz.ImpactModel.predict_on_batch` here.
+    Prefer :meth:`~aimz.ImpactModel.predict` whenever it is compatible with the model.
+
+Comparing these two distributions allows us to estimate the effect of `Z` on `Y`, adjusted for the influence of `C`.
+
+.. jupyter-execute::
+    :hide-output:
+
+    im = ImpactModel(
+        model,
+        rng_key=rng_key,
+        inference=SVI(
+            model,
+            guide=AutoNormal(model, init_loc_fn=init_to_feasible()),
+            optim=optim.Adam(step_size=1e-3),
+            loss=Trace_ELBO(),
+        ),
+    )
+    im.fit_on_batch(X, y, C=C)
+
+    # Predict under factual (Z) and counterfactual (zeroed Z) scenarios
+    dt_factual = im.predict_on_batch(X, C=C, intervention={"z": Z})
+    dt_counterfactual = im.predict_on_batch(
+        X,
+        C=C,
+        intervention={"z": jnp.zeros_like(Z)},
+    )
+
+    # Estimate effect of intervening on Z while conditioning on C
+    impact = im.estimate_effect(
+        output_baseline=dt_factual,
+        output_intervention=dt_counterfactual,
+    )
+    impact
+
+.. jupyter-execute::
+    :hide-code:
+
+    impact

--- a/tests/test_estimate_effect.py
+++ b/tests/test_estimate_effect.py
@@ -1,0 +1,113 @@
+# Copyright 2025 Eli Lilly and Company
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the `.estimate_effect()` method."""
+
+from pathlib import Path
+
+import jax.numpy as jnp
+import pytest
+from conftest import latent_variable_model, lm
+from jax import random
+from jax.typing import ArrayLike
+from numpyro.infer import SVI, Trace_ELBO
+from numpyro.infer.autoguide import AutoNormal
+from numpyro.optim import Adam
+
+from aimz import ImpactModel
+from aimz._exceptions import NotFittedError
+
+
+def test_model_not_fitted() -> None:
+    """Calling `.estimate_effect()` on an unfitted model raises an error."""
+
+    def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
+        pass
+
+    im = ImpactModel(
+        kernel,
+        rng_key=random.key(42),
+        inference=SVI(
+            kernel,
+            guide=AutoNormal(kernel),
+            optim=Adam(step_size=1e-3),
+            loss=Trace_ELBO(),
+        ),
+    )
+    with pytest.raises(NotFittedError):
+        im.estimate_effect()
+
+
+@pytest.mark.parametrize("vi", [latent_variable_model], indirect=True)
+def test_estimate_effect_argument_validation(
+    synthetic_data: tuple[ArrayLike, ArrayLike],
+    vi: SVI,
+) -> None:
+    """Validate argument exclusivity and successful effect computation."""
+    X, y = synthetic_data
+    im = ImpactModel(latent_variable_model, rng_key=random.key(42), inference=vi)
+    im.fit(X=X, y=y, batch_size=len(X))
+
+    msg = "Either `output_baseline` or `args_baseline` must be provided."
+    with pytest.raises(ValueError, match=msg):
+        im.estimate_effect(output_baseline=None, args_baseline=None)
+
+    dt_baseline = im.predict_on_batch(X)
+
+    msg = "Either `output_intervention` or `args_intervention` must be provided."
+    with pytest.raises(ValueError, match=msg):
+        im.estimate_effect(output_baseline=dt_baseline)
+
+    dt_intervention = im.predict_on_batch(X, intervention={"z": jnp.zeros_like(y)})
+
+    impact = im.estimate_effect(
+        output_baseline=dt_baseline,
+        output_intervention=dt_intervention,
+    )
+
+    assert impact.posterior_predictive["y"].mean(dim=["chain", "draw"]).shape == (
+        len(y),
+    )
+
+
+@pytest.mark.parametrize("vi", [lm], indirect=True)
+def test_estimate_effect_output_dir_lazy_args(
+    synthetic_data: tuple[ArrayLike, ArrayLike],
+    vi: SVI,
+) -> None:
+    """Ensure lazy (args_*) inputs work and baseline `output_dir` is propagated."""
+    X, y = synthetic_data
+    im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
+    im.fit(X=X, y=y, batch_size=len(X))
+
+    msg = (
+        r"The `batch_size` \(\d+\) is not divisible by the number of devices"
+        r" \(\d+\)\."
+    )
+    with pytest.warns(UserWarning, match=msg):
+        impact = im.estimate_effect(
+            args_baseline={
+                "X": X,
+                "batch_size": len(X),
+            },
+            args_intervention={
+                "X": X,
+                "intervention": {"sigma": 10.0},
+                "batch_size": len(X),
+            },
+        )
+
+    # Confirm the temporary output directory propagated to effect result
+    assert impact.attrs.get("output_dir") == str(Path(im.temp_dir).resolve())
+    im.cleanup()


### PR DESCRIPTION
Update the `.estimate_effect()` method to return a `posterior` group when posterior samples are available, ensuring consistency with other methods. Additionally, propagate the `output_dir` attribute from the baseline or intervention DataTree objects to the resulting DataTree. Include documentation updates and unit tests to validate these changes.

Fixes #110