### PR TITLE
Change `ArrayDataset` default to `to_jax=False`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.2
+    rev: v0.15.5
     hooks:
       # Run the linter.
       - id: ruff-check
@@ -50,6 +50,6 @@ repos:
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.10.4
+    rev: 0.10.9
     hooks:
       - id: uv-lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file and are best
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- {class}`~aimz.utils.data.ArrayDataset` now employs NumPy-based indexing in {class}`~aimz.utils.data.ArrayLoader` instead of triggering JAX tracing on each batch ([#168](https://github.com/markean/aimz/issues/168)).
+- Changed the default value of `to_jax` in {class}`~aimz.utils.data.ArrayDataset` from `True` to `False` to avoid redundant conversion ([#170](https://github.com/markean/aimz/issues/170)).
+
 ## [v0.9.1](https://github.com/markean/aimz/releases/tag/v0.9.1) - 2025-12-08
 
 ### Fixed

--- a/aimz/utils/_output.py
+++ b/aimz/utils/_output.py
@@ -45,7 +45,7 @@ def _writer(site: str, queue: Queue, group_path: Path, error_queue: Queue) -> No
     Args:
         site: The name of the sample site.
         queue: The queue to retrieve posterior predictive samples from.
-        group_path: The path to the Zarr group where data will be written.
+        group_path: The path of the Zarr group.
         error_queue: The queue to collect errors raised by the writer thread.
     """
     group = open_group(group_path, mode="r+")

--- a/aimz/utils/data/_input_setup.py
+++ b/aimz/utils/data/_input_setup.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, NamedTuple, cast
+from typing import TYPE_CHECKING, NamedTuple
 from warnings import warn
 
 from jax.typing import ArrayLike
@@ -27,8 +27,6 @@ from aimz.utils._kwargs import _group_kwargs
 from aimz.utils.data import ArrayDataset, ArrayLoader
 
 if TYPE_CHECKING:
-    from collections.abc import Sized
-
     from jax import Array
     from jax.sharding import Sharding
 
@@ -83,8 +81,8 @@ def _setup_inputs(
             X, y = check_X_y(X, y, force_writeable=True, y_numeric=True)
         num_devices = device.num_devices if device else 1
         if batch_size is None:
-            if len(cast("Sized", X)) * num_samples < MAX_ELEMENTS:
-                batch_size = len(cast("Sized", X))
+            if len(X) * num_samples < MAX_ELEMENTS:
+                batch_size = len(X)
             else:
                 batch_size = MAX_ELEMENTS // num_samples
                 batch_size -= batch_size % num_devices
@@ -101,7 +99,7 @@ def _setup_inputs(
             )
             warn(msg, category=UserWarning, stacklevel=2)
         loader = ArrayLoader(
-            ArrayDataset(X=X, y=y, to_jax=False, **kwargs_array._asdict()),
+            ArrayDataset(X=X, y=y, **kwargs_array._asdict()),
             rng_key=rng_key,
             batch_size=batch_size,
             shuffle=shuffle,

--- a/aimz/utils/data/array_dataset.py
+++ b/aimz/utils/data/array_dataset.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module for custom dataset for JAX arrays."""
+"""Module for :class:`~aimz.utils.data.ArrayDataset`."""
 
 from __future__ import annotations
 
@@ -28,23 +28,25 @@ if TYPE_CHECKING:
 
 
 class ArrayDataset:
-    """ArrayDataset class for JAX arrays."""
+    """Dataset for named arrays."""
 
     def __init__(
         self,
         *,
-        to_jax: bool = True,
+        to_jax: bool = False,
         **arrays: Array | npt.NDArray | None,
     ) -> None:
         """Initialize an ArrayDataset instance.
 
         Args:
             to_jax: Whether to convert the input arrays to JAX arrays.
-            **arrays: One or more JAX arrays or compatible array-like objects.
+            **arrays: Named JAX arrays, NumPy arrays, or ``None``. At least one
+                non-``None`` array must be provided. All non-``None`` arrays must have
+                the same length.
 
         Raises:
-            ValueError: If no arrays are provided or if the arrays do not have the same
-                length.
+            ValueError: If no non-``None`` arrays are provided or if the arrays do not
+                have the same length.
         """
         arrays = {k: v for k, v in arrays.items() if v is not None}
         if not arrays:
@@ -75,6 +77,6 @@ class ArrayDataset:
             idx: Index of the item to retrieve.
 
         Returns:
-            A tuple containing the elements from each array at the specified index.
+            A dictionary mapping array names to their elements at the specified index.
         """
         return {k: v[idx] for k, v in self.arrays.items() if v is not None}

--- a/tests/test_array_loader.py
+++ b/tests/test_array_loader.py
@@ -42,10 +42,10 @@ class TestArrayDataset:
             ArrayDataset(X=X, y=y)
 
     def test_no_jax_conversion(self) -> None:
-        """Check that arrays remain NumPy arrays when `to_jax=False` is specified."""
+        """Check that arrays remain NumPy arrays by default."""
         X = np.array([[1, 2, 3], [4, 5, 6]])
         y = np.array([1, 2])
-        dataset = ArrayDataset(X=X, y=y, to_jax=False)
+        dataset = ArrayDataset(X=X, y=y)
         actual = next(iter(dataset))
         desired = {"X": np.array([1, 2, 3]), "y": np.array(1)}
         assert actual.keys() == desired.keys()


### PR DESCRIPTION
Update the default value of `to_jax` in `ArrayDataset` to `False` to prevent unnecessary eager conversion of input arrays to JAX arrays during construction, which can lead to increased memory usage. Adjusted related docstrings for clarity and updated tests to reflect the new default behavior.

Fixes #170