### PR TITLE
Update JAX shard_map usage and pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.14.1
+    rev: v0.14.2
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.14.0
+    rev: v0.14.1
     hooks:
       # Run the linter.
       - id: ruff-check
@@ -50,6 +50,6 @@ repos:
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.9.2
+    rev: 0.9.5
     hooks:
       - id: uv-lock

--- a/aimz/utils/data/_sharding.py
+++ b/aimz/utils/data/_sharding.py
@@ -12,19 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module for creating functions for sharding.
-
-NOTE: This module is experimental and subject to change. It utilizes JAX's `shard_map()`
-to distribute computations across devices. Tested on CPU and GPU.
-"""
+"""Module for creating functions for sharding."""
 
 from __future__ import annotations
 
 from functools import partial
 from typing import TYPE_CHECKING
 
-from jax import Array, jit
-from jax.experimental.shard_map import shard_map
+from jax import Array, jit, shard_map
 from jax.sharding import PartitionSpec
 from numpyro.infer import log_likelihood as log_lik
 
@@ -132,7 +127,6 @@ def _create_sharded_sampler(
                 ),
             ),
             out_specs=PartitionSpec(None, axis),
-            check_rep=False,
         )(f),
     )
 
@@ -227,6 +221,5 @@ def _create_sharded_log_likelihood(
                 ),
             ),
             out_specs=PartitionSpec(None, axis),
-            check_rep=False,
         )(f),
     )

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,7 +20,8 @@ import sys
 from importlib import metadata
 from pathlib import Path
 
-import mlflow
+# Prevent Sphinx autodoc from failing when inspecting MLflow autologging decorators
+from mlflow.utils.autologging_utils import autologging_integration
 
 import aimz
 
@@ -57,6 +58,7 @@ extensions = [
 ]
 templates_path = ["_templates"]
 exclude_patterns = ["**.pkl", "**.ipynb_checkpoints"]
+autodoc_mock_imports = ["mlflow.utils.autologging_utils.autologging_integration"]
 autodoc_typehints = "description"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),


### PR DESCRIPTION
Replace deprecated `jax.experimental.shard_map` with `jax.shard_map` to ensure compatibility with JAX 0.8 and later. Update pre-commit hooks to their latest versions and adjust Sphinx configuration for MLflow integration.

Fixes #128