### PR TITLE
Fix static argument handling in train_on_batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The numerical-instability warning for the loss history is emitted once per fit instead of twice ({meth}`~aimz.ImpactModel.fit` and {meth}`~aimz.ImpactModel.fit_on_batch` duplicated the {attr}`~aimz.ImpactModel.vi_result` setter's check), and the check now also detects Inf losses, as its message has stated ([#269](https://github.com/markean/aimz/issues/269)).
+- Calling {meth}`~aimz.ImpactModel.train_on_batch` (or {meth}`~aimz.ImpactModel.fit`) on the same model with a different set of non-array keyword arguments than an earlier call no longer reuses a stale compiled update function whose static arguments were derived from the first call. Each distinct set of non-array argument names now gets its own cached update function ([#271](https://github.com/markean/aimz/issues/271)).
 
 ## [v0.13.0](https://github.com/markean/aimz/releases/tag/v0.13.0) - 2026-07-03
 

--- a/aimz/model/_streaming.py
+++ b/aimz/model/_streaming.py
@@ -38,6 +38,7 @@ from aimz.utils._output import (
     _SliceWriteStrategy,
     _write_loop,
 )
+from aimz.utils._validation import _is_arraylike
 from aimz.utils.data import ArrayLoader
 from aimz.utils.data._input_setup import _resolve_batch_size, _setup_inputs
 from aimz.utils.data._sharding import (
@@ -52,6 +53,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     import numpy as np
+    import numpy.typing as npt
     from jax.sharding import Mesh, Sharding
     from jax.typing import ArrayLike
 
@@ -335,9 +337,25 @@ class _OutputStreamer:
         if group == "prior_predictive":
             # Single-element, unsharded probe draws the global prior samples once; the
             # return sites are dropped so they are redrawn per batch. Prior samples are
-            # redrawn every call, so this is a one-shot (not cached) placement.
+            # redrawn every call, so this is a one-shot (not cached) placement. The
+            # probe is built from a single-row slice so the whole input is not converted
+            # to host just to draw one batch.
+            if isinstance(req.X, ArrayLoader):
+                X_probe, kwargs_probe = req.X, req.kwargs
+            else:
+                # Anything non-array-like is passed through unsliced so that
+                # `_setup_inputs` rejects it with its usual error.
+                X_probe = (
+                    cast("Array | npt.NDArray", req.X)[:1]
+                    if _is_arraylike(req.X)
+                    else req.X
+                )
+                kwargs_probe = {
+                    k: cast("Array | npt.NDArray", v)[:1] if _is_arraylike(v) else v
+                    for k, v in req.kwargs.items()
+                }
             probe, _ = _setup_inputs(
-                X=req.X,
+                X=X_probe,
                 y=None,
                 param_input=self._ctx.param_input,
                 param_output=self._ctx.param_output,
@@ -346,7 +364,7 @@ class _OutputStreamer:
                 num_samples=req.num_samples,
                 shuffle=False,
                 device=None,
-                **req.kwargs,
+                **kwargs_probe,
             )
             batch, _ = next(iter(probe))
             rng_key, rng_subkey = random.split(rng_key)

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -132,7 +132,7 @@ class ImpactModel(BaseModel):
 
     def _init_runtime_attrs(self) -> None:
         """Initialize runtime attributes."""
-        self._fn_vi_update: Callable | None = None
+        self._fn_vi_update: dict[tuple[str, ...], Callable] = {}
         self._num_devices = local_device_count()
         if self._num_devices > 1:
             mesh = make_mesh(
@@ -915,14 +915,20 @@ class ImpactModel(BaseModel):
             if rng_key is None:
                 self._rng_key, rng_key = random.split(self._rng_key)
             self._vi_state = cast("SVI", self.inference).init(rng_key, **batch)
-        if self._fn_vi_update is None:
-            _, kwargs_extra = _group_kwargs(kwargs)
-            self._fn_vi_update = jit(
+        # Cache one jitted update per set of non-array kwarg names: the names are baked
+        # into `static_argnames`, so a call with different extras needs its own wrapper
+        # rather than reusing a stale one.
+        _, kwargs_extra = _group_kwargs(kwargs)
+        fn_key = tuple(sorted(kwargs_extra))
+        fn_vi_update = self._fn_vi_update.get(fn_key)
+        if fn_vi_update is None:
+            fn_vi_update = jit(
                 cast("SVI", self.inference).update,
-                static_argnames=tuple(kwargs_extra),
+                static_argnames=fn_key,
             )
+            self._fn_vi_update[fn_key] = fn_vi_update
 
-        self._vi_state, loss = self._fn_vi_update(self._vi_state, **batch)
+        self._vi_state, loss = fn_vi_update(self._vi_state, **batch)
 
         return self._vi_state, loss
 

--- a/tests/test_train_on_batch.py
+++ b/tests/test_train_on_batch.py
@@ -16,16 +16,17 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
+import jax.numpy as jnp
+import numpyro.distributions as dist
 import pytest
 from jax import Array, random
+from numpyro import sample
+from numpyro.infer import SVI, Trace_ELBO
+from numpyro.infer.autoguide import AutoNormal
+from numpyro.optim import Adam
 
 from aimz import ImpactModel
 from tests.conftest import lm_with_kwargs_array
-
-if TYPE_CHECKING:
-    from numpyro.infer import SVI
 
 
 @pytest.mark.parametrize("vi", [lm_with_kwargs_array], indirect=True)
@@ -46,3 +47,34 @@ def test_train_on_batch_lm_with_kwargs_array(
     assert last_loss < first_loss, (
         f"Loss did not decrease after training: first={first_loss}, last={last_loss}"
     )
+
+
+def test_train_on_batch_different_extra_kwargs(
+    synthetic_data: tuple[Array, Array],
+) -> None:
+    """Calls with different non-array kwargs each get their own static wrapper."""
+    X, y = synthetic_data
+
+    def kernel(
+        X: Array,
+        link: str = "identity",
+        noise: str = "normal",
+        y: Array | None = None,
+    ) -> None:
+        w = sample("w", dist.Normal(jnp.zeros(X.shape[1]), 1.0).to_event(1))
+        mu = jnp.dot(X, w)
+        mu = mu if link == "identity" else jnp.exp(mu)
+        sample("y", dist.Normal(mu, 1.0), obs=y)
+
+    vi = SVI(
+        kernel,
+        guide=AutoNormal(kernel),
+        optim=Adam(step_size=1e-3),
+        loss=Trace_ELBO(),
+    )
+    im = ImpactModel(kernel, rng_key=random.key(42), inference=vi)
+
+    # Each call passes a different set of string (non-array, static) kwargs
+    im.train_on_batch(X=X, y=y, link="identity")
+    im.train_on_batch(X=X, y=y, noise="normal")
+    assert sorted(im._fn_vi_update) == [("link",), ("noise",)]


### PR DESCRIPTION
Improve handling of non-array keyword arguments in `train_on_batch` to ensure each unique set of arguments gets its own compiled update function. This change addresses the issue of reusing stale compiled functions, which could lead to errors when different arguments are passed.

Fixes #271