### PR TITLE
Forward the non-array kwargs into the probe trace in prior predictive sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - {meth}`~aimz.ImpactModel.predict` / {meth}`~aimz.ImpactModel.predict_on_batch` interventions (and {meth}`~aimz.ImpactModel.estimate_effect`) no longer reuse one likelihood-noise draw across all posterior draws, fixing under-dispersed intervention predictions and intervals ([#239](https://github.com/markean/aimz/issues/239)).
 - {meth}`~aimz.ImpactModel.estimate_effect` now warns when the baseline and intervention scenarios have different dimension sizes, instead of silently computing the effect on their overlap ([#241](https://github.com/markean/aimz/issues/241)).
 - A background writer-thread failure while streaming results to disk now raises instead of being swallowed; previously disk-backed methods could return a silently zero-filled or truncated result ([#243](https://github.com/markean/aimz/issues/243)).
+- {meth}`~aimz.ImpactModel.sample_prior_predictive` under the default `shard_axis="obs"` now forwards non-array keyword arguments to the model when drawing prior samples; previously they were dropped, so those samples used the kernel's default values (silently wrong) or raised a `TypeError` for a required argument ([#245](https://github.com/markean/aimz/issues/245)).
 
 ## [v0.12.0](https://github.com/markean/aimz/releases/tag/v0.12.0) - 2026-05-23
 

--- a/aimz/model/_streaming.py
+++ b/aimz/model/_streaming.py
@@ -294,7 +294,7 @@ class _OutputStreamer:
                 rng_keys=random.split(rng_subkey, num=req.num_samples),
                 return_sites=None,
                 samples=None,
-                model_kwargs=batch,
+                model_kwargs={**batch, **kwargs_extra},
             )
             samples = {k: v for k, v in samples.items() if k not in req.return_sites}
             if self._ctx.replicated_sharding is not None:

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -590,10 +590,9 @@ class ImpactModel(BaseModel):
                 is used and split as needed.
             return_sites: Names of variables (sites) to return. If ``None``, samples
                 :attr:`~aimz.ImpactModel.param_output` and deterministic sites.
-            shard_axis: Multi-device sharding strategy; no effect on a single device.
-                ``"obs"`` (default) shards the input across devices and replicates the
-                drawn samples. ``"draw"`` shards the drawn samples across devices and
-                replicates the input.
+            shard_axis: Multi-device sharding strategy. ``"obs"`` (default) shards the
+                input across devices and replicates the drawn samples. ``"draw"`` shards
+                the drawn samples across devices and replicates the input.
             batch_size: Size of each batch, taken from the input under
                 ``shard_axis="obs"`` and from the draws under ``shard_axis="draw"``.
                 Also used as the chunk size when storing results. If ``None``, it is


### PR DESCRIPTION
Fix #245.