### PR TITLE
Add class-level cleanup method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file and are best
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added the class method {meth}`~aimz.ImpactModel.cleanup_models` to clean up temporary directories for all active model instances ([#136](https://github.com/markean/aimz/issues/136)).
+
 ## [v0.8.1](https://github.com/markean/aimz/releases/tag/v0.8.1) - 2025-10-23
 
 ### Changed

--- a/docs/source/api/impact_model.rst
+++ b/docs/source/api/impact_model.rst
@@ -62,3 +62,4 @@ Miscellaneous
 
    ImpactModel.estimate_effect
    ImpactModel.cleanup
+   ImpactModel.cleanup_models

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aimz"
-version = "0.8.2.dev0"
+version = "0.9.0.dev0"
 description = "Scalable probabilistic impact modeling"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_cleanup_models.py
+++ b/tests/test_cleanup_models.py
@@ -1,0 +1,46 @@
+# Copyright 2025 Eli Lilly and Company
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the `.cleanup_models()` method."""
+
+import pytest
+from jax import random
+from jax.typing import ArrayLike
+from numpyro.infer import SVI
+
+from aimz import ImpactModel
+from tests.conftest import lm
+
+
+@pytest.mark.parametrize("vi", [lm], indirect=True)
+def test_predict_after_cleanup(
+    synthetic_data: tuple[ArrayLike, ArrayLike],
+    vi: SVI,
+) -> None:
+    """Ensure class-level cleanup removes temporary directories for all instances."""
+    X, y = synthetic_data
+
+    im1 = ImpactModel(lm, rng_key=random.key(42), inference=vi)
+    im1.fit_on_batch(X=X, y=y)
+
+    im2 = ImpactModel(lm, rng_key=random.key(42), inference=vi)
+    im2.fit_on_batch(X=X, y=y)
+
+    im1.predict(X, batch_size=3)
+    im2.predict(X, batch_size=3)
+
+    ImpactModel.cleanup_models()
+
+    assert im1.temp_dir is None
+    assert im2.temp_dir is None

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ wheels = [
 
 [[package]]
 name = "aimz"
-version = "0.8.2.dev0"
+version = "0.9.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "dask" },


### PR DESCRIPTION
Introduce a class method `cleanup_models` to the `ImpactModel` class, enabling the cleanup of temporary directories for all active model instances at once. 

Fixes #136