### PR TITLE
Optimize eager forward sampling to prevent recompilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The numerical-instability warning for the loss history is emitted once per fit instead of twice ({meth}`~aimz.ImpactModel.fit` and {meth}`~aimz.ImpactModel.fit_on_batch` duplicated the {attr}`~aimz.ImpactModel.vi_result` setter's check), and the check now also detects Inf losses, as its message has stated ([#269](https://github.com/markean/aimz/issues/269)).
 - Calling {meth}`~aimz.ImpactModel.train_on_batch` (or {meth}`~aimz.ImpactModel.fit`) on the same model with a different set of non-array keyword arguments than an earlier call no longer reuses a stale compiled update function whose static arguments were derived from the first call. Each distinct set of non-array argument names now gets its own cached update function ([#271](https://github.com/markean/aimz/issues/271)).
 - {meth}`~aimz.ImpactModel.log_likelihood` no longer triggers unnecessary JAX recompilation when evaluating a fitted posterior. The kernel is now seeded only when no posterior is supplied and a single prior draw is required. Incomplete posteriors now raise an error instead of silently conditioning on frozen prior draws for missing latent sites ([#273](https://github.com/markean/aimz/issues/273)).
+- {meth}`~aimz.ImpactModel.predict_on_batch` and {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch` no longer recompile and retain a new compiled program on every call ([#275](https://github.com/markean/aimz/issues/275)).
+
 
 ## [v0.13.0](https://github.com/markean/aimz/releases/tag/v0.13.0) - 2026-07-03
 

--- a/aimz/sampling/_forward.py
+++ b/aimz/sampling/_forward.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from jax import Array, lax
+from jax import Array, lax, vmap
+from jax.core import Tracer
 from numpyro.handlers import mask, seed, substitute, trace
 
 if TYPE_CHECKING:
@@ -41,6 +42,13 @@ def _sample_forward(
     with ``random.split(rng_key, num=num_samples)``, while the draw-parallel sharded
     path forwards its device-local slice of the host-split keys (so draws stay
     deterministic across mesh sizes).
+
+    Under a trace (e.g. when called inside :external:func:`jax.jit`), draws run as a
+    single fused :external:func:`jax.lax.map` loop in the compiled program. Called
+    eagerly, draws are instead vectorized with :external:func:`jax.vmap`: eager
+    ``lax.map`` would compile and cache a program keyed on the identity of a
+    per-call closure, so repeated eager calls would each retain a new compilation,
+    growing the cache without bound.
 
     Args:
         model: A probabilistic model with NumPyro primitives.
@@ -85,4 +93,7 @@ def _sample_forward(
 
         return {k: v["value"] for k, v in model_trace.items() if k in sites}
 
-    return lax.map(_trace_one_sample, xs=(rng_keys, samples or {}))
+    if isinstance(rng_keys, Tracer):
+        return lax.map(_trace_one_sample, xs=(rng_keys, samples or {}))
+
+    return vmap(_trace_one_sample)((rng_keys, samples or {}))

--- a/docs/source/examples/hillstrom.rst
+++ b/docs/source/examples/hillstrom.rst
@@ -275,7 +275,7 @@ Calling :meth:`~aimz.ImpactModel.fit_on_batch` runs the configured inference eng
         inference=MCMC(
             NUTS(conversion_model),
             num_warmup=500,
-            num_samples=500,
+            num_samples=250,
             num_chains=2,
         ),
     )
@@ -521,7 +521,7 @@ We fit the hurdle model using the same MCMC configuration as before.
         inference=MCMC(
             NUTS(spend_model),
             num_warmup=500,
-            num_samples=500,
+            num_samples=250,
             num_chains=2,
         ),
     )


### PR DESCRIPTION
Eager forward sampling functions now utilize `jax.vmap` to avoid unnecessary recompilation and retain a single compiled program across calls. This change addresses the issue of multiple compilations during eager sampling, improving performance and efficiency.

Fixes #275