### PR TITLE
Enhance log-likelihood computation and update dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,6 @@ repos:
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.8
+    rev: 0.11.11
     hooks:
       - id: uv-lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Input arrays of any shape with at least one dimension are now accepted; the leading axis is treated as the sample axis. Previously, `X` was required to be 2D and `y` 1D, and `y` with shape `(n, 1)` triggered a `DataConversionWarning` from `scikit-learn` ([#199](https://github.com/markean/aimz/issues/199)).
+- {meth}`~aimz.ImpactModel.log_likelihood` now evaluates the kernel directly at each posterior draw, mirroring the per-draw pattern used by predictive sampling. The seeded kernel is also constructed once before the per-batch loop, so each batch reuses the same cached compilation ([#202](https://github.com/markean/aimz/issues/202)).
 
 ### Removed
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -1690,6 +1690,7 @@ class ImpactModel(BaseModel):
         )
 
         site = self.param_output
+        draws = self._num_samples if self.posterior else 1
         pbar = tqdm(
             desc=(f"Computing log-likelihood of {site}..."),
             total=len(dataloader),
@@ -1707,6 +1708,9 @@ class ImpactModel(BaseModel):
         )
         worker_err: tuple | None = None
         success = False
+        # Seed once so tracing succeeds even when posterior is empty or only partially
+        # covers latent sites.
+        kernel = seed(self.kernel, rng_seed=self.rng_key)
         try:
             for batch, n_pad in dataloader:
                 kwargs_batch = [
@@ -1716,10 +1720,8 @@ class ImpactModel(BaseModel):
                 ]
                 arr = device_get(
                     self._fn_log_likelihood(
-                        # Although computing the log-likelihood is deterministic, the
-                        # model still needs to be seeded in order to trace its graph.
-                        seed(self.kernel, rng_seed=self.rng_key),
-                        self.posterior,
+                        kernel,
+                        self.posterior or {},
                         self.param_input,
                         site,
                         kwargs_array._fields + kwargs_extra._fields,
@@ -1729,7 +1731,6 @@ class ImpactModel(BaseModel):
                     ),
                 )
                 if site not in zarr_arr:
-                    draws = self._num_samples if self.posterior else 1
                     zarr_arr[site] = zarr_group.create_array(
                         name=site,
                         shape=(draws, 0, *arr.shape[2:]),

--- a/aimz/utils/_log_likelihood.py
+++ b/aimz/utils/_log_likelihood.py
@@ -1,0 +1,61 @@
+# Copyright 2025 Eli Lilly and Company
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for computing log-likelihoods."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from jax import Array, lax
+from numpyro.handlers import substitute, trace
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+
+def _log_likelihood(
+    model: Callable,
+    samples: dict[str, Array] | None,
+    model_kwargs: Mapping[str, object] | None,
+) -> dict[str, Array]:
+    """Compute per-site log-likelihood at observed sites for each posterior draw.
+
+    Args:
+        model: A probabilistic model with NumPyro primitives.
+        samples: A dictionary of posterior samples to substitute into the model, where
+            each array has leading axis equal to the number of draws. ``None`` or an
+            empty dict yields a single-draw result with a leading axis of size 1.
+        model_kwargs: Arguments passed to the model. Must include the input and the
+            output values keyed under the model's parameter names.
+
+    Returns:
+        A dictionary mapping each observed sample site to its log-probability array
+        with leading axis equal to the number of posterior draws (or 1 when ``samples``
+        is empty or ``None``).
+    """
+
+    def _loglik_one_sample(sample: dict[str, Array]) -> dict[str, Array]:
+        substituted_model = substitute(model, sample) if sample else model
+        model_trace = trace(substituted_model).get_trace(**(model_kwargs or {}))
+        return {
+            k: site["fn"].log_prob(site["value"])
+            for k, site in model_trace.items()
+            if site["type"] == "sample" and site["is_observed"]
+        }
+
+    if not samples:
+        return {k: v[None, ...] for k, v in _loglik_one_sample({}).items()}
+
+    return lax.map(_loglik_one_sample, xs=samples)

--- a/aimz/utils/data/_sharding.py
+++ b/aimz/utils/data/_sharding.py
@@ -21,9 +21,9 @@ from typing import TYPE_CHECKING
 
 from jax import Array, jit, shard_map
 from jax.sharding import PartitionSpec
-from numpyro.infer import log_likelihood as log_lik
 
 from aimz.sampling._forward import _sample_forward
+from aimz.utils._log_likelihood import _log_likelihood
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -147,9 +147,8 @@ def _create_sharded_log_likelihood(
 
     Returns:
         A sharded function that takes the following arguments:
-            - kernel (Callable): A probabilistic model with NumPyro primitives optimized
-                with variational inference.
-            - posterior_samples (dict): A dictionary of posterior samples.
+            - kernel (Callable): A probabilistic model with NumPyro primitives.
+            - samples (dict): A dictionary of posterior samples to condition on.
             - param_input (str): The name of the parameter in the ``kernel`` for the
                 input data.
             - param_output (str): The name of the parameter in the ``kernel`` for the
@@ -159,23 +158,22 @@ def _create_sharded_log_likelihood(
             - y (Array): Output data.
             - *args (tuple): Additional arguments constructed from the original keyword
                 arguments (both sharded and non-sharded).
-
     """
 
     def f(
         kernel: Callable,
-        posterior_samples: dict,
+        samples: dict[str, Array],
         param_input: str,
         param_output: str,
         kwargs_key: tuple[str, ...],
         X: Array,
         y: Array,
-        *args: tuple,
+        *args: object,
     ) -> Array:
-        return log_lik(
-            kernel,
-            posterior_samples=posterior_samples,
-            **{
+        return _log_likelihood(
+            model=kernel,
+            samples=samples,
+            model_kwargs={
                 param_input: X,
                 param_output: y,
                 **dict(zip(kwargs_key, args, strict=True)),
@@ -209,7 +207,7 @@ def _create_sharded_log_likelihood(
             mesh=mesh,
             in_specs=(
                 None,  # kernel
-                None,  # posterior_samples
+                PartitionSpec(),  # samples
                 None,  # param_input
                 None,  # param_output
                 None,  # kwargs_key
@@ -221,5 +219,6 @@ def _create_sharded_log_likelihood(
                 ),
             ),
             out_specs=PartitionSpec(None, axis),
+            check_vma=False,
         )(f),
     )

--- a/tests/test_log_likelihood.py
+++ b/tests/test_log_likelihood.py
@@ -44,6 +44,21 @@ def test_model_not_fitted() -> None:
         im.log_likelihood(None, None)
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_empty_posterior(
+    synthetic_data: tuple[Array, Array],
+    im_lm_svi_fitted: ImpactModel,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty posterior produces a single-draw log-likelihood without crashing."""
+    X, y = synthetic_data
+    monkeypatch.setattr(im_lm_svi_fitted, "_posterior", None)
+
+    out = im_lm_svi_fitted.log_likelihood(X=X, y=y, progress=False)
+
+    assert out.log_likelihood["y"].sizes["draw"] == 1
+
+
 class TestBatchSize:
     """Test class related to batch size specification."""
 


### PR DESCRIPTION
Refactor `ImpactModel.log_likelihood` to evaluate the kernel directly at each posterior draw, improving efficiency. Update the `uv-pre-commit` version to 0.11.11. Fixes #202.