### PR TITLE
Bump version to 0.11.0.dev0 and refactor tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aimz"
-version = "0.10.0"
+version = "0.11.0.dev0"
 description = "Scalable probabilistic impact modeling"
 readme = "README.md"
 license = "Apache-2.0"
@@ -108,4 +108,4 @@ include = ["aimz*"]
 namespaces = false
 
 [tool.uv]
-native-tls = true
+system-certs = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,15 +14,18 @@
 
 """pytest configuration."""
 
+from collections.abc import Callable, Iterator
+
 import jax.numpy as jnp
 import numpyro
 import numpyro.distributions as dist
 import pytest
 from jax import Array, random
-from jax.typing import ArrayLike
 from numpyro import sample
 from numpyro.infer import MCMC, NUTS, SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
+
+from aimz import ImpactModel
 
 numpyro.set_host_device_count(3)
 
@@ -32,7 +35,7 @@ def synthetic_data() -> tuple[Array, Array]:
     """Fixture for generating synthetic data.
 
     Returns:
-        tuple[Array, Array]: A tuple containing the input data and output data.
+        The input data and output data.
     """
     rng_key = random.key(42)
     key_w, key_b, key_x, key_e = random.split(rng_key, 4)
@@ -89,7 +92,7 @@ def vi(request: pytest.FixtureRequest) -> SVI:
     )
 
 
-def lm(X: ArrayLike, y: ArrayLike | None = None) -> None:
+def lm(X: Array, y: Array | None = None) -> None:
     """Linear regression model."""
     n_features = X.shape[1]
 
@@ -103,11 +106,7 @@ def lm(X: ArrayLike, y: ArrayLike | None = None) -> None:
     sample("y", dist.Normal(mu, sigma), obs=y)
 
 
-def lm_with_kwargs_array(
-    X: ArrayLike,
-    c: ArrayLike,
-    y: ArrayLike | None = None,
-) -> None:
+def lm_with_kwargs_array(X: Array, c: Array, y: Array | None = None) -> None:
     """Linear regression model with an extra array argument."""
     n_features = X.shape[1]
 
@@ -121,10 +120,77 @@ def lm_with_kwargs_array(
     sample("y", dist.Normal(mu, sigma), obs=y)
 
 
-def latent_variable_model(X: ArrayLike, y: ArrayLike | None = None) -> None:
+def latent_variable_model(X: Array, y: Array | None = None) -> None:
     """Latent variable model."""
     z = numpyro.sample(
         "z",
         dist.Normal(0.0, 1.0).expand([X.shape[0]]),
     ) + X.mean(axis=1)
     numpyro.sample("y", dist.Normal(z, 1.0), obs=y)
+
+
+def _make_svi(model: Callable) -> SVI:
+
+    return SVI(
+        model,
+        guide=AutoNormal(model),
+        optim=numpyro.optim.Adam(step_size=1e-3),
+        loss=Trace_ELBO(),
+    )
+
+
+def _make_mcmc(model: Callable) -> MCMC:
+
+    return MCMC(NUTS(model), num_warmup=100, num_samples=100, num_chains=1)
+
+
+@pytest.fixture(scope="module")
+def im_lm_svi_fitted(synthetic_data: tuple[Array, Array]) -> Iterator[ImpactModel]:
+    """`lm` fitted with SVI. Reusable for read-only tests."""
+    X, y = synthetic_data
+    im = ImpactModel(lm, rng_key=random.key(42), inference=_make_svi(lm))
+    im.fit(X=X, y=y, batch_size=len(X), progress=False)
+    yield im
+    im.cleanup()
+
+
+@pytest.fixture(scope="module")
+def im_lm_mcmc_fitted(synthetic_data: tuple[Array, Array]) -> Iterator[ImpactModel]:
+    """`lm` fitted with MCMC. Reusable for read-only tests."""
+    X, y = synthetic_data
+    im = ImpactModel(lm, rng_key=random.key(42), inference=_make_mcmc(lm))
+    im.fit_on_batch(X=X, y=y)
+    yield im
+    im.cleanup()
+
+
+@pytest.fixture(scope="module")
+def im_lm_with_kwargs_svi_fitted(
+    synthetic_data: tuple[Array, Array],
+) -> Iterator[ImpactModel]:
+    """`lm_with_kwargs_array` fitted with SVI. Reusable for read-only tests."""
+    X, y = synthetic_data
+    im = ImpactModel(
+        lm_with_kwargs_array,
+        rng_key=random.key(42),
+        inference=_make_svi(lm_with_kwargs_array),
+    )
+    im.fit(X=X, y=y, c=y, batch_size=3, progress=False)
+    yield im
+    im.cleanup()
+
+
+@pytest.fixture(scope="module")
+def im_latent_var_svi_fitted(
+    synthetic_data: tuple[Array, Array],
+) -> Iterator[ImpactModel]:
+    """`latent_variable_model` fitted with SVI. Reusable for read-only tests."""
+    X, y = synthetic_data
+    im = ImpactModel(
+        latent_variable_model,
+        rng_key=random.key(42),
+        inference=_make_svi(latent_variable_model),
+    )
+    im.fit(X=X, y=y, batch_size=len(X), progress=False)
+    yield im
+    im.cleanup()

--- a/tests/test_array_loader.py
+++ b/tests/test_array_loader.py
@@ -18,7 +18,6 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 from jax import Array, random
-from jax.typing import ArrayLike
 from numpyro.infer import SVI
 
 from aimz import ImpactModel
@@ -104,7 +103,7 @@ class TestArrayLoader:
     @pytest.mark.parametrize("vi", [lm], indirect=True)
     def test_fit_dataloader_y_not_none_error(
         self,
-        synthetic_data: tuple[ArrayLike, ArrayLike],
+        synthetic_data: tuple[Array, Array],
         vi: SVI,
     ) -> None:
         """Passing a data loader as `X` and a non-None `y` raises an error."""
@@ -121,7 +120,7 @@ class TestArrayLoader:
     @pytest.mark.parametrize("vi", [lm], indirect=True)
     def test_fit_consistency_with_array_and_dataloader(
         self,
-        synthetic_data: tuple[ArrayLike, ArrayLike],
+        synthetic_data: tuple[Array, Array],
         vi: SVI,
     ) -> None:
         """Calling `.fit()` with arrays or a data loader can yield identical results."""

--- a/tests/test_cleanup_models.py
+++ b/tests/test_cleanup_models.py
@@ -15,8 +15,7 @@
 """Tests for the `.cleanup_models()` method."""
 
 import pytest
-from jax import random
-from jax.typing import ArrayLike
+from jax import Array, random
 from numpyro.infer import SVI
 
 from aimz import ImpactModel
@@ -25,7 +24,7 @@ from tests.conftest import lm
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
 def test_predict_after_cleanup(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
+    synthetic_data: tuple[Array, Array],
     vi: SVI,
 ) -> None:
     """Ensure class-level cleanup removes temporary directories for all instances."""

--- a/tests/test_estimate_effect.py
+++ b/tests/test_estimate_effect.py
@@ -18,21 +18,20 @@ from pathlib import Path
 
 import jax.numpy as jnp
 import pytest
-from jax import random
-from jax.typing import ArrayLike
+from jax import Array, random
 from numpyro.infer import SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
 from numpyro.optim import Adam
 
 from aimz import ImpactModel
 from aimz._exceptions import NotFittedError
-from tests.conftest import latent_variable_model, lm
+from tests.conftest import lm
 
 
 def test_model_not_fitted() -> None:
     """Calling `.estimate_effect()` on an unfitted model raises an error."""
 
-    def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
+    def kernel(X: Array, y: Array | None = None) -> None:
         pass
 
     im = ImpactModel(
@@ -49,15 +48,13 @@ def test_model_not_fitted() -> None:
         im.estimate_effect()
 
 
-@pytest.mark.parametrize("vi", [latent_variable_model], indirect=True)
 def test_estimate_effect_argument_validation(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
-    vi: SVI,
+    synthetic_data: tuple[Array, Array],
+    im_latent_var_svi_fitted: ImpactModel,
 ) -> None:
     """Validate argument exclusivity and successful effect computation."""
     X, y = synthetic_data
-    im = ImpactModel(latent_variable_model, rng_key=random.key(42), inference=vi)
-    im.fit(X=X, y=y, batch_size=len(X))
+    im = im_latent_var_svi_fitted
 
     msg = "Either `output_baseline` or `args_baseline` must be provided."
     with pytest.raises(ValueError, match=msg):
@@ -83,7 +80,7 @@ def test_estimate_effect_argument_validation(
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
 def test_estimate_effect_output_dir_lazy_args(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
+    synthetic_data: tuple[Array, Array],
     vi: SVI,
 ) -> None:
     """Ensure lazy (args_*) inputs work and baseline `output_dir` is propagated."""
@@ -113,17 +110,14 @@ def test_estimate_effect_output_dir_lazy_args(
     im.cleanup()
 
 
-@pytest.mark.parametrize("vi", [lm], indirect=True)
 def test_estimate_effect_on_batch(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
-    vi: SVI,
+    synthetic_data: tuple[Array, Array],
+    im_lm_svi_fitted: ImpactModel,
 ) -> None:
     """Ensure `on_batch=True` uses `predict_on_batch` and produces valid results."""
-    X, y = synthetic_data
-    im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
-    im.fit(X=X, y=y, batch_size=len(X))
+    X, _ = synthetic_data
 
-    effect = im.estimate_effect(
+    effect = im_lm_svi_fitted.estimate_effect(
         args_baseline={"X": X},
         args_intervention={"X": X, "intervention": {"sigma": 10.0}},
         on_batch=True,
@@ -133,22 +127,19 @@ def test_estimate_effect_on_batch(
     assert "output_dir" not in effect.attrs
 
 
-@pytest.mark.parametrize("vi", [lm], indirect=True)
 @pytest.mark.parametrize("in_sample", [True, False])
 def test_estimate_effect_on_batch_dict(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
-    vi: SVI,
+    synthetic_data: tuple[Array, Array],
+    im_lm_svi_fitted: ImpactModel,
     *,
     in_sample: bool,
 ) -> None:
     """Dict results from `predict_on_batch` are wrapped in the correct group."""
-    X, y = synthetic_data
-    im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
-    im.fit(X=X, y=y, batch_size=len(X))
+    X, _ = synthetic_data
 
     expected_group = "posterior_predictive" if in_sample else "predictions"
 
-    effect = im.estimate_effect(
+    effect = im_lm_svi_fitted.estimate_effect(
         args_baseline={"X": X, "return_datatree": False, "in_sample": in_sample},
         args_intervention={
             "X": X,

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -17,8 +17,7 @@
 import jax.numpy as jnp
 import numpyro.distributions as dist
 import pytest
-from jax import random
-from jax.typing import ArrayLike
+from jax import Array, random
 from numpyro import deterministic, sample
 from numpyro.infer import MCMC, SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
@@ -37,7 +36,7 @@ class TestKernelSignatureValidation:
     def test_extra_parameters(self) -> None:
         """Extra parameters not present in the kernel raise an error."""
 
-        def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
+        def kernel(X: Array, y: Array | None = None) -> None:
             pass
 
         with pytest.warns(
@@ -60,7 +59,7 @@ class TestKernelSignatureValidation:
     def test_missing_parameters(self) -> None:
         """Missing required parameters in the kernel raise an error."""
 
-        def kernel(X: ArrayLike, arg: object, y: ArrayLike | None = None) -> None:
+        def kernel(X: Array, arg: object, y: Array | None = None) -> None:
             pass
 
         im = ImpactModel(
@@ -83,7 +82,7 @@ class TestKernelBodyValidation:
     def test_missing_output_site(self) -> None:
         """Missing output sample site in the kernel raises an error."""
 
-        def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
+        def kernel(X: Array, y: Array | None = None) -> None:
             sample("z", dist.Normal(0.0, 1.0), obs=y)
 
         im = ImpactModel(
@@ -102,7 +101,7 @@ class TestKernelBodyValidation:
     def test_sample_output_site(self) -> None:
         """Raises error if output site is not a sample site."""
 
-        def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
+        def kernel(X: Array, y: Array | None = None) -> None:
             deterministic("y", jnp.zeros_like(y))
 
         im = ImpactModel(
@@ -121,7 +120,7 @@ class TestKernelBodyValidation:
     def test_unobserved_output_site(self) -> None:
         """Raises error if output site is not observed."""
 
-        def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
+        def kernel(X: Array, y: Array | None = None) -> None:
             sample("y", dist.Normal(0.0, 1.0))
 
         im = ImpactModel(
@@ -140,7 +139,7 @@ class TestKernelBodyValidation:
     def test_parameter_site_conflict(self) -> None:
         """Raises an error if a parameter name conflicts with a site name."""
 
-        def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
+        def kernel(X: Array, y: Array | None = None) -> None:
             sample("X", dist.Normal(0.0, 1.0))
             sample("y", dist.Normal(0.0, 1.0), obs=y)
 
@@ -160,7 +159,7 @@ class TestKernelBodyValidation:
     def test_kernel_with_invalid_site_name(self) -> None:
         """Kernel with site names incompatible with xarray.DataTree raises an error."""
 
-        def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
+        def kernel(X: Array, y: Array | None = None) -> None:
             mu = sample("x/y", dist.Normal())
             sigma = sample("sigma", dist.Exponential(1.0))
             sample("y", dist.Normal(mu, sigma), obs=y)
@@ -190,7 +189,7 @@ def test_fit_raises_for_mcmc_inference(mcmc: MCMC) -> None:
 def test_fit_unexpected_y_shape() -> None:
     """Calling `.fit()` with an unexpected shape of `y` raises a warning."""
 
-    def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
+    def kernel(X: Array, y: Array | None = None) -> None:
         sample("y", dist.Normal(0.0, 1.0), obs=y)
 
     im = ImpactModel(
@@ -207,7 +206,7 @@ def test_fit_unexpected_y_shape() -> None:
         im.fit(X=jnp.zeros((3, 2)), y=jnp.zeros((3, 1)), batch_size=3)
 
 
-def test_fit_nan_warning(synthetic_data: tuple[ArrayLike, ArrayLike]) -> None:
+def test_fit_nan_warning(synthetic_data: tuple[Array, Array]) -> None:
     """Test that `.fit()` emits a RuntimeWarning when NaN is in the loss."""
     X, y = synthetic_data
     im = ImpactModel(
@@ -228,7 +227,7 @@ def test_fit_nan_warning(synthetic_data: tuple[ArrayLike, ArrayLike]) -> None:
 
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
-def test_fit_lm(synthetic_data: tuple[ArrayLike, ArrayLike], vi: SVI) -> None:
+def test_fit_lm(synthetic_data: tuple[Array, Array], vi: SVI) -> None:
     """Test the `.fit()` method of `ImpactModel`."""
     X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), inference=vi)

--- a/tests/test_fit_on_batch.py
+++ b/tests/test_fit_on_batch.py
@@ -15,8 +15,7 @@
 """Tests for the `.fit_on_batch()` method."""
 
 import pytest
-from jax import random
-from jax.typing import ArrayLike
+from jax import Array, random
 from numpyro.infer import MCMC, SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
 from numpyro.optim import Adam
@@ -26,7 +25,7 @@ from aimz.utils._validation import _is_fitted
 from tests.conftest import lm
 
 
-def test_fit_on_batch_nan_warning(synthetic_data: tuple[ArrayLike, ArrayLike]) -> None:
+def test_fit_on_batch_nan_warning(synthetic_data: tuple[Array, Array]) -> None:
     """Test that `.fit_on_batch()` emits a RuntimeWarning when NaN is in the loss."""
     X, y = synthetic_data
     im = ImpactModel(
@@ -44,7 +43,7 @@ def test_fit_on_batch_nan_warning(synthetic_data: tuple[ArrayLike, ArrayLike]) -
 
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
-def test_fit_svi(synthetic_data: tuple[ArrayLike, ArrayLike], vi: SVI) -> None:
+def test_fit_svi(synthetic_data: tuple[Array, Array], vi: SVI) -> None:
     """Test the `.fit()` method of ImpactModel using SVI."""
     X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
@@ -62,7 +61,7 @@ def test_fit_svi(synthetic_data: tuple[ArrayLike, ArrayLike], vi: SVI) -> None:
 
 
 @pytest.mark.parametrize("mcmc", [lm], indirect=True)
-def test_fit_mcmc(synthetic_data: tuple[ArrayLike, ArrayLike], mcmc: MCMC) -> None:
+def test_fit_mcmc(synthetic_data: tuple[Array, Array], mcmc: MCMC) -> None:
     """Test the `.fit()` method of ImpactModel using MCMC."""
     X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), inference=mcmc)

--- a/tests/test_log_likelihood.py
+++ b/tests/test_log_likelihood.py
@@ -15,21 +15,19 @@
 """Tests for the `.log_likelihood()` method."""
 
 import pytest
-from jax import random
-from jax.typing import ArrayLike
+from jax import Array, random
 from numpyro.infer import SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
 from numpyro.optim import Adam
 
 from aimz import ImpactModel
 from aimz._exceptions import NotFittedError
-from tests.conftest import lm
 
 
 def test_model_not_fitted() -> None:
     """Calling `.log_likelihood()` on an unfitted model raises an error."""
 
-    def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
+    def kernel(X: Array, y: Array | None = None) -> None:
         pass
 
     im = ImpactModel(
@@ -49,19 +47,16 @@ def test_model_not_fitted() -> None:
 class TestBatchSize:
     """Test class related to batch size specification."""
 
-    @pytest.mark.parametrize("vi", [lm], indirect=True)
     def test_default_batch_size(
         self,
-        synthetic_data: tuple[ArrayLike, ArrayLike],
-        vi: SVI,
+        synthetic_data: tuple[Array, Array],
+        im_lm_svi_fitted: ImpactModel,
     ) -> None:
         """Warns if `batch_size` is not explicitly set."""
         X, y = synthetic_data
-        im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
-        im.fit(X=X, y=y, batch_size=3)
         msg = (
             r"The `batch_size` \(\d+\) is not divisible by the number of devices "
             r"\(\d+\)\."
         )
         with pytest.warns(UserWarning, match=msg):
-            im.log_likelihood(X=X, y=y)
+            im_lm_svi_fitted.log_likelihood(X=X, y=y)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -18,8 +18,7 @@ from tempfile import TemporaryDirectory
 
 import numpyro.distributions as dist
 import pytest
-from jax import random
-from jax.typing import ArrayLike
+from jax import Array, random
 from numpyro import sample
 from numpyro.infer import SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
@@ -27,13 +26,13 @@ from numpyro.optim import Adam
 
 from aimz import ImpactModel
 from aimz._exceptions import NotFittedError
-from tests.conftest import latent_variable_model, lm
+from tests.conftest import lm
 
 
 def test_model_not_fitted() -> None:
     """Calling `.predict()` on an unfitted model raises an error."""
 
-    def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
+    def kernel(X: Array, y: Array | None = None) -> None:
         pass
 
     im = ImpactModel(
@@ -50,58 +49,46 @@ def test_model_not_fitted() -> None:
         im.predict(None)
 
 
-@pytest.mark.parametrize("vi", [latent_variable_model], indirect=True)
 def test_predict_fall_back(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
-    vi: SVI,
+    synthetic_data: tuple[Array, Array],
+    im_latent_var_svi_fitted: ImpactModel,
 ) -> None:
     """Calling `.predict()` warns and falls back on an incompatible model."""
-    X, y = synthetic_data
-    im = ImpactModel(latent_variable_model, rng_key=random.key(42), inference=vi)
-    im.fit(X=X, y=y, batch_size=len(X))
+    X, _ = synthetic_data
     msg = "One or more posterior sample shapes are not compatible"
     with pytest.warns(UserWarning, match=msg):
-        im.predict(X=X, batch_size=len(X), progress=False)
+        im_latent_var_svi_fitted.predict(X=X, batch_size=len(X), progress=False)
 
 
 class TestKernelParameterValidation:
     """Test class for validating parameter compatibility with the kernel."""
 
-    @pytest.mark.parametrize("vi", [lm], indirect=True)
     def test_invalid_parameter(
         self,
-        synthetic_data: tuple[ArrayLike, ArrayLike],
-        vi: SVI,
+        synthetic_data: tuple[Array, Array],
+        im_lm_svi_fitted: ImpactModel,
     ) -> None:
         """An invalid parameter raise an error."""
         X, y = synthetic_data
-        im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
-        im.fit(X=X, y=y, batch_size=3)
         with pytest.raises(TypeError):
-            im.predict(X=X, y=y)
+            im_lm_svi_fitted.predict(X=X, y=y)
 
-    @pytest.mark.parametrize("vi", [lm], indirect=True)
     def test_extra_parameters(
         self,
-        synthetic_data: tuple[ArrayLike, ArrayLike],
-        vi: SVI,
+        synthetic_data: tuple[Array, Array],
+        im_lm_svi_fitted: ImpactModel,
     ) -> None:
         """Extra parameters not present in the kernel raise an error."""
-        X, y = synthetic_data
-        im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
-        im.fit(X=X, y=y, batch_size=3)
+        X, _ = synthetic_data
         with pytest.raises(TypeError):
-            im.predict(X=X, extra=True)
+            im_lm_svi_fitted.predict(X=X, extra=True)
 
-    def test_missing_parameters(
-        self,
-        synthetic_data: tuple[ArrayLike, ArrayLike],
-    ) -> None:
+    def test_missing_parameters(self, synthetic_data: tuple[Array, Array]) -> None:
         """Missing required parameters in the kernel raise an error."""
         X, y = synthetic_data
         arg = True
 
-        def kernel(X: ArrayLike, arg: object, y: ArrayLike | None = None) -> None:
+        def kernel(X: Array, arg: object, y: Array | None = None) -> None:
             sample("y", dist.Normal(0.0, 1.0), obs=y)
 
         vi = SVI(
@@ -119,25 +106,19 @@ class TestKernelParameterValidation:
 class TestBatchSize:
     """Test class related to batch size specification."""
 
-    @pytest.mark.parametrize("vi", [lm], indirect=True)
     def test_default_batch_size(
         self,
-        synthetic_data: tuple[ArrayLike, ArrayLike],
-        vi: SVI,
+        synthetic_data: tuple[Array, Array],
+        im_lm_svi_fitted: ImpactModel,
     ) -> None:
         """Warns if `batch_size` is not explicitly set."""
-        X, y = synthetic_data
-        im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
-        im.fit(X=X, y=y, batch_size=3)
+        X, _ = synthetic_data
         with pytest.warns(UserWarning, match=".*"):
-            im.predict(X=X, progress=False)
+            im_lm_svi_fitted.predict(X=X, progress=False)
 
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
-def test_predict_after_cleanup(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
-    vi: SVI,
-) -> None:
+def test_predict_after_cleanup(synthetic_data: tuple[Array, Array], vi: SVI) -> None:
     """Test `.predict()` recreates tempdir after `.cleanup()`."""
     X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), inference=vi)

--- a/tests/test_predict_on_batch.py
+++ b/tests/test_predict_on_batch.py
@@ -16,8 +16,7 @@
 
 import numpyro.distributions as dist
 import pytest
-from jax import random
-from jax.typing import ArrayLike
+from jax import Array, random
 from numpyro import sample
 from numpyro.infer import SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
@@ -25,13 +24,12 @@ from numpyro.optim import Adam
 
 from aimz import ImpactModel
 from aimz._exceptions import NotFittedError
-from tests.conftest import lm, lm_with_kwargs_array
 
 
 def test_model_not_fitted() -> None:
     """Calling `.predict_on_batch()` on an unfitted model raises an error."""
 
-    def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
+    def kernel(X: Array, y: Array | None = None) -> None:
         pass
 
     im = ImpactModel(
@@ -51,41 +49,32 @@ def test_model_not_fitted() -> None:
 class TestKernelParameterValidation:
     """Test class for validating parameter compatibility with the kernel."""
 
-    @pytest.mark.parametrize("vi", [lm], indirect=True)
     def test_invalid_parameter(
         self,
-        synthetic_data: tuple[ArrayLike, ArrayLike],
-        vi: SVI,
+        synthetic_data: tuple[Array, Array],
+        im_lm_svi_fitted: ImpactModel,
     ) -> None:
         """An invalid parameter raise an error."""
         X, y = synthetic_data
-        im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
-        im.fit(X=X, y=y, batch_size=3)
         with pytest.raises(TypeError):
-            im.predict_on_batch(X=X, y=y)
+            im_lm_svi_fitted.predict_on_batch(X=X, y=y)
 
-    @pytest.mark.parametrize("vi", [lm], indirect=True)
     def test_extra_parameters(
         self,
-        synthetic_data: tuple[ArrayLike, ArrayLike],
-        vi: SVI,
+        synthetic_data: tuple[Array, Array],
+        im_lm_svi_fitted: ImpactModel,
     ) -> None:
         """Extra parameters not present in the kernel raise an error."""
         X, y = synthetic_data
-        im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
-        im.fit(X=X, y=y, batch_size=3)
         with pytest.raises(TypeError):
-            im.predict_on_batch(X=X, y=y, extra=True)
+            im_lm_svi_fitted.predict_on_batch(X=X, y=y, extra=True)
 
-    def test_missing_parameters(
-        self,
-        synthetic_data: tuple[ArrayLike, ArrayLike],
-    ) -> None:
+    def test_missing_parameters(self, synthetic_data: tuple[Array, Array]) -> None:
         """Missing required parameters in the kernel raise an error."""
         X, y = synthetic_data
         arg = True
 
-        def kernel(X: ArrayLike, arg: object, y: ArrayLike | None = None) -> None:
+        def kernel(X: Array, arg: object, y: Array | None = None) -> None:
             sample("y", dist.Normal(0.0, 1.0), obs=y)
 
         vi = SVI(
@@ -100,19 +89,16 @@ class TestKernelParameterValidation:
             im.predict_on_batch(X=X)
 
 
-@pytest.mark.parametrize("vi", [lm_with_kwargs_array], indirect=True)
 def test_predict_on_batch_lm_with_kwargs_array(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
-    vi: SVI,
+    synthetic_data: tuple[Array, Array],
+    im_lm_with_kwargs_svi_fitted: ImpactModel,
 ) -> None:
     """Test the `.predict_on_batch()` method of ImpactModel."""
     X, y = synthetic_data
-    im = ImpactModel(lm_with_kwargs_array, rng_key=random.key(42), inference=vi)
-    im.fit(X=X, y=y, c=y, batch_size=3)
-    im.predict_on_batch(X=X, c=y, return_sites="y")
+    im_lm_with_kwargs_svi_fitted.predict_on_batch(X=X, c=y, return_sites="y")
 
     # `.sample_posterior_predictive_on_batch()` is an alias for `.predict_on_batch()`.
-    im.sample_posterior_predictive_on_batch(
+    im_lm_with_kwargs_svi_fitted.sample_posterior_predictive_on_batch(
         X=X,
         c=y,
         return_sites=["y"],

--- a/tests/test_prng_state.py
+++ b/tests/test_prng_state.py
@@ -16,8 +16,7 @@
 
 import jax.numpy as jnp
 import pytest
-from jax import random
-from jax.typing import ArrayLike
+from jax import Array, random
 from numpyro.infer import SVI
 
 from aimz import ImpactModel
@@ -25,10 +24,7 @@ from tests.conftest import lm
 
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
-def test_rng_key_consistency(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
-    vi: SVI,
-) -> None:
+def test_rng_key_consistency(synthetic_data: tuple[Array, Array], vi: SVI) -> None:
     """Test that the ImpactModel's internal rng_key remains unchanged.
 
     Verifies that providing an explicit PRNG key to method calls does not mutate the

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -14,45 +14,30 @@
 
 """Tests for the `.sample()` method."""
 
-from typing import TYPE_CHECKING
-
 import pytest
-from jax import random
-from jax.typing import ArrayLike
-from numpyro.infer import MCMC
+from jax import Array, random
 
 from aimz import ImpactModel
-from tests.conftest import lm
-
-if TYPE_CHECKING:
-    from numpyro.infer import SVI
 
 
-@pytest.mark.parametrize("mcmc", [lm], indirect=True)
 def test_missing_param_output(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
-    mcmc: MCMC,
+    synthetic_data: tuple[Array, Array],
+    im_lm_mcmc_fitted: ImpactModel,
 ) -> None:
     """Missing `param_output` argument raises TypeError."""
-    X, y = synthetic_data
-    im = ImpactModel(lm, rng_key=random.key(42), inference=mcmc)
-    im.fit_on_batch(X=X, y=y)
+    X, _ = synthetic_data
     with pytest.raises(TypeError):
-        im.sample(rng_key=random.key(42), X=X)
+        im_lm_mcmc_fitted.sample(rng_key=random.key(42), X=X)
 
 
-@pytest.mark.parametrize("vi", [lm], indirect=True)
 def test_sample_with_vi(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
-    vi: "SVI",
+    synthetic_data: tuple[Array, Array],
+    im_lm_svi_fitted: ImpactModel,
 ) -> None:
     """Test the `.sample()` method of ImpactModel with SVI."""
     X, y = synthetic_data
-    im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
-    im.fit_on_batch(X=X, y=y)
-
     num_samples = 7
-    samples = im.sample(
+    samples = im_lm_svi_fitted.sample(
         num_samples=num_samples,
         rng_key=random.key(42),
         return_sites="b",
@@ -66,7 +51,7 @@ def test_sample_with_vi(
             f"Incorrect number of samples for site {var}"
         )
 
-    samples_dict = im.sample(
+    samples_dict = im_lm_svi_fitted.sample(
         num_samples=num_samples,
         rng_key=random.key(42),
         return_sites=["w", "b", "sigma"],
@@ -79,26 +64,22 @@ def test_sample_with_vi(
         assert v.shape[0] == num_samples, f"Incorrect number of samples for site {k}"
 
 
-@pytest.mark.parametrize("mcmc", [lm], indirect=True)
 def test_sample_with_mcmc(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
-    mcmc: MCMC,
+    synthetic_data: tuple[Array, Array],
+    im_lm_mcmc_fitted: ImpactModel,
 ) -> None:
     """Test the `.sample()` method of ImpactModel with MCMC."""
     X, y = synthetic_data
-    im = ImpactModel(lm, rng_key=random.key(42), inference=mcmc)
-    im.fit_on_batch(X=X, y=y)
-
     num_samples = 7
     # rng_key is ignored for MCMC; sampling uses the post_warmup_state
-    samples = im.sample(
+    samples = im_lm_mcmc_fitted.sample(
         num_samples=num_samples,
         rng_key=random.key(42),
         X=X,
         y=y,
     ).posterior
 
-    assert im.inference.num_samples == num_samples
+    assert im_lm_mcmc_fitted.inference.num_samples == num_samples
 
     # Check shapes for all sampled sites
     for var in samples.data_vars:
@@ -106,7 +87,7 @@ def test_sample_with_mcmc(
             f"Incorrect number of samples for site {var}"
         )
 
-    samples_dict = im.sample(
+    samples_dict = im_lm_mcmc_fitted.sample(
         num_samples=num_samples,
         rng_key=random.key(42),
         return_datatree=False,

--- a/tests/test_sample_prior_predictive.py
+++ b/tests/test_sample_prior_predictive.py
@@ -19,8 +19,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 import xarray as xr
-from jax import random
-from jax.typing import ArrayLike
+from jax import Array, random
 
 from aimz import ImpactModel
 from tests.conftest import lm
@@ -35,7 +34,7 @@ class TestKernelParameterValidation:
 
     def test_invalid_parameter(
         self,
-        synthetic_data: tuple[ArrayLike, ArrayLike],
+        synthetic_data: tuple[Array, Array],
         vi: "SVI",
     ) -> None:
         """An invalid parameter raise an error."""
@@ -47,7 +46,7 @@ class TestKernelParameterValidation:
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
 def test_sample_prior_predictive_lm(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
+    synthetic_data: tuple[Array, Array],
     vi: "SVI",
 ) -> None:
     """Test the `.sample_prior_predictive()` method of ImpactModel."""

--- a/tests/test_sample_prior_predictive_on_batch.py
+++ b/tests/test_sample_prior_predictive_on_batch.py
@@ -18,8 +18,7 @@ import jax.numpy as jnp
 import numpyro.distributions as dist
 import pytest
 import xarray as xr
-from jax import random
-from jax.typing import ArrayLike
+from jax import Array, random
 from numpyro import sample
 from numpyro.infer import SVI, Trace_ELBO
 from numpyro.infer.autoguide import AutoNormal
@@ -30,10 +29,10 @@ from aimz._exceptions import KernelValidationError
 from tests.conftest import lm
 
 
-def test_kernel_without_output(synthetic_data: tuple[ArrayLike, ArrayLike]) -> None:
+def test_kernel_without_output(synthetic_data: tuple[Array, Array]) -> None:
     """Kernel without output sample site raises an error."""
 
-    def kernel(X: ArrayLike, y: ArrayLike | None = None) -> None:
+    def kernel(X: Array, y: Array | None = None) -> None:
         sample("z", dist.Delta(y if y is not None else jnp.zeros(len(X))), obs=y)
 
     X, _ = synthetic_data
@@ -58,7 +57,7 @@ class TestKernelParameterValidation:
 
     def test_invalid_parameter(
         self,
-        synthetic_data: tuple[ArrayLike, ArrayLike],
+        synthetic_data: tuple[Array, Array],
         vi: "SVI",
     ) -> None:
         """An invalid parameter raise an error."""
@@ -68,21 +67,22 @@ class TestKernelParameterValidation:
             im.sample_prior_predictive_on_batch(X=X, y=y)
 
 
-@pytest.mark.parametrize("vi", [lm], indirect=True)
 def test_sample_prior_predictive_on_batch_lm(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
-    vi: "SVI",
+    synthetic_data: tuple[Array, Array],
+    im_lm_svi_fitted: ImpactModel,
 ) -> None:
     """Test the `.sample_prior_predictive_on_batch()` method of ImpactModel."""
-    X, y = synthetic_data
-    im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
-    im.fit_on_batch(X, y)
-    samples = im.sample_prior_predictive_on_batch(X=X, num_samples=99, return_sites="y")
+    X, _ = synthetic_data
+    samples = im_lm_svi_fitted.sample_prior_predictive_on_batch(
+        X=X,
+        num_samples=99,
+        return_sites="y",
+    )
 
     assert isinstance(samples, xr.DataTree)
     assert samples.prior_predictive["y"].values.shape == (1, 99, len(X))
 
-    samples_dict = im.sample_prior_predictive_on_batch(
+    samples_dict = im_lm_svi_fitted.sample_prior_predictive_on_batch(
         X=X,
         num_samples=99,
         return_datatree=False,
@@ -91,5 +91,5 @@ def test_sample_prior_predictive_on_batch_lm(
 
     assert isinstance(samples_dict, dict)
     assert samples_dict["y"].shape == (99, len(X))
-    assert im.kernel_spec.traced
-    assert im.kernel_spec.output_observed
+    assert im_lm_svi_fitted.kernel_spec.traced
+    assert im_lm_svi_fitted.kernel_spec.output_observed

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -15,36 +15,18 @@
 """Tests for saving and loading functionality of models."""
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import cloudpickle
-import pytest
-from jax import random
-from jax.typing import ArrayLike
 
 from aimz import ImpactModel
-from tests.conftest import lm
-
-if TYPE_CHECKING:
-    from numpyro.infer import SVI
 
 
-@pytest.mark.parametrize("vi", [lm], indirect=True)
-def test_save_load(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
-    vi: "SVI",
-    tmp_path: "Path",
-) -> None:
+def test_save_load(im_lm_svi_fitted: ImpactModel, tmp_path: Path) -> None:
     """Test saving and loading an ImpactModel without errors."""
-    X, y = synthetic_data
-    im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
-    im.fit(X=X, y=y, batch_size=3)
-
     p = tmp_path / "model.pkl"
-    with Path.open(p, "wb") as f:
-        cloudpickle.dump(im, f)
-    del im  # Simulate reloading from scratch
-    with Path.open(p, "rb") as f:
+    with p.open("wb") as f:
+        cloudpickle.dump(im_lm_svi_fitted, f)
+    with p.open("rb") as f:
         im = cloudpickle.load(f)
 
     assert isinstance(im, ImpactModel)

--- a/tests/test_set_posterior_sample.py
+++ b/tests/test_set_posterior_sample.py
@@ -14,13 +14,14 @@
 
 """Tests for the `.set_posterior_sample()` method."""
 
+from __future__ import annotations
+
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 
 import pytest
+from jax import Array, random
 from jax import numpy as jnp
-from jax import random
-from jax.typing import ArrayLike
 from numpyro.infer import Predictive
 from numpyro.infer.svi import SVIRunResult
 
@@ -33,7 +34,7 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
-def test_empty_posterior_sample(vi: "SVI") -> None:
+def test_empty_posterior_sample(vi: SVI) -> None:
     """Empty posterior sample raises ValueError."""
     im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
     msg = "`posterior_sample` cannot be empty."
@@ -42,10 +43,7 @@ def test_empty_posterior_sample(vi: "SVI") -> None:
 
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
-def test_set_posterior_sample(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
-    vi: "SVI",
-) -> None:
+def test_set_posterior_sample(synthetic_data: tuple[Array, Array], vi: SVI) -> None:
     """Test the `.set_posterior_sample()` method of ImpactModel."""
     X, y = synthetic_data
 
@@ -83,7 +81,7 @@ def test_set_posterior_sample(
 
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
-def test_inconsistent_batch_shapes(vi: "SVI") -> None:
+def test_inconsistent_batch_shapes(vi: SVI) -> None:
     """Setting a posterior sample with inconsistent batch shapes raises ValueError."""
     im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
     with pytest.raises(

--- a/tests/test_train_on_batch.py
+++ b/tests/test_train_on_batch.py
@@ -14,18 +14,23 @@
 
 """Tests for the `.train_on_batch()` method."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
-from jax import random
-from jax.typing import ArrayLike
-from numpyro.infer import SVI
+from jax import Array, random
 
 from aimz import ImpactModel
 from tests.conftest import lm_with_kwargs_array
 
+if TYPE_CHECKING:
+    from numpyro.infer import SVI
+
 
 @pytest.mark.parametrize("vi", [lm_with_kwargs_array], indirect=True)
 def test_train_on_batch_lm_with_kwargs_array(
-    synthetic_data: tuple[ArrayLike, ArrayLike],
+    synthetic_data: tuple[Array, Array],
     vi: SVI,
 ) -> None:
     """Test the `.train_on_batch()` method of `ImpactModel`."""

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ wheels = [
 
 [[package]]
 name = "aimz"
-version = "0.10.0"
+version = "0.11.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "dask" },


### PR DESCRIPTION
Update the project version and dependencies, refactor tests for type consistency, and introduce new fixtures for SVI and MCMC fitted models. Ensure all tests are compatible with the latest changes.