### PR TITLE
Register cloudpickle-restored models for cleanup in ImpactModel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - {meth}`~aimz.ImpactModel.log_likelihood` now raises a ValueError when called with an array `X` but no `y`, instead of a `KeyError: 'y'` ([#254](https://github.com/markean/aimz/issues/254)).
 - The disk-backed methods now raise a clear `TypeError` when `X` is neither an array-like nor a data loader (e.g. a Python list), instead of an `UnboundLocalError` from an incomplete internal type check ([#256](https://github.com/markean/aimz/issues/256)).
 - A disk-backed method that fails before the write phase no longer leaves an orphaned subdirectory behind; the partially-created subdirectory is removed and the original error is re-raised ([#258](https://github.com/markean/aimz/issues/258)).
+- A model restored from disk with `pickle`/`cloudpickle` (e.g. through the `mlflow` integration) is now re-registered for class-level cleanup, so {meth}`~aimz.ImpactModel.cleanup_models` removes its temporary directory; previously only directly constructed models were tracked ([#260](https://github.com/markean/aimz/issues/260)).
 
 ## [v0.12.0](https://github.com/markean/aimz/releases/tag/v0.12.0) - 2026-05-23
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -130,9 +130,6 @@ class ImpactModel(BaseModel):
         self._posterior: dict[str, Array] | None = None
         self._init_runtime_attrs()
 
-        # Register this instance
-        ImpactModel._models.add(self)
-
     def _init_runtime_attrs(self) -> None:
         """Initialize runtime attributes."""
         self._fn_vi_update: Callable | None = None
@@ -159,6 +156,7 @@ class ImpactModel(BaseModel):
             ),
         )
         self._temp_dir: TemporaryDirectory | None = None
+        ImpactModel._models.add(self)
         logger.info(
             "Backend: %s, Devices: %d",
             default_backend(),

--- a/tests/test_cleanup_models.py
+++ b/tests/test_cleanup_models.py
@@ -14,6 +14,7 @@
 
 """Tests for the `.cleanup_models()` method."""
 
+import cloudpickle
 import pytest
 from jax import Array, random
 from numpyro.infer import SVI
@@ -43,3 +44,27 @@ def test_predict_after_cleanup(
 
     assert im1.temp_dir is None
     assert im2.temp_dir is None
+
+
+@pytest.mark.parametrize("vi", [lm], indirect=True)
+def test_cleanup_models_covers_unpickled_instance(
+    synthetic_data: tuple[Array, Array],
+    vi: SVI,
+) -> None:
+    """A cloudpickle-restored model re-registers, so `cleanup_models()` reaches it."""
+    X, y = synthetic_data
+
+    im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
+    im.fit_on_batch(X=X, y=y)
+
+    # cloudpickle bypasses `__init__` (only `__setstate__` runs), so the restored
+    # instance must re-register itself in `_models`.
+    restored = cloudpickle.loads(cloudpickle.dumps(im))
+    assert restored in ImpactModel._models
+
+    restored.predict(X, batch_size=3)
+    assert restored.temp_dir is not None
+
+    ImpactModel.cleanup_models()
+
+    assert restored.temp_dir is None


### PR DESCRIPTION
Fix #260.