### PR TITLE
Fix background writer-thread failure handling in disk-backed methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On multi-device hosts, calling a disk-backed method again with a different number of array or keyword arguments no longer fails with a sharding structure error ([#237](https://github.com/markean/aimz/issues/237)).
 - {meth}`~aimz.ImpactModel.predict` / {meth}`~aimz.ImpactModel.predict_on_batch` interventions (and {meth}`~aimz.ImpactModel.estimate_effect`) no longer reuse one likelihood-noise draw across all posterior draws, fixing under-dispersed intervention predictions and intervals ([#239](https://github.com/markean/aimz/issues/239)).
 - {meth}`~aimz.ImpactModel.estimate_effect` now warns when the baseline and intervention scenarios have different dimension sizes, instead of silently computing the effect on their overlap ([#241](https://github.com/markean/aimz/issues/241)).
+- A background writer-thread failure while streaming results to disk now raises instead of being swallowed; previously disk-backed methods could return a silently zero-filled or truncated result ([#243](https://github.com/markean/aimz/issues/243)).
 
 ## [v0.12.0](https://github.com/markean/aimz/releases/tag/v0.12.0) - 2026-05-23
 

--- a/aimz/utils/_output.py
+++ b/aimz/utils/_output.py
@@ -518,12 +518,14 @@ def _write_loop(
             pbar.update()
         if worker_err is None:
             pbar.set_description("Writing in progress...")
-            _shutdown_writer_threads(threads, queues=queues)
-            success = True
+        success = worker_err is None
     finally:
+        _shutdown_writer_threads(threads, queues=queues)
+        if success and error_queue is not None and not error_queue.empty():
+            worker_err = error_queue.get()
+            success = False
         if not success:
             logger.warning("Cleaning up output directory: %s", output_dir)
-            _shutdown_writer_threads(threads, queues=queues)
             rmtree(output_dir, ignore_errors=True)
         pbar.close()
     if worker_err is not None:

--- a/docs/source/user_guide/dataloader.rst
+++ b/docs/source/user_guide/dataloader.rst
@@ -29,7 +29,7 @@ It consumes an :class:`~aimz.utils.data.ArrayDataset` and produces an iterator o
 * ``batch_dict`` maps each field name to a (possibly padded) mini-batch array.
 * ``n_pad`` is the number of synthetic examples added so the (possibly last) batch size is divisible by the number of local devices.
   When no device is specified (``device=None``), no padding is performed and ``n_pad`` is always ``0``.
-  If set, batch is padded (if needed) then moved via :func:`jax.device_put`.
+  If set, batch is padded (if needed) then moved via :external:func:`jax.device_put`.
   Padding uses :external:func:`jax.numpy.pad` with ``mode="edge"`` (it repeats the last row) so shapes align for sharded computations; callers can ignore those rows (track via ``n_pad``).
   The ``batch_size`` must be a positive integer, and if using a device or sharding it is best to choose a multiple of :external:func:`jax.local_device_count()` to avoid padding.
 
@@ -93,14 +93,27 @@ If the user pass raw arrays instead, :meth:`~aimz.ImpactModel.fit` may internall
     # Set up variational inference strategy
     vi = SVI(model, ...)
 
-    # Initialize ImpactModel with a model, random key, and SVI object
-    im = ImpactModel(model, rng_key=random.key(0), svi=vi)
+    # Initialize ImpactModel with a model, random key, and inference object
+    im = ImpactModel(model, rng_key=random.key(0), inference=vi)
 
-    # Use a prepared ArrayLoader for explicit batching/shuffling
+    # Build one loader for both fit and predict. Loaders do not shuffle by default,
+    # so prediction output stays aligned with the input order.
+    loader = ArrayLoader(
+        ArrayDataset(X=X, y=y),
+        rng_key=random.key(0),
+        batch_size=10,
+    )
+
+    # Explicit batching for fit
     im.fit(loader, epochs=10)
 
-    # Predictions also accept a loader for consistent batching
+    # Predictions accept the same loader for consistent batching
     preds = im.predict(loader)
+
+.. note::
+
+    :class:`~aimz.utils.data.ArrayLoader` does not shuffle by default (``shuffle=False``), which is what prediction requires: streamed output is written in input order, so a ``shuffle=True`` loader would misalign the results with the input rows.
+    Enable ``shuffle=True`` only for training/fit loops.
 
 
 Custom Training Loops with :meth:`~aimz.ImpactModel.train_on_batch`
@@ -135,7 +148,7 @@ Any iterable that yields a mapping (field name -> array) per batch works with a 
 
     # PyTorch DataLoader example (CPU -> JAX conversion per batch)
     dataset = TensorDataset(X, y)
-    loader = DataLoader(dataset, batch_size=10, shuffle=True)
+    loader = DataLoader(dataset, batch_size=10)
 
     losses = []
     for epoch in range(num_epochs):


### PR DESCRIPTION
Fix background writer-thread failure handling in disk-backed methods and update data loader documentation.

Fixes #243.