### PR TITLE
Add MLflow autolog support for `.fit_on_batch()`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
       # Ruff version.
-      rev: v0.13.2
+      rev: v0.13.3
       hooks:
           # Run the linter.
           - id: ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file and are best
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Extended MLflow autologging to support the {meth}`~aimz.ImpactModel.fit_on_batch` method ([#119](https://github.com/markean/aimz/issues/119)).
+
 ## [v0.7.0](https://github.com/markean/aimz/releases/tag/v0.7.0) - 2025-09-29
 
 ### Added

--- a/docs/source/user_guide/mlflow.rst
+++ b/docs/source/user_guide/mlflow.rst
@@ -123,8 +123,7 @@ Logging directly to an active MLflow run:
         mlflow.log_metric("training_time_sec", 120.5)
 
         # Log the model
-        # input_example should be a dict of named arrays
-        model_info = log_model(im, input_example={"X": X, "y": y, "z": z})
+        model_info = log_model(im)
 
 
     # Reload the model from the MLflow registry for inference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aimz"
-version = "0.7.0"
+version = "0.8.0.dev0"
 description = "Scalable probabilistic impact modeling"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ wheels = [
 
 [[package]]
 name = "aimz"
-version = "0.7.0"
+version = "0.8.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "dask" },


### PR DESCRIPTION
Integrate MLflow autologging within the `.fit_on_batch()` method of `ImpactModel` and update the documentation accordingly. Increment the version to 0.8.0.dev0 to reflect these changes.

Fixes #119