### PR TITLE
Adaptive writer-queue sizing based on host memory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,6 @@ repos:
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.12
+    rev: 0.11.13
     hooks:
       - id: uv-lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Input arrays of any shape with at least one dimension are now accepted; the leading axis is treated as the sample axis. Previously, `X` was required to be 2D and `y` 1D, and `y` with shape `(n, 1)` triggered a `DataConversionWarning` from `scikit-learn` ([#199](https://github.com/markean/aimz/issues/199)).
 - {meth}`~aimz.ImpactModel.log_likelihood` now evaluates the kernel directly at each posterior draw, mirroring the per-draw pattern used by predictive sampling. The seeded kernel is also constructed once before the per-batch loop, so each batch reuses the same cached compilation ([#202](https://github.com/markean/aimz/issues/202)).
+- Writer-thread queue sizing used when streaming batched outputs now adapts to available host memory and the per-batch output size ([#208](https://github.com/markean/aimz/issues/208)).
 
 ### Removed
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -20,7 +20,6 @@ import contextlib
 import logging
 from datetime import UTC, datetime
 from inspect import signature, stack
-from os import cpu_count
 from pathlib import Path
 from shutil import rmtree
 from tempfile import TemporaryDirectory
@@ -48,15 +47,15 @@ from numpyro.handlers import do, seed, substitute, trace
 from numpyro.infer import MCMC, SVI
 from numpyro.infer.svi import SVIRunResult, SVIState
 from tqdm.auto import tqdm
-from xarray import open_zarr
 from zarr import open_group
 
 from aimz.model._core import BaseModel
 from aimz.model.kernel_spec import KernelSpec
 from aimz.sampling._forward import _sample_forward
-from aimz.utils._format import _dict_to_datatree, _make_attrs
+from aimz.utils._format import _build_datatree, _dict_to_datatree
 from aimz.utils._kwargs import _group_kwargs
 from aimz.utils._output import (
+    _determine_writer_queue_size,
     _shutdown_writer_threads,
     _start_writer_threads,
     _writer,
@@ -453,12 +452,9 @@ class ImpactModel(BaseModel):
 
         zarr_group = open_group(output_dir, mode="w")
         zarr_arr = {}
-        threads, queues, error_queue = _start_writer_threads(
-            return_sites,
-            group_path=output_dir,
-            writer=_writer,
-            queue_size=min(cpu_count() or 1, 4),
-        )
+        threads = []
+        queues = {}
+        error_queue = None
         worker_err: tuple | None = None
         success = False
         try:
@@ -481,7 +477,24 @@ class ImpactModel(BaseModel):
                         *(*kwargs_batch, *kwargs_extra),
                     ),
                 )
-                for site, arr in dict_arr.items():
+                sliced = {
+                    site: (arr[:, None] if arr.ndim == 1 else arr)[:, : -n_pad or None]
+                    for site, arr in dict_arr.items()
+                }
+                if error_queue is None:
+                    threads, queues, error_queue = _start_writer_threads(
+                        return_sites,
+                        group_path=output_dir,
+                        writer=_writer,
+                        queue_size=_determine_writer_queue_size(
+                            len(dataloader),
+                            item_nbytes=max(
+                                1,
+                                sum(int(arr.nbytes) for arr in sliced.values()),
+                            ),
+                        ),
+                    )
+                for site, arr in sliced.items():
                     if site not in zarr_arr:
                         zarr_arr[site] = zarr_group.create_array(
                             name=site,
@@ -494,15 +507,10 @@ class ImpactModel(BaseModel):
                             ),
                             dimension_names=(
                                 "draw",
-                                *tuple(
-                                    f"{site}_dim_{i}"
-                                    for i in range(max(arr.ndim - 1, 1))
-                                ),
+                                *tuple(f"{site}_dim_{i}" for i in range(arr.ndim - 1)),
                             ),
                         )
-                    queues[site].put(
-                        (arr[:, None] if arr.ndim == 1 else arr)[:, : -n_pad or None],
-                    )
+                    queues[site].put(arr)
                 if not error_queue.empty():
                     worker_err = error_queue.get()
                     break
@@ -714,21 +722,12 @@ class ImpactModel(BaseModel):
             **kwargs,
         )
 
-        ds = open_zarr(output_subdir, consolidated=False).expand_dims(
-            dim="chain",
-            axis=0,
+        return _build_datatree(
+            output_dir,
+            output_subdir=output_subdir,
+            group="prior_predictive",
+            posterior=self.posterior,
         )
-        ds = ds.assign_coords(
-            {k: np.arange(ds.sizes[k]) for k in ds.sizes},
-        ).assign_attrs(_make_attrs())
-        out = xr.DataTree(name="root")
-        out["prior_predictive"] = xr.DataTree(ds)
-        out["prior_predictive"].attrs["output_dir"] = str(output_subdir)
-        if self.posterior:
-            out["posterior"] = _dict_to_datatree(self.posterior)
-        out.attrs["output_dir"] = str(output_dir)
-
-        return out
 
     def sample(
         self,
@@ -1504,22 +1503,12 @@ class ImpactModel(BaseModel):
             **kwargs,
         )
 
-        ds = open_zarr(output_subdir, consolidated=False).expand_dims(
-            dim="chain",
-            axis=0,
+        return _build_datatree(
+            output_dir,
+            output_subdir=output_subdir,
+            group="posterior_predictive" if in_sample else "predictions",
+            posterior=self.posterior,
         )
-        ds = ds.assign_coords(
-            {k: np.arange(ds.sizes[k]) for k in ds.sizes},
-        ).assign_attrs(_make_attrs())
-        out = xr.DataTree(name="root")
-        if self.posterior:
-            out["posterior"] = _dict_to_datatree(self.posterior)
-        group = "posterior_predictive" if in_sample else "predictions"
-        out[group] = xr.DataTree(ds)
-        out[group].attrs["output_dir"] = str(output_subdir)
-        out.attrs["output_dir"] = str(output_dir)
-
-        return out
 
     def estimate_effect(
         self,
@@ -1700,12 +1689,9 @@ class ImpactModel(BaseModel):
 
         zarr_group = open_group(output_subdir, mode="w")
         zarr_arr = {}
-        threads, queues, error_queue = _start_writer_threads(
-            (site,),
-            group_path=output_subdir,
-            writer=_writer,
-            queue_size=min(cpu_count() or 1, 4),
-        )
+        threads = []
+        queues = {}
+        error_queue = None
         worker_err: tuple | None = None
         success = False
         # Seed once so tracing succeeds even when posterior is empty or only partially
@@ -1741,6 +1727,16 @@ class ImpactModel(BaseModel):
                             *tuple(f"{site}_dim_{i}" for i in range(arr.ndim - 1)),
                         ),
                     )
+                if error_queue is None:
+                    threads, queues, error_queue = _start_writer_threads(
+                        (site,),
+                        group_path=output_subdir,
+                        writer=_writer,
+                        queue_size=_determine_writer_queue_size(
+                            len(dataloader),
+                            item_nbytes=max(1, int((arr[:, : -n_pad or None]).nbytes)),
+                        ),
+                    )
                 queues[site].put(arr[:, : -n_pad or None])
                 if not error_queue.empty():
                     worker_err = error_queue.get()
@@ -1760,21 +1756,12 @@ class ImpactModel(BaseModel):
             _, exc, tb = worker_err
             raise exc.with_traceback(tb)
 
-        ds = open_zarr(output_subdir, consolidated=False).expand_dims(
-            dim="chain",
-            axis=0,
+        return _build_datatree(
+            output_dir,
+            output_subdir=output_subdir,
+            group="log_likelihood",
+            posterior=self.posterior,
         )
-        ds = ds.assign_coords(
-            {k: np.arange(ds.sizes[k]) for k in ds.sizes},
-        ).assign_attrs(_make_attrs())
-        out = xr.DataTree(name="root")
-        if self.posterior:
-            out["posterior"] = _dict_to_datatree(self.posterior)
-        out["log_likelihood"] = xr.DataTree(ds)
-        out["log_likelihood"].attrs["output_dir"] = str(output_subdir)
-        out.attrs["output_dir"] = str(output_dir)
-
-        return out
 
     def cleanup(self) -> None:
         """Clean up the temporary directory created for storing outputs.

--- a/aimz/utils/_format.py
+++ b/aimz/utils/_format.py
@@ -17,11 +17,13 @@
 import datetime
 from collections.abc import Mapping
 from importlib.metadata import version
+from pathlib import Path
 
 import numpy as np
 import numpy.typing as npt
 import xarray as xr
 from jax import Array
+from xarray import open_zarr
 
 
 def _make_attrs() -> dict[str, str]:
@@ -34,6 +36,42 @@ def _make_attrs() -> dict[str, str]:
         "created_at": datetime.datetime.now(datetime.UTC).isoformat(),
         "aimz_version": version("aimz"),
     }
+
+
+def _build_datatree(
+    output_dir: Path,
+    output_subdir: Path,
+    group: str,
+    posterior: Mapping[str, Array | npt.NDArray] | None = None,
+) -> xr.DataTree:
+    """Build the aimz output DataTree from a Zarr group.
+
+    Args:
+        output_dir: Top-level output directory; stored on the root tree's attrs.
+        output_subdir: Subdirectory holding the Zarr group; read with
+            :external:func:`~xarray.open_zarr` and stored on the group's attrs.
+        group: Group name to attach the loaded dataset under (e.g.
+            ``"log_likelihood"``, ``"prior_predictive"``).
+        posterior: Optional posterior samples; when provided, added as a ``"posterior"``
+            subtree before ``group``.
+
+    Returns:
+        A DataTree rooted at ``"root"`` with the loaded dataset attached under ``group``
+        and, optionally, a ``"posterior"`` subtree.
+    """
+    ds = open_zarr(output_subdir, consolidated=False).expand_dims(dim="chain", axis=0)
+    ds = ds.assign_coords(
+        {k: np.arange(ds.sizes[k]) for k in ds.sizes},
+    ).assign_attrs(_make_attrs())
+
+    out = xr.DataTree(name="root")
+    if posterior:
+        out["posterior"] = _dict_to_datatree(posterior)
+    out[group] = xr.DataTree(ds)
+    out[group].attrs["output_dir"] = str(output_subdir)
+    out.attrs["output_dir"] = str(output_dir)
+
+    return out
 
 
 def _dict_to_datatree(data: Mapping[str, Array | npt.NDArray]) -> xr.DataTree:

--- a/aimz/utils/_output.py
+++ b/aimz/utils/_output.py
@@ -17,9 +17,15 @@
 from __future__ import annotations
 
 import logging
+from os import cpu_count
 from queue import Queue
 from threading import Thread
 from typing import TYPE_CHECKING, cast
+
+try:
+    import psutil
+except ImportError:
+    psutil: ModuleType | None = None
 
 from zarr import open_group
 
@@ -28,8 +34,31 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
+    from types import ModuleType
 
     from zarr import Array
+
+
+_QUEUE_SIZE_MAX = 128
+_QUEUE_SIZE_FALLBACK_CAP = 4
+
+
+def _determine_writer_queue_size(num_items: int, item_nbytes: int) -> int:
+    """Determine the writer queue size from workload and host-memory bounds.
+
+    Args:
+        num_items: Total number of items the producer will emit.
+        item_nbytes: Bytes the producer commits to the queue(s) per iteration.
+
+    Returns:
+        The writer queue size.
+    """
+    if psutil is None:
+        queue_size = min(cpu_count() or 1, _QUEUE_SIZE_FALLBACK_CAP)
+    else:
+        queue_size = psutil.virtual_memory().available // item_nbytes
+
+    return max(1, min(_QUEUE_SIZE_MAX, num_items, queue_size))
 
 
 def _writer(site: str, queue: Queue, group_path: Path, error_queue: Queue) -> None:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,0 +1,65 @@
+# Copyright 2025 Eli Lilly and Company
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for writer-thread queue sizing in :mod:`aimz.utils._output`."""
+
+import pytest
+
+from aimz.utils._output import (
+    _QUEUE_SIZE_FALLBACK_CAP,
+    _QUEUE_SIZE_MAX,
+    _determine_writer_queue_size,
+)
+
+
+class TestDetermineWriterQueueSize:
+    """Test class for :func:`_determine_writer_queue_size`."""
+
+    def test_queue_size_without_psutil(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Fallback path: bounded by the CPU-derived cap when psutil is missing."""
+        monkeypatch.setattr("aimz.utils._output.psutil", None)
+
+        assert (
+            1
+            <= _determine_writer_queue_size(num_items=100, item_nbytes=1)
+            <= _QUEUE_SIZE_FALLBACK_CAP
+        )
+
+    def test_queue_size_with_psutil(self) -> None:
+        """Memory-aware path: result respects the absolute cap on a normal host."""
+        assert (
+            1
+            <= _determine_writer_queue_size(num_items=100, item_nbytes=1024)
+            <= _QUEUE_SIZE_MAX
+        )
+
+    def test_workload_cap_binds(self) -> None:
+        """``num_items`` caps the queue size when smaller than memory/CPU bounds."""
+        assert _determine_writer_queue_size(num_items=1, item_nbytes=1024) == 1
+
+    def test_absolute_cap_binds(self) -> None:
+        """The absolute ceiling binds for huge workloads with tiny items."""
+        assert (
+            _determine_writer_queue_size(num_items=10**6, item_nbytes=1)
+            == _QUEUE_SIZE_MAX
+        )
+
+    def test_floor_binds(self) -> None:
+        """The floor at 1 binds so ``Queue(maxsize)`` is always bounded."""
+        # Drive the memory-derived term to zero by choosing ``item_nbytes`` large
+        # enough that ``available // item_nbytes`` collapses; the floor must hold.
+        assert _determine_writer_queue_size(num_items=100, item_nbytes=10**18) == 1

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -14,6 +14,8 @@
 
 """Tests for writer-thread queue sizing in :mod:`aimz.utils._output`."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from aimz.utils._output import (
@@ -21,6 +23,20 @@ from aimz.utils._output import (
     _QUEUE_SIZE_MAX,
     _determine_writer_queue_size,
 )
+
+
+@pytest.fixture
+def fake_psutil(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Install a fake `psutil` with a controllable `virtual_memory().available`.
+
+    Decouples the tests from whether the real `psutil` is installed, so the memory-aware
+    branch runs deterministically in any environment.
+    """
+    fake = MagicMock()
+    fake.virtual_memory.return_value.available = 10**12  # 1 TiB default
+    monkeypatch.setattr("aimz.utils._output.psutil", fake)
+
+    return fake
 
 
 class TestDetermineWriterQueueSize:
@@ -39,27 +55,33 @@ class TestDetermineWriterQueueSize:
             <= _QUEUE_SIZE_FALLBACK_CAP
         )
 
-    def test_queue_size_with_psutil(self) -> None:
+    def test_queue_size_with_psutil(self, fake_psutil: MagicMock) -> None:
         """Memory-aware path: result respects the absolute cap on a normal host."""
+        # Silence unused-argument warning; we just need the fixture to ensure the
+        # memory-aware branch runs
+        del fake_psutil
         assert (
             1
             <= _determine_writer_queue_size(num_items=100, item_nbytes=1024)
             <= _QUEUE_SIZE_MAX
         )
 
-    def test_workload_cap_binds(self) -> None:
-        """``num_items`` caps the queue size when smaller than memory/CPU bounds."""
+    def test_workload_cap_binds(self, fake_psutil: MagicMock) -> None:
+        """`num_items` caps the queue size when smaller than memory/CPU bounds."""
+        del fake_psutil
         assert _determine_writer_queue_size(num_items=1, item_nbytes=1024) == 1
 
-    def test_absolute_cap_binds(self) -> None:
+    def test_absolute_cap_binds(self, fake_psutil: MagicMock) -> None:
         """The absolute ceiling binds for huge workloads with tiny items."""
+        del fake_psutil
         assert (
             _determine_writer_queue_size(num_items=10**6, item_nbytes=1)
             == _QUEUE_SIZE_MAX
         )
 
-    def test_floor_binds(self) -> None:
-        """The floor at 1 binds so ``Queue(maxsize)`` is always bounded."""
-        # Drive the memory-derived term to zero by choosing ``item_nbytes`` large
-        # enough that ``available // item_nbytes`` collapses; the floor must hold.
+    def test_floor_binds(self, fake_psutil: MagicMock) -> None:
+        """The floor at 1 binds so `Queue(maxsize)` is always bounded."""
+        # Tight available memory + huge item drives `available // item_nbytes` to zero;
+        # The function's floor must keep `Queue(maxsize)` bounded.
+        fake_psutil.virtual_memory.return_value.available = 1
         assert _determine_writer_queue_size(num_items=100, item_nbytes=10**18) == 1


### PR DESCRIPTION
Enhance the writer-thread queue sizing to adapt based on available host memory and per-batch output size. Update the `uv-pre-commit` version and add tests for the new queue size determination logic.

Fixes #208