### PR TITLE
Fix validation to exclude strings and mappings from array-like checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When an observation-aligned posterior sample shape is detected as incompatible with the default `shard_axis="obs"`, {meth}`~aimz.ImpactModel.predict` now warns and reruns under the new `shard_axis="draw"` scheme instead of falling back to the in-memory {meth}`~aimz.ImpactModel.predict_on_batch`, keeping results streamed to disk and memory-bounded. {meth}`~aimz.ImpactModel.log_likelihood`, which previously failed with a raw shape-broadcasting error for such posteriors, behaves the same way ([#224](https://github.com/markean/aimz/issues/224)).
 - The auto-computed `batch_size` budget is now denominated in bytes rather than a fixed element count. The element cap is derived at call time by dividing the byte budget by the output dtype's item size ([#227](https://github.com/markean/aimz/issues/227)).
 
+### Fixed
+
+- Keyword arguments to the disk-backed methods whose values are strings or mappings are no longer mistaken for array inputs. Previously such a value was routed into the observation-axis batching pipeline and raised a misleading leading-axis error ([#229](https://github.com/markean/aimz/issues/229)).
+
 ## [v0.12.0](https://github.com/markean/aimz/releases/tag/v0.12.0) - 2026-05-23
 
 ### Changed

--- a/aimz/utils/_validation.py
+++ b/aimz/utils/_validation.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from inspect import Parameter, getfullargspec, signature
 from typing import TYPE_CHECKING
 
@@ -38,6 +39,9 @@ if TYPE_CHECKING:
 
 def _is_arraylike(x: object) -> bool:
     """Returns whether the input is array-like."""
+    if isinstance(x, (str, bytes, bytearray, Mapping)):
+        return False
+
     return hasattr(x, "__len__") or hasattr(x, "shape") or hasattr(x, "__array__")
 
 

--- a/tests/test_input_setup.py
+++ b/tests/test_input_setup.py
@@ -75,3 +75,18 @@ def test_y_zero_dim_raises() -> None:
             batch_size=None,
             num_samples=1,
         )
+
+
+def test_non_array_kwargs_classified_as_extra() -> None:
+    """Non-array keyword arguments are routed to extras, not the batched dataset."""
+    loader, extra = _setup_inputs(
+        X=jnp.ones((4, 2)),
+        y=None,
+        rng_key=random.key(0),
+        batch_size=2,
+        num_samples=1,
+        family="gaussian",
+    )
+
+    assert set(loader.dataset.arrays) == {"X"}
+    assert extra == {"family": "gaussian"}


### PR DESCRIPTION
Fix #229