### PR TITLE
Replace per-batch Zarr append with preallocated slice writes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.12
+    rev: v0.15.14
     hooks:
       # Run the linter.
       - id: ruff-check
@@ -50,6 +50,6 @@ repos:
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.13
+    rev: 0.11.16
     hooks:
       - id: uv-lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Input arrays of any shape with at least one dimension are now accepted; the leading axis is treated as the sample axis. Previously, `X` was required to be 2D and `y` 1D, and `y` with shape `(n, 1)` triggered a `DataConversionWarning` from `scikit-learn` ([#199](https://github.com/markean/aimz/issues/199)).
 - {meth}`~aimz.ImpactModel.log_likelihood` now evaluates the kernel directly at each posterior draw, mirroring the per-draw pattern used by predictive sampling. The seeded kernel is also constructed once before the per-batch loop, so each batch reuses the same cached compilation ([#202](https://github.com/markean/aimz/issues/202)).
 - Writer-thread queue sizing used when streaming batched outputs now adapts to available host memory and the per-batch output size ([#208](https://github.com/markean/aimz/issues/208)).
+- Disk-backed methods ({meth}`~aimz.ImpactModel.predict`, {meth}`~aimz.ImpactModel.sample_prior_predictive`, {meth}`~aimz.ImpactModel.log_likelihood`) now preallocate each site's Zarr array and write each batch into a fixed slice, replacing the previous per-batch append. This avoids repeated Zarr resizing and is faster when the batch size is small and the number of batches is large. As a consequence, every return site must emit an axis-1 size equal to the input batch size; kernels with incompatible return sites raise `NotImplementedError` ([#213](https://github.com/markean/aimz/issues/213)).
 
 ### Fixed
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -56,9 +56,10 @@ from aimz.utils._format import _build_datatree, _dict_to_datatree
 from aimz.utils._kwargs import _group_kwargs
 from aimz.utils._output import (
     _determine_writer_queue_size,
+    _select_write_strategy,
     _shutdown_writer_threads,
     _start_writer_threads,
-    _writer,
+    _WriteStrategy,
 )
 from aimz.utils._validation import (
     _check_is_fitted,
@@ -415,13 +416,16 @@ class ImpactModel(BaseModel):
         samples: dict[str, Array],
         dataloader: ArrayLoader,
         pbar: tqdm,
+        strategy_cls: type[_WriteStrategy],
         **kwargs: object,
     ) -> None:
         """Draw samples using a predictive function and write them concurrently to disk.
 
-        This function iterates over batches from the provided data loader, calls the
-        specified sampling function (``sampler``) to generate predictions conditioned on
-        the provided ``samples``, and writes the resulting arrays to a Zarr group.
+        Iterates over batches from the data loader, calls ``sampler`` to generate
+        predictions conditioned on ``samples``, and writes the resulting arrays to a
+        Zarr group. How site arrays are created and enqueued is delegated to
+        ``strategy_cls`` (append vs. preallocated slices); the loop itself is
+        strategy-agnostic.
 
         Args:
             num_samples: Number of samples to draw.
@@ -435,6 +439,8 @@ class ImpactModel(BaseModel):
             dataloader: Iterator over batches of input data. Each batch must be a tuple
                 containing a dictionary of arrays and a padding value.
             pbar: Progress bar instance to display sampling progress.
+            strategy_cls: Write-strategy class deciding how site arrays are created
+                and enqueued (append vs. preallocated slices).
             **kwargs: Additional arguments passed to the model.
 
         Raises:
@@ -443,7 +449,8 @@ class ImpactModel(BaseModel):
         """
         kwargs_array, kwargs_extra = _group_kwargs(kwargs)
 
-        rng_key, *subkeys = random.split(rng_key, num=len(dataloader) + 1)
+        n_batches = len(dataloader)
+        rng_key, *subkeys = random.split(rng_key, num=n_batches + 1)
         if self._device and self._mesh:
             subkeys = device_put(
                 subkeys,
@@ -451,7 +458,11 @@ class ImpactModel(BaseModel):
             )
 
         zarr_group = open_group(output_dir, mode="w")
-        zarr_arr = {}
+        strategy = strategy_cls(
+            zarr_group=zarr_group,
+            draws=num_samples,
+            dataloader=dataloader,
+        )
         threads = []
         queues = {}
         error_queue = None
@@ -478,39 +489,24 @@ class ImpactModel(BaseModel):
                     ),
                 )
                 sliced = {
-                    site: (arr[:, None] if arr.ndim == 1 else arr)[:, : -n_pad or None]
+                    site: arr[:, None] if arr.ndim == 1 else arr[:, : -n_pad or None]
                     for site, arr in dict_arr.items()
                 }
+                strategy.create_arrays(sliced)
                 if error_queue is None:
                     threads, queues, error_queue = _start_writer_threads(
                         return_sites,
                         group_path=output_dir,
-                        writer=_writer,
+                        apply=strategy.apply,
                         queue_size=_determine_writer_queue_size(
-                            len(dataloader),
+                            n_batches,
                             item_nbytes=max(
                                 1,
                                 sum(int(arr.nbytes) for arr in sliced.values()),
                             ),
                         ),
                     )
-                for site, arr in sliced.items():
-                    if site not in zarr_arr:
-                        zarr_arr[site] = zarr_group.create_array(
-                            name=site,
-                            shape=(num_samples, 0, *arr.shape[2:]),
-                            dtype="float32" if arr.dtype == "bfloat16" else arr.dtype,
-                            chunks=(
-                                num_samples,
-                                dataloader.batch_size,
-                                *arr.shape[2:],
-                            ),
-                            dimension_names=(
-                                "draw",
-                                *tuple(f"{site}_dim_{i}" for i in range(arr.ndim - 1)),
-                            ),
-                        )
-                    queues[site].put(arr)
+                strategy.enqueue(queues, sliced)
                 if not error_queue.empty():
                     worker_err = error_queue.get()
                     break
@@ -559,6 +555,9 @@ class ImpactModel(BaseModel):
         Raises:
             TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
                 argument.
+
+        See Also:
+            :meth:`~aimz.ImpactModel.sample_prior_predictive`
         """
         X = cast("Array", _validate_X_y_to_jax(X))
 
@@ -637,8 +636,13 @@ class ImpactModel(BaseModel):
         Raises:
             TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
                 argument.
+            NotImplementedError: If a return site's axis-1 size does not match the
+                input batch size.
 
         See Also:
+            :meth:`~aimz.ImpactModel.sample_prior_predictive_on_batch` for an
+            in-memory alternative.
+
             :meth:`~aimz.ImpactModel.cleanup` to remove the temporary directory if
             created.
         """
@@ -703,6 +707,7 @@ class ImpactModel(BaseModel):
             device=self._device,
             **kwargs,
         )
+        n_batches = len(dataloader)
 
         self._sample_and_write(
             num_samples,
@@ -715,10 +720,11 @@ class ImpactModel(BaseModel):
             dataloader=dataloader,
             pbar=tqdm(
                 desc=(f"Prior predictive sampling [{', '.join(return_sites)}]"),
-                total=len(dataloader),
+                total=n_batches,
                 disable=not progress,
                 dynamic_ncols=True,
             ),
+            strategy_cls=_select_write_strategy(dataloader),
             **kwargs,
         )
 
@@ -1138,6 +1144,7 @@ class ImpactModel(BaseModel):
             device=None,
             **kwargs,
         )
+        n_batches = len(dataloader)
 
         logger.info("Performing variational inference optimization")
         losses: list[float] = []
@@ -1147,7 +1154,7 @@ class ImpactModel(BaseModel):
             pbar = tqdm(
                 dataloader,
                 desc=f"Epoch {epoch + 1}/{epochs}",
-                total=len(dataloader),
+                total=n_batches,
                 disable=not progress,
                 dynamic_ncols=True,
             )
@@ -1412,6 +1419,8 @@ class ImpactModel(BaseModel):
         Raises:
             TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
                 argument.
+            NotImplementedError: If a return site's axis-1 size does not match the
+                input batch size.
 
         See Also:
             :meth:`~aimz.ImpactModel.cleanup` to remove the temporary directory if
@@ -1484,9 +1493,10 @@ class ImpactModel(BaseModel):
             device=self._device,
             **kwargs,
         )
+        n_batches = len(dataloader)
 
         self._sample_and_write(
-            num_samples=self._num_samples,
+            self._num_samples,
             rng_key=rng_key,
             return_sites=return_sites,
             output_dir=output_subdir,
@@ -1496,10 +1506,11 @@ class ImpactModel(BaseModel):
             dataloader=dataloader,
             pbar=tqdm(
                 desc=(f"Posterior predictive sampling [{', '.join(return_sites)}]"),
-                total=len(dataloader),
+                total=n_batches,
                 disable=not progress,
                 dynamic_ncols=True,
             ),
+            strategy_cls=_select_write_strategy(dataloader),
             **kwargs,
         )
 
@@ -1651,6 +1662,10 @@ class ImpactModel(BaseModel):
         Returns:
             Log-likelihood values. Posterior samples are included if available.
 
+        Raises:
+            NotImplementedError: If a return site's axis-1 size does not match the
+                input batch size.
+
         See Also:
             :meth:`~aimz.ImpactModel.cleanup` to remove the temporary directory if
             created.
@@ -1677,18 +1692,23 @@ class ImpactModel(BaseModel):
             device=self._device,
             **kwargs,
         )
+        n_batches = len(dataloader)
 
         site = self.param_output
         draws = self._num_samples if self.posterior else 1
         pbar = tqdm(
             desc=(f"Computing log-likelihood of {site}..."),
-            total=len(dataloader),
+            total=n_batches,
             disable=not progress,
             dynamic_ncols=True,
         )
 
         zarr_group = open_group(output_subdir, mode="w")
-        zarr_arr = {}
+        strategy = _select_write_strategy(dataloader)(
+            zarr_group=zarr_group,
+            draws=draws,
+            dataloader=dataloader,
+        )
         threads = []
         queues = {}
         error_queue = None
@@ -1716,28 +1736,21 @@ class ImpactModel(BaseModel):
                         *(*kwargs_batch, *kwargs_extra),
                     ),
                 )
-                if site not in zarr_arr:
-                    zarr_arr[site] = zarr_group.create_array(
-                        name=site,
-                        shape=(draws, 0, *arr.shape[2:]),
-                        dtype="float32" if arr.dtype == "bfloat16" else arr.dtype,
-                        chunks=(draws, dataloader.batch_size, *arr.shape[2:]),
-                        dimension_names=(
-                            "draw",
-                            *tuple(f"{site}_dim_{i}" for i in range(arr.ndim - 1)),
-                        ),
-                    )
+                sliced = {
+                    site: arr[:, None] if arr.ndim == 1 else arr[:, : -n_pad or None],
+                }
+                strategy.create_arrays(sliced)
                 if error_queue is None:
                     threads, queues, error_queue = _start_writer_threads(
                         (site,),
                         group_path=output_subdir,
-                        writer=_writer,
+                        apply=strategy.apply,
                         queue_size=_determine_writer_queue_size(
-                            len(dataloader),
-                            item_nbytes=max(1, int((arr[:, : -n_pad or None]).nbytes)),
+                            n_batches,
+                            item_nbytes=max(1, int(sliced[site].nbytes)),
                         ),
                     )
-                queues[site].put(arr[:, : -n_pad or None])
+                strategy.enqueue(queues, sliced)
                 if not error_queue.empty():
                     worker_err = error_queue.get()
                     break

--- a/aimz/utils/_output.py
+++ b/aimz/utils/_output.py
@@ -20,7 +20,7 @@ import logging
 from os import cpu_count
 from queue import Queue
 from threading import Thread
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Protocol, cast
 
 try:
     import psutil
@@ -32,11 +32,14 @@ from zarr import open_group
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
     from pathlib import Path
     from types import ModuleType
 
-    from zarr import Array
+    import numpy as np
+    from zarr import Array, Group
+
+    from aimz.utils.data import ArrayLoader
 
 
 _QUEUE_SIZE_MAX = 128
@@ -61,20 +64,67 @@ def _determine_writer_queue_size(num_items: int, item_nbytes: int) -> int:
     return max(1, min(_QUEUE_SIZE_MAX, num_items, queue_size))
 
 
-def _writer(site: str, queue: Queue, group_path: Path, error_queue: Queue) -> None:
-    """Background worker that writes posterior predictive samples to a Zarr array.
+def _create_site_array(
+    zarr_group: Group,
+    site: str,
+    arr: np.ndarray,
+    *,
+    draws: int,
+    sample_axis_size: int,
+    chunk_axis_size: int,
+) -> None:
+    """Create one Zarr array for a site.
 
-    This function runs in a loop, retrieving posterior predictive samples as arrays from
-    the queue and appending them to the appropriate dataset in the given Zarr group
-    along the sample (second) axis. It exits when a ``None`` sentinel value is received.
-    If an error occurs while writing to the Zarr array, it is logged and the error
-    details are put into the ``error_queue``.
+    The draw axis is sized to ``draws``; the sample (axis-1) dimension is sized to
+    ``sample_axis_size`` (``0`` for append-style growth, the full size for preallocated
+    slice writing); any trailing data dimensions are preserved verbatim.
+    ``dimension_names`` is ``("draw", "<site>_dim_0", ...)`` with one name per array
+    dimension.
 
     Args:
-        site: The name of the sample site.
-        queue: The queue to retrieve posterior predictive samples from.
+        zarr_group: The open Zarr group to create the array in.
+        site: The sample site name (also the array name).
+        arr: A representative (post-slice) sample array; only ``shape[2:]``, ``ndim``,
+            and ``dtype`` are read.
+        draws: Size of the leading (draw) dimension.
+        sample_axis_size: Size of the sample (axis-1) dimension.
+        chunk_axis_size: Chunk length along the sample (axis-1) dimension.
+    """
+    zarr_group.create_array(
+        name=site,
+        shape=(draws, sample_axis_size, *arr.shape[2:]),
+        dtype="float32" if arr.dtype == "bfloat16" else arr.dtype,
+        chunks=(draws, chunk_axis_size, *arr.shape[2:]),
+        dimension_names=(
+            "draw",
+            *tuple(f"{site}_dim_{i}" for i in range(arr.ndim - 1)),
+        ),
+    )
+
+
+def _writer(
+    site: str,
+    queue: Queue,
+    group_path: Path,
+    error_queue: Queue,
+    *,
+    apply: Callable[[Array, object], None],
+) -> None:
+    """Background worker that writes queued batches to a Zarr array.
+
+    Runs in a loop, retrieving items from the queue and writing each into the site's
+    dataset via ``apply``. It exits when a ``None`` sentinel is received. If opening the
+    group or a write fails, the error is logged, its details are put into
+    ``error_queue``, and the queue is drained (including the sentinel) so
+    :func:`_shutdown_writer_threads`'s ``queue.join()`` can finish.
+
+    Args:
+        site: The name of the sample site (also the Zarr array name).
+        queue: The queue to retrieve queued batches from.
         group_path: The path of the Zarr group.
         error_queue: The queue to collect errors raised by the writer thread.
+        apply: Writes one queued item into the site's Zarr array; the only behavior that
+            differs between write strategies.
     """
     try:
         group = open_group(group_path, mode="r+")
@@ -89,13 +139,13 @@ def _writer(site: str, queue: Queue, group_path: Path, error_queue: Queue) -> No
         return
 
     while True:
-        arr = queue.get()
-        if arr is None:
+        item = queue.get()
+        if item is None:
             queue.task_done()
             break
 
         try:
-            cast("Array", group[site]).append(arr, axis=1)
+            apply(cast("Array", group[site]), item)
         except Exception as exc:
             logger.exception("Error writing to site '%s'", site)
             error_queue.put((site, exc, exc.__traceback__))
@@ -113,7 +163,7 @@ def _writer(site: str, queue: Queue, group_path: Path, error_queue: Queue) -> No
 def _start_writer_threads(
     sites: tuple[str, ...],
     group_path: Path,
-    writer: Callable[[str, Queue, Path, Queue], None],
+    apply: Callable[[Array, object], None],
     queue_size: int,
 ) -> tuple[list[Thread], dict[str, Queue], Queue]:
     """Start writer threads and their corresponding queues for each site.
@@ -121,7 +171,7 @@ def _start_writer_threads(
     Args:
         sites: Names of the return sites.
         group_path: The path to the Zarr group where data will be written.
-        writer: The function that processes queued data and writes to Zarr.
+        apply: Writes one queued item into a site's Zarr array.
         queue_size: Maximum size of each queue (per site).
 
     Returns:
@@ -132,7 +182,11 @@ def _start_writer_threads(
     threads = []
     error_queue: Queue = Queue()
     for site, queue in queues.items():
-        thread = Thread(target=writer, args=(site, queue, group_path, error_queue))
+        thread = Thread(
+            target=_writer,
+            args=(site, queue, group_path, error_queue),
+            kwargs={"apply": apply},
+        )
         thread.start()
         threads.append(thread)
 
@@ -148,7 +202,6 @@ def _shutdown_writer_threads(
     Args:
         threads: List of writer threads to join.
         queues: Mapping of site names to their respective queues.
-        error_queue: Queue to collect errors raised by writer threads.
     """
     for queue in queues.values():
         queue.put(None)
@@ -156,3 +209,231 @@ def _shutdown_writer_threads(
         queue.join()
     for thread in threads:
         thread.join()
+
+
+def _select_write_strategy(dataloader: ArrayLoader) -> type[_WriteStrategy]:
+    """Select a write strategy from the loader's size capability.
+
+    Slice writing needs the batch count and dataset size up front; if either is
+    unavailable the append strategy is used instead.
+
+    Args:
+        dataloader: The data loader the sample loop will iterate.
+
+    Returns:
+        The write-strategy class to instantiate.
+    """
+    try:
+        len(dataloader)
+        len(dataloader.dataset)
+    except (TypeError, AttributeError):
+        return _AppendWriteStrategy
+
+    return _SliceWriteStrategy
+
+
+class _WriteStrategy(Protocol):
+    """How a batch of per-site samples is created and queued for writing."""
+
+    @staticmethod
+    def apply(array: Array, item: object) -> None:
+        """Write one queued item into a site's Zarr array.
+
+        Args:
+            array: The site's Zarr array.
+            item: The queued payload to write.
+        """
+
+    def create_arrays(self, site_arrays: Mapping[str, np.ndarray]) -> None:
+        """Create any not-yet-created Zarr arrays for the sites in a batch.
+
+        Args:
+            site_arrays: Mapping of site name to the (post-slice) sample array emitted
+                for the current batch.
+        """
+
+    def enqueue(
+        self,
+        queues: dict[str, Queue],
+        site_arrays: Mapping[str, np.ndarray],
+    ) -> None:
+        """Put a batch's per-site arrays onto their writer queues.
+
+        Args:
+            queues: Per-site writer queues, keyed by site name.
+            site_arrays: Mapping of site name to the (post-slice) sample array
+                emitted for the current batch.
+        """
+
+
+class _AppendWriteStrategy(_WriteStrategy):
+    """Grow each site's Zarr array by appending batches along axis 1.
+
+    Requires no size information up front; the array shape emerges from the batches as
+    they arrive.
+    """
+
+    @staticmethod
+    def apply(array: Array, item: object) -> None:
+        """Append the queued batch along the sample (axis-1) dimension.
+
+        Args:
+            array: The site's Zarr array.
+            item: The batch array to append.
+        """
+        array.append(cast("np.ndarray", item), axis=1)
+
+    def __init__(
+        self,
+        *,
+        zarr_group: Group,
+        draws: int,
+        dataloader: ArrayLoader,
+    ) -> None:
+        """Initialize the append write strategy.
+
+        Args:
+            zarr_group: The open Zarr group to create site arrays in.
+            draws: Size of the leading (draw) dimension for every site array.
+            dataloader: The data loader the sample loop will iterate; its ``batch_size``
+                is used as the Zarr chunk length along the sample (axis-1) dimension.
+        """
+        self._zarr_group = zarr_group
+        self._draws = draws
+        self._chunk_size = dataloader.batch_size
+        self._seen: set[str] = set()
+
+    def create_arrays(self, site_arrays: Mapping[str, np.ndarray]) -> None:
+        """Create zero-width Zarr arrays for sites not yet seen.
+
+        Args:
+            site_arrays: Mapping of site name to the (post-slice) sample array emitted
+                for the current batch.
+        """
+        for site, arr in site_arrays.items():
+            if site not in self._seen:
+                _create_site_array(
+                    self._zarr_group,
+                    site,
+                    arr,
+                    draws=self._draws,
+                    sample_axis_size=0,
+                    chunk_axis_size=self._chunk_size,
+                )
+                self._seen.add(site)
+
+    def enqueue(
+        self,
+        queues: dict[str, Queue],
+        site_arrays: Mapping[str, np.ndarray],
+    ) -> None:
+        """Put each site's batch array onto its writer queue.
+
+        Args:
+            queues: Per-site writer queues, keyed by site name.
+            site_arrays: Mapping of site name to the batch array to append.
+        """
+        for site, arr in site_arrays.items():
+            queues[site].put(arr)
+
+
+class _SliceWriteStrategy(_WriteStrategy):
+    """Write each batch into a fixed slice of a preallocated Zarr array.
+
+    Requires the dataset size up front. Every return site must emit an axis-1 size equal
+    to the input batch size (the loader's configured batch size, less any sharding
+    padding). Sites whose axis-1 size doesn't match raise :exc:`NotImplementedError` on
+    the first batch.
+    """
+
+    @staticmethod
+    def apply(array: Array, item: object) -> None:
+        """Assign the queued ``(start, arr)`` batch into a fixed sample slice.
+
+        Args:
+            array: The site's (preallocated) Zarr array.
+            item: A ``(start, arr)`` tuple; ``arr`` is written to
+                ``array[:, start : start + arr.shape[1], ...]``.
+        """
+        start, arr = cast("tuple[int, np.ndarray]", item)
+        array[:, start : start + arr.shape[1], ...] = arr
+
+    def __init__(
+        self,
+        *,
+        zarr_group: Group,
+        draws: int,
+        dataloader: ArrayLoader,
+    ) -> None:
+        """Initialize the slice write strategy.
+
+        Args:
+            zarr_group: The open Zarr group to create site arrays in.
+            draws: Size of the leading (draw) dimension for every site array.
+            dataloader: The data loader the sample loop will iterate; its ``batch_size``
+                and ``len(dataloader.dataset)`` are used to preallocate each site's
+                sample (axis-1) dimension.
+        """
+        self._zarr_group = zarr_group
+        self._draws = draws
+        self._chunk_size = dataloader.batch_size
+        self._n_obs = len(dataloader.dataset)
+        self._seen: set[str] = set()
+        self._site_offsets: dict[str, int] = {}
+
+    def create_arrays(self, site_arrays: Mapping[str, np.ndarray]) -> None:
+        """Preallocate full-size Zarr arrays for sites not yet seen.
+
+        On the first call (the first batch), every site is verified to emit an axis-1
+        size equal to the input batch size; mismatches raise. After creation, each site
+        is registered in ``self._site_offsets`` with offset zero so subsequent batches
+        can be written to fixed slices.
+
+        Args:
+            site_arrays: Mapping of site name to the (post-slice) sample array emitted
+                for the current batch.
+
+        Raises:
+            NotImplementedError: If any return site emits an axis-1 size that does not
+                match the input batch size.
+        """
+        # The first call carries the first batch's sites; on full first batches the real
+        # batch size equals ``self._chunk_size``, and when the dataset is smaller than
+        # the configured batch the single batch's real size is ``self._n_obs``.
+        expected_size = min(self._chunk_size, self._n_obs)
+        for site, arr in site_arrays.items():
+            if site not in self._seen:
+                if arr.shape[1] != expected_size:
+                    msg = (
+                        "Slice writing requires the per-site axis-1 size to match the "
+                        f"input batch size. Site {site!r} emitted shape {arr.shape} "
+                        f"for a batch of size {expected_size}; this kernel is not "
+                        "currently supported under slice writing."
+                    )
+                    raise NotImplementedError(msg)
+                _create_site_array(
+                    self._zarr_group,
+                    site,
+                    arr,
+                    draws=self._draws,
+                    sample_axis_size=self._n_obs,
+                    chunk_axis_size=expected_size,
+                )
+                self._seen.add(site)
+                self._site_offsets[site] = 0
+
+    def enqueue(
+        self,
+        queues: dict[str, Queue],
+        site_arrays: Mapping[str, np.ndarray],
+    ) -> None:
+        """Enqueue each site's batch as ``(start, arr)`` and advance its offset.
+
+        Args:
+            queues: Per-site writer queues, keyed by site name.
+            site_arrays: Mapping of site name to the batch array to write.
+        """
+        for site, arr in site_arrays.items():
+            start = self._site_offsets[site]
+            queues[site].put((start, arr))
+            self._site_offsets[site] = start + arr.shape[1]

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -60,6 +60,28 @@ def test_predict_fall_back(
         im_latent_var_svi_fitted.predict(X=X, batch_size=len(X), progress=False)
 
 
+def test_predict_rejects_unsupported_size(
+    synthetic_data: tuple[Array, Array],
+    im_lm_svi_fitted: ImpactModel,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`.predict()` rejects return sites whose axis-1 size doesn't match the batch.
+
+    The slice write strategy requires every return site to emit an axis-1 size equal to
+    the input batch size; ``sigma`` in ``lm`` does not satisfy this.
+    """
+    X, _ = synthetic_data
+    monkeypatch.setattr(im_lm_svi_fitted, "_mesh", None)
+    monkeypatch.setattr(im_lm_svi_fitted, "_fn_sample_posterior_predictive", None)
+    with pytest.raises(NotImplementedError, match="match the input batch size"):
+        im_lm_svi_fitted.predict(
+            X=X,
+            return_sites="sigma",
+            batch_size=3,
+            progress=False,
+        )
+
+
 class TestKernelParameterValidation:
     """Test class for validating parameter compatibility with the kernel."""
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -107,7 +107,11 @@ def test_writer_reports_open_group_failure_and_drains_queue(
     monkeypatch.setattr("aimz.utils._output.open_group", fail_open_group)
     queue = Queue(maxsize=1)
     error_queue = Queue()
-    thread = Thread(target=_writer, args=("site", queue, tmp_path, error_queue))
+    thread = Thread(
+        target=_writer,
+        args=("site", queue, tmp_path, error_queue),
+        kwargs={"apply": lambda _array, _item: None},
+    )
 
     thread.start()
     queue.put(object())


### PR DESCRIPTION
Implement a new strategy for disk-backed methods to preallocate Zarr arrays and write batches into fixed slices, enhancing performance by avoiding repeated resizing. Ensure that all return sites emit an axis-1 size matching the input batch size to prevent errors with incompatible return sites.

Fixes #213.