### PR TITLE
Fix unnecessary recompilation in `log_likelihood()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The numerical-instability warning for the loss history is emitted once per fit instead of twice ({meth}`~aimz.ImpactModel.fit` and {meth}`~aimz.ImpactModel.fit_on_batch` duplicated the {attr}`~aimz.ImpactModel.vi_result` setter's check), and the check now also detects Inf losses, as its message has stated ([#269](https://github.com/markean/aimz/issues/269)).
 - Calling {meth}`~aimz.ImpactModel.train_on_batch` (or {meth}`~aimz.ImpactModel.fit`) on the same model with a different set of non-array keyword arguments than an earlier call no longer reuses a stale compiled update function whose static arguments were derived from the first call. Each distinct set of non-array argument names now gets its own cached update function ([#271](https://github.com/markean/aimz/issues/271)).
+- {meth}`~aimz.ImpactModel.log_likelihood` no longer triggers unnecessary JAX recompilation when evaluating a fitted posterior. The kernel is now seeded only when no posterior is supplied and a single prior draw is required. Incomplete posteriors now raise an error instead of silently conditioning on frozen prior draws for missing latent sites ([#273](https://github.com/markean/aimz/issues/273)).
 
 ## [v0.13.0](https://github.com/markean/aimz/releases/tag/v0.13.0) - 2026-07-03
 

--- a/aimz/model/_streaming.py
+++ b/aimz/model/_streaming.py
@@ -405,7 +405,8 @@ class _OutputStreamer:
 
         Args:
             req: The streamed write job (its single return site is the output site).
-            kernel: Probabilistic model with `NumPyro`_ primitives, already seeded.
+            kernel: Probabilistic model with `NumPyro`_ primitives, seeded by the
+                caller when tracing needs to sample latent sites (empty posterior).
             posterior: The posterior to condition on.
             y: Output data.
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -1671,9 +1671,13 @@ class ImpactModel(BaseModel):
                 **kwargs,
             )
 
-        # Seed once so tracing succeeds even when posterior is empty or only partially
-        # covers latent sites.
-        kernel = seed(self.kernel, rng_seed=self.rng_key)
+        # With no posterior, the single-draw result samples every latent site from the
+        # prior, which requires a seeded kernel. A posterior from fitting covers every
+        # latent site, so no key is consumed and the bare kernel keeps a stable identity
+        # for the compilation cache; a partial posterior raises an error.
+        kernel = (
+            self.kernel if self.posterior else seed(self.kernel, rng_seed=self.rng_key)
+        )
 
         output_dir, output_subdir = self._create_output_subdir(output_dir)
 


### PR DESCRIPTION
`log_likelihood()` now avoids unnecessary JAX recompilation when evaluating a fitted posterior. Seeding occurs only when no posterior is supplied and a single prior draw is required. Incomplete posteriors will raise an error instead of silently conditioning on frozen prior draws for missing latent sites.

Fixes #273