### PR TITLE
Fix multi-device sampling issue and update version to 0.11.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,10 +6,6 @@ on:
       version:
         description: 'Version to publish (x.y.z)'
         required: true
-      destination:
-        description: 'Where to upload (testpypi or pypi)'
-        default: 'testpypi'
-        required: true
 
 jobs:
   build:
@@ -34,29 +30,8 @@ jobs:
           name: python-package-distributions
           path: dist/
 
-  publish-to-pypi:
-    name: Publish to PyPI
-    if: ${{ github.event.inputs.destination == 'pypi' }}
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/aimz
-    permissions:
-      id-token: write
-
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v8
-        with:
-          name: python-package-distributions
-          path: dist/
-      - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-
   publish-to-testpypi:
     name: Publish to TestPyPI
-    if: ${{ github.event.inputs.destination == 'testpypi' }}
     needs: build
     runs-on: ubuntu-latest
     environment:
@@ -75,3 +50,22 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: publish-to-testpypi
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/aimz
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v0.11.0](https://github.com/markean/aimz/releases/tag/v0.11.0) - 2025-04-29
+
 ### Changed
 
 - Removed package-level logging configuration from `aimz/__init__.py`. `aimz` no longer sets a log level, attaches a `StreamHandler(sys.stdout)`, or calls `logging.captureWarnings(True)` on import; the `aimz` logger now only has a `logging.NullHandler()` attached.
 Configuring handlers, levels, and warnings capture is the responsibility of the application.
 Log messages emitted by {class}`~aimz.ImpactModel` were also refined—trailing ellipses were removed and posterior sampling now reports the number of samples being drawn—and the output-directory cleanup notice raised when {meth}`~aimz.ImpactModel.predict_on_batch` and {meth}`~aimz.ImpactModel.log_likelihood` encounter an error is now logged at the `warning` level (previously `debug`) ([#192](https://github.com/markean/aimz/issues/192)).
+
+### Fixed
+
+- Fixed {meth}`~aimz.ImpactModel.sample_prior_predictive` failing on multi-device meshes with `ValueError: in_specs ... does not match the specs of the input ... @obs`. The probe batch used to trace the kernel and draw global prior samples is now built with `batch_size=1` and `device=None`, preventing JAX's sharding-in-types from propagating the `obs` mesh axis onto global (non-batched) sample sites that are later passed as the replicated `samples` argument to the {func}`jax.shard_map` sampler ([#194](https://github.com/markean/aimz/issues/194)).
 
 ## [v0.10.0](https://github.com/markean/aimz/releases/tag/v0.10.0) - 2025-04-17
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -647,15 +647,18 @@ class ImpactModel(BaseModel):
 
         return_sites = self._coerce_return_sites(return_sites)
 
-        # Prior sampling
+        # Use a single-element, unsharded probe (batch_size=1) to build the kernel spec
+        # and draw global prior samples once. A sharded probe would propagate the mesh
+        # axis onto global (non-batched) sites via JAX's sharding-in-types, incorrectly
+        # replicating them per device.
         dataloader, _ = _setup_inputs(
             X=X,
             y=None,
             rng_key=self.rng_key,
-            batch_size=self._device.num_devices if self._device is not None else 1,
+            batch_size=1,
             num_samples=num_samples,
             shuffle=False,
-            device=self._device,
+            device=None,
             **kwargs,
         )
         batch, _ = next(iter(dataloader))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aimz"
-version = "0.11.0.dev0"
+version = "0.11.0"
 description = "Scalable probabilistic impact modeling"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ wheels = [
 
 [[package]]
 name = "aimz"
-version = "0.11.0.dev0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "dask" },


### PR DESCRIPTION
- Refactor GitHub Actions workflow to streamline publishing to TestPyPI and PyPI.
- Remove unnecessary input for destination in the workflow.
- Fix prior sampling in ImpactModel to prevent errors on multi-device meshes.
- Update version in pyproject.toml and uv.lock to 0.11.0.

Fixes #194