### PR TITLE
Lower logging level for temporary directory cleanup exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The output subdirectory naming convention has changed from using only a timestamp to the pattern `<timestamp>_<caller_name>/`, where `<caller_name>` is the name of the method that triggered the write operation ([#138](https://github.com/markean/aimz/issues/138)).
+- Lowered the logging level for exceptions during temporary directory cleanup from `exception` to `debug` to reduce console noise.
 
 ## [v0.8.1](https://github.com/markean/aimz/releases/tag/v0.8.1) - 2025-10-23
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -493,7 +493,6 @@ class ImpactModel(BaseModel):
                     queues[site].put(
                         (arr[:, None] if arr.ndim == 1 else arr)[:, : -n_pad or None],
                     )
-
                 if not error_queue.empty():
                     _, exc, tb = error_queue.get()
                     raise exc.with_traceback(tb)
@@ -501,7 +500,7 @@ class ImpactModel(BaseModel):
             pbar.set_description("Sampling complete, writing in progress...")
             _shutdown_writer_threads(threads, queues)
         except:
-            logger.exception(
+            logger.debug(
                 "Exception encountered. Cleaning up output directory: %s",
                 output_dir,
             )
@@ -1715,7 +1714,7 @@ class ImpactModel(BaseModel):
             pbar.set_description("Computation complete, writing in progress...")
             _shutdown_writer_threads(threads, queues=queues)
         except:
-            logger.exception(
+            logger.debug(
                 "Exception encountered. Cleaning up output directory: %s",
                 output_subdir,
             )


### PR DESCRIPTION
Lowered the logging level for exceptions during temporary directory cleanup from `exception` to `debug` to reduce console noise while still allowing developers to track cleanup activities.

Fixes #140