### PR TITLE
Fix writer-thread startup error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - {meth}`~aimz.ImpactModel.log_likelihood` now evaluates the kernel directly at each posterior draw, mirroring the per-draw pattern used by predictive sampling. The seeded kernel is also constructed once before the per-batch loop, so each batch reuses the same cached compilation ([#202](https://github.com/markean/aimz/issues/202)).
 - Writer-thread queue sizing used when streaming batched outputs now adapts to available host memory and the per-batch output size ([#208](https://github.com/markean/aimz/issues/208)).
 
+### Fixed
+
+- Writer-thread startup errors while opening Zarr output groups are now reported through the existing writer error path and queued items are drained before shutdown, preventing the main thread from waiting indefinitely when a background writer fails before consuming its queue ([#210](https://github.com/markean/aimz/issues/210)).
+
 ### Removed
 
 - The `scikit-learn` dependency ([#199](https://github.com/markean/aimz/issues/199)).

--- a/aimz/utils/_output.py
+++ b/aimz/utils/_output.py
@@ -76,7 +76,17 @@ def _writer(site: str, queue: Queue, group_path: Path, error_queue: Queue) -> No
         group_path: The path of the Zarr group.
         error_queue: The queue to collect errors raised by the writer thread.
     """
-    group = open_group(group_path, mode="r+")
+    try:
+        group = open_group(group_path, mode="r+")
+    except Exception as exc:
+        logger.exception("Error opening output group for site '%s'", site)
+        error_queue.put((site, exc, exc.__traceback__))
+        while True:
+            leftover = queue.get()
+            queue.task_done()
+            if leftover is None:
+                break
+        return
 
     while True:
         arr = queue.get()
@@ -89,13 +99,12 @@ def _writer(site: str, queue: Queue, group_path: Path, error_queue: Queue) -> No
         except Exception as exc:
             logger.exception("Error writing to site '%s'", site)
             error_queue.put((site, exc, exc.__traceback__))
-            # Drain remaining items including sentinel
+            # Drain remaining items including sentinel so queue.join() can finish
             while True:
                 leftover = queue.get()
                 queue.task_done()
                 if leftover is None:
                     break
-
             break
         finally:
             queue.task_done()

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -14,6 +14,9 @@
 
 """Tests for writer-thread queue sizing in :mod:`aimz.utils._output`."""
 
+from pathlib import Path
+from queue import Queue
+from threading import Thread
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,6 +25,7 @@ from aimz.utils._output import (
     _QUEUE_SIZE_FALLBACK_CAP,
     _QUEUE_SIZE_MAX,
     _determine_writer_queue_size,
+    _writer,
 )
 
 
@@ -85,3 +89,34 @@ class TestDetermineWriterQueueSize:
         # The function's floor must keep `Queue(maxsize)` bounded.
         fake_psutil.virtual_memory.return_value.available = 1
         assert _determine_writer_queue_size(num_items=100, item_nbytes=10**18) == 1
+
+
+def test_writer_reports_open_group_failure_and_drains_queue(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Writer startup errors are surfaced without leaving queued items stuck."""
+
+    class StoreOpenError(OSError):
+        """Test exception for a store-open failure."""
+
+    def fail_open_group(*args: object, **kwargs: object) -> None:
+        """Raise an error that mimics a filesystem or store-open failure."""
+        raise StoreOpenError
+
+    monkeypatch.setattr("aimz.utils._output.open_group", fail_open_group)
+    queue = Queue(maxsize=1)
+    error_queue = Queue()
+    thread = Thread(target=_writer, args=("site", queue, tmp_path, error_queue))
+
+    thread.start()
+    queue.put(object())
+    queue.put(None)
+    queue.join()
+    thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    site, exc, tb = error_queue.get_nowait()
+    assert site == "site"
+    assert isinstance(exc, StoreOpenError)
+    assert tb is not None


### PR DESCRIPTION
Writer-thread startup errors while opening Zarr output groups are now reported through the existing writer error path. The implementation ensures that queued items are drained before shutdown, preventing the main thread from waiting indefinitely when a background writer fails before consuming its queue. Corresponding tests have been added to verify this behavior.

Fixes #210