### PR TITLE
Require `y` for `log_likelihood()` when X is array-like; raise `ValueError` if not provided.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,6 @@ jobs:
         run: uv run pytest tests --cov=aimz --cov-report=xml --cov-report=term
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install uv and set the Python version
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up Python

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: ruff-action
         uses: astral-sh/ruff-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - {meth}`~aimz.ImpactModel.sample_prior_predictive` under the default `shard_axis="obs"` now forwards non-array keyword arguments to the model when drawing prior samples; previously they were dropped, so those samples used the kernel's default values (silently wrong) or raised a `TypeError` for a required argument ([#245](https://github.com/markean/aimz/issues/245)).
 - The disk-backed methods now work with an array input when a custom `param_input`/`param_output` is set; previously the streamed dataset was keyed by the literal names `X`/`y` ([#247](https://github.com/markean/aimz/issues/247)).
 - A user-built {class}`~aimz.utils.data.ArrayLoader` whose dataset carries array fields beyond the model input/output now works with the disk-backed methods, binding each field to the kernel parameter of the same name; previously such a loader failed during tracing with an error, and array arguments were matched by position rather than name ([#249](https://github.com/markean/aimz/issues/249)).
+- {meth}`~aimz.ImpactModel.log_likelihood` now raises a ValueError when called with an array `X` but no `y`, instead of a `KeyError: 'y'` ([#254](https://github.com/markean/aimz/issues/254)).
 
 ## [v0.12.0](https://github.com/markean/aimz/releases/tag/v0.12.0) - 2026-05-23
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -1622,6 +1622,12 @@ class ImpactModel(BaseModel):
         _validate_shard_axis(shard_axis, X=X)
         _validate_batch_size(batch_size, X=X)
         _validate_aligned_inputs(X, y=y, kwargs=kwargs)
+        if y is None and isinstance(X, ArrayLike):
+            msg = (
+                "`y` is required for `log_likelihood()` when `X` is array-like. "
+                "Provide `y`, or give `X` as a data loader that carries it."
+            )
+            raise ValueError(msg)
 
         # No posterior to shard means draw-parallel has nothing to chunk, so it behaves
         # identically to the data-parallel path (a single-draw result).

--- a/tests/test_log_likelihood.py
+++ b/tests/test_log_likelihood.py
@@ -59,6 +59,16 @@ def test_empty_posterior(
     assert out.log_likelihood["y"].sizes["draw"] == 1
 
 
+def test_log_likelihood_requires_y(
+    synthetic_data: tuple[Array, Array],
+    im_lm_svi_fitted: ImpactModel,
+) -> None:
+    """`log_likelihood()` requires `y` for an array `X`."""
+    X, _ = synthetic_data
+    with pytest.raises(ValueError, match="`y` is required"):
+        im_lm_svi_fitted.log_likelihood(X, progress=False)
+
+
 class TestBatchSize:
     """Test class related to batch size specification."""
 


### PR DESCRIPTION
Fix #254.