### PR TITLE
Improve error handling for input type in `_setup_inputs`; raise `TypeError` for non-array-like or non-loader `X`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The disk-backed methods now work with an array input when a custom `param_input`/`param_output` is set; previously the streamed dataset was keyed by the literal names `X`/`y` ([#247](https://github.com/markean/aimz/issues/247)).
 - A user-built {class}`~aimz.utils.data.ArrayLoader` whose dataset carries array fields beyond the model input/output now works with the disk-backed methods, binding each field to the kernel parameter of the same name; previously such a loader failed during tracing with an error, and array arguments were matched by position rather than name ([#249](https://github.com/markean/aimz/issues/249)).
 - {meth}`~aimz.ImpactModel.log_likelihood` now raises a ValueError when called with an array `X` but no `y`, instead of a `KeyError: 'y'` ([#254](https://github.com/markean/aimz/issues/254)).
+- The disk-backed methods now raise a clear `TypeError` when `X` is neither an array-like nor a data loader (e.g. a Python list), instead of an `UnboundLocalError` from an incomplete internal type check ([#256](https://github.com/markean/aimz/issues/256)).
 
 ## [v0.12.0](https://github.com/markean/aimz/releases/tag/v0.12.0) - 2026-05-23
 

--- a/aimz/utils/data/_input_setup.py
+++ b/aimz/utils/data/_input_setup.py
@@ -167,5 +167,8 @@ def _setup_inputs(
             raise TypeError(msg)
         loader = X
         loader.device = device
+    else:
+        msg = f"`X` must be an array-like or a data loader, got {type(X).__name__!r}."
+        raise TypeError(msg)
 
     return loader, kwargs_extra

--- a/tests/test_input_setup.py
+++ b/tests/test_input_setup.py
@@ -83,6 +83,20 @@ def test_y_zero_dim_raises() -> None:
         )
 
 
+def test_x_wrong_type_raises() -> None:
+    """A non-array, non-loader ``X`` (e.g. a Python list) raises ``TypeError``."""
+    with pytest.raises(TypeError, match=r"`X` must be an array-like or a data loader"):
+        _setup_inputs(
+            X=[[1.0, 2.0], [3.0, 4.0]],
+            y=None,
+            param_input="X",
+            param_output="y",
+            rng_key=random.key(0),
+            batch_size=None,
+            num_samples=1,
+        )
+
+
 def test_non_array_kwargs_classified_as_extra() -> None:
     """Non-array keyword arguments are routed to extras, not the batched dataset."""
     loader, extra = _setup_inputs(


### PR DESCRIPTION
Fix #256.