### PR TITLE
Polish output handling with artifact paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A host-backed posterior is now placed on the default device once and cached, instead of being re-transferred on every {meth}`~aimz.ImpactModel.predict_on_batch` call and on every batch of the single-device data-parallel path of {meth}`~aimz.ImpactModel.predict` and {meth}`~aimz.ImpactModel.log_likelihood`. The placed copy stays device-resident until the posterior is replaced ([#267](https://github.com/markean/aimz/issues/267)).
 - Loss history stored by {meth}`~aimz.ImpactModel.fit` and {meth}`~aimz.ImpactModel.fit_on_batch` (`vi_result.losses`) is now a host-backed NumPy array rather than a JAX device array. Values are unchanged, and the {attr}`~aimz.ImpactModel.vi_result` setter continues to accept any array-like losses ([#268](https://github.com/markean/aimz/issues/268)).
+- The disk-backed methods now record the call's artifact path in an `artifact_path` attribute on both the root and the group node of the returned {class}`xarray.DataTree`. The former `output_dir` attribute is removed; the temporary root remains available via {attr}`~aimz.ImpactModel.temp_dir` ([#XXX](https://github.com/markean/aimz/issues/277)).
 
 ### Fixed
 
@@ -18,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Calling {meth}`~aimz.ImpactModel.train_on_batch` (or {meth}`~aimz.ImpactModel.fit`) on the same model with a different set of non-array keyword arguments than an earlier call no longer reuses a stale compiled update function whose static arguments were derived from the first call. Each distinct set of non-array argument names now gets its own cached update function ([#271](https://github.com/markean/aimz/issues/271)).
 - {meth}`~aimz.ImpactModel.log_likelihood` no longer triggers unnecessary JAX recompilation when evaluating a fitted posterior. The kernel is now seeded only when no posterior is supplied and a single prior draw is required. Incomplete posteriors now raise an error instead of silently conditioning on frozen prior draws for missing latent sites ([#273](https://github.com/markean/aimz/issues/273)).
 - {meth}`~aimz.ImpactModel.predict_on_batch` and {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch` no longer recompile and retain a new compiled program on every call ([#275](https://github.com/markean/aimz/issues/275)).
-
+- The root-level attribute of a disk-backed result pointed at the parent output directory rather than the call's own subdirectory, and {meth}`~aimz.ImpactModel.estimate_effect` propagated only that parent directory (or the temporary root), so scenario artifacts computed lazily via `args_baseline`/`args_intervention` were not discoverable from the effect tree. {meth}`~aimz.ImpactModel.estimate_effect` now records each scenario's artifact path under `artifact_path_baseline` and `artifact_path_intervention` and no longer falls back to the temporary root ([#XXX](https://github.com/markean/aimz/issues/277)).
 
 ## [v0.13.0](https://github.com/markean/aimz/releases/tag/v0.13.0) - 2026-07-03
 

--- a/aimz/model/_streaming.py
+++ b/aimz/model/_streaming.py
@@ -81,7 +81,7 @@ class _WriteRequest:
     return_sites: tuple[str, ...]
     num_samples: int
     batch_size: int | None
-    output_dir: Path
+    artifact_path: Path
     progress: bool
     loader_rng_key: Array
     kwargs: dict[str, object]
@@ -270,7 +270,7 @@ class _OutputStreamer:
         group: str,
         posterior: dict[str, Array] | None,
     ) -> None:
-        """Write predictive samples (predict / prior predictive) to ``req.output_dir``.
+        """Write predictive samples to ``req.artifact_path``.
 
         Builds the predictive ``compute`` — one sharded-sampler call per item — and
         dispatches to the strategy streamer. ``shard_axis="draw"`` chunks the draw axis;
@@ -398,7 +398,7 @@ class _OutputStreamer:
         posterior: dict[str, Array] | None,
         y: ArrayLike | None,
     ) -> None:
-        """Write the log-likelihood of ``y`` under ``kernel`` to ``req.output_dir``.
+        """Write the log-likelihood to ``req.artifact_path``.
 
         Builds the log-likelihood ``compute`` — one sharded call per item, keyed by the
         output site — and dispatches to the strategy streamer.
@@ -474,7 +474,7 @@ class _OutputStreamer:
         rng_key: Array | None,
         pbar: tqdm,
     ) -> None:
-        """Stream over data-parallel batches and write to ``req.output_dir``.
+        """Stream over data-parallel batches and write to ``req.artifact_path``.
 
         Shards the observation axis across devices and conditions every batch on the
         whole (replicated) ``samples``. For each batch it assembles a :class:`_Step`,
@@ -543,9 +543,9 @@ class _OutputStreamer:
             items=zip(dataloader, subkeys, strict=True),
             n_items=n_batches,
             return_sites=req.return_sites,
-            output_dir=req.output_dir,
+            artifact_path=req.artifact_path,
             strategy=_select_write_strategy(
-                open_group(req.output_dir, mode="w"),
+                open_group(req.artifact_path, mode="w"),
                 dataloader=dataloader,
             ),
             produce=produce,
@@ -561,7 +561,7 @@ class _OutputStreamer:
         rng_key: Array | None,
         pbar: tqdm,
     ) -> None:
-        """Stream over draw chunks and write to ``req.output_dir``.
+        """Stream over draw chunks and write to ``req.artifact_path``.
 
         Shards the draw axis across devices and holds the whole input resident:
         replicates the input/output/array-kwargs once, splits the per-draw keys once,
@@ -643,9 +643,9 @@ class _OutputStreamer:
             items=range(0, req.num_samples, batch_size),
             n_items=-(-req.num_samples // batch_size),
             return_sites=req.return_sites,
-            output_dir=req.output_dir,
+            artifact_path=req.artifact_path,
             strategy=_SliceWriteStrategy(
-                zarr_group=open_group(req.output_dir, mode="w"),
+                zarr_group=open_group(req.artifact_path, mode="w"),
                 total=req.num_samples,
                 batch_size=batch_size,
                 axis=0,

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -173,9 +173,9 @@ class ImpactModel(BaseModel):
             f"Output parameter: '{self.param_output}'",
             f"Fitted: {getattr(self, '_is_fitted', False)}",
         ]
-        outdir = getattr(self, "temp_dir", None)
-        if outdir:
-            out.append(f"Output directory: {outdir}")
+        temp_dir = getattr(self, "temp_dir", None)
+        if temp_dir:
+            out.append(f"Temporary directory: {temp_dir}")
 
         return "\n".join(out)
 
@@ -278,7 +278,7 @@ class ImpactModel(BaseModel):
 
     @property
     def temp_dir(self) -> str | None:
-        """Temporary directory path, or ``None`` if not set."""
+        """Path of the model's temporary directory, or ``None`` if none exists."""
         return self._temp_dir.name if self._temp_dir else None
 
     @property
@@ -423,20 +423,22 @@ class ImpactModel(BaseModel):
 
         return requested
 
-    def _create_output_subdir(
+    def _create_artifact_path(
         self,
         output_dir: str | Path | None,
-    ) -> tuple[Path, Path]:
-        """Create a subdirectory for storing output.
+    ) -> Path:
+        """Create the artifact path for one disk-backed call.
 
-        This function is called for its side effect: it creates a subdirectory within
-        the specified output directory with a timestamp.
+        This function is called for its side effect: it creates a timestamped
+        subdirectory within the specified output directory.
 
         Args:
             output_dir: Base directory where the output subdirectory will be created.
 
         Returns:
-            The paths to the output directory and the created subdirectory.
+            The created call-specific artifact path (``<UTC-timestamp>_<caller>``
+            under the resolved base directory); recorded on returned trees as the
+            ``artifact_path`` attribute.
         """
         if output_dir is None:
             if self._temp_dir is None:
@@ -457,10 +459,10 @@ class ImpactModel(BaseModel):
             if frame.frame.f_locals.get("self") is not self:
                 break
             caller = frame.function
-        output_subdir = output_dir / f"{timestamp}_{caller}"
-        output_subdir.mkdir(parents=False, exist_ok=False)
+        artifact_path = output_dir / f"{timestamp}_{caller}"
+        artifact_path.mkdir(parents=False, exist_ok=False)
 
-        return output_dir, output_subdir
+        return artifact_path
 
     def _requires_whole_input(
         self,
@@ -604,8 +606,10 @@ class ImpactModel(BaseModel):
             output_dir: The directory where the outputs will be saved. If the specified
                 directory does not exist, it will be created automatically. If ``None``,
                 a model-owned temporary directory is used. A subdirectory is generated
-                within this directory to store the outputs. The temporary directory is
-                removed by :meth:`~aimz.ImpactModel.cleanup`,
+                within this directory to store the outputs; its path is recorded in
+                the returned tree's ``artifact_path`` attribute (on the root and the
+                group node). The temporary directory is removed by
+                :meth:`~aimz.ImpactModel.cleanup`,
                 :meth:`~aimz.ImpactModel.cleanup_models`, or when the model is
                 garbage-collected. Pass an explicit ``output_dir`` to keep results
                 beyond the model's lifetime.
@@ -650,7 +654,7 @@ class ImpactModel(BaseModel):
         if rng_key is None:
             self._rng_key, rng_key = random.split(self._rng_key)
 
-        output_dir, output_subdir = self._create_output_subdir(output_dir)
+        artifact_path = self._create_artifact_path(output_dir)
 
         try:
             self._streamer.write_predictive(
@@ -660,7 +664,7 @@ class ImpactModel(BaseModel):
                     return_sites=return_sites,
                     num_samples=num_samples,
                     batch_size=batch_size,
-                    output_dir=output_subdir,
+                    artifact_path=artifact_path,
                     progress=progress,
                     loader_rng_key=self.rng_key,
                     kwargs=kwargs,
@@ -671,12 +675,11 @@ class ImpactModel(BaseModel):
                 posterior=self.posterior,
             )
         except BaseException:
-            rmtree(output_subdir, ignore_errors=True)
+            rmtree(artifact_path, ignore_errors=True)
             raise
 
         return _build_datatree(
-            output_dir,
-            output_subdir=output_subdir,
+            artifact_path,
             group="prior_predictive",
             posterior=self.posterior,
         )
@@ -846,8 +849,10 @@ class ImpactModel(BaseModel):
             output_dir: The directory where the outputs will be saved. If the specified
                 directory does not exist, it will be created automatically. If ``None``,
                 a model-owned temporary directory is used. A subdirectory is generated
-                within this directory to store the outputs. The temporary directory is
-                removed by :meth:`~aimz.ImpactModel.cleanup`,
+                within this directory to store the outputs; its path is recorded in
+                the returned tree's ``artifact_path`` attribute (on the root and the
+                group node). The temporary directory is removed by
+                :meth:`~aimz.ImpactModel.cleanup`,
                 :meth:`~aimz.ImpactModel.cleanup_models`, or when the model is
                 garbage-collected. Pass an explicit ``output_dir`` to keep results
                 beyond the model's lifetime.
@@ -1376,8 +1381,10 @@ class ImpactModel(BaseModel):
             output_dir: The directory where the outputs will be saved. If the specified
                 directory does not exist, it will be created automatically. If ``None``,
                 a model-owned temporary directory is used. A subdirectory is generated
-                within this directory to store the outputs. The temporary directory is
-                removed by :meth:`~aimz.ImpactModel.cleanup`,
+                within this directory to store the outputs; its path is recorded in
+                the returned tree's ``artifact_path`` attribute (on the root and the
+                group node). The temporary directory is removed
+                by :meth:`~aimz.ImpactModel.cleanup`,
                 :meth:`~aimz.ImpactModel.cleanup_models`, or when the model is
                 garbage-collected. Pass an explicit ``output_dir`` to keep results
                 beyond the model's lifetime.
@@ -1445,7 +1452,7 @@ class ImpactModel(BaseModel):
 
         group = "posterior_predictive" if in_sample else "predictions"
 
-        output_dir, output_subdir = self._create_output_subdir(output_dir)
+        artifact_path = self._create_artifact_path(output_dir)
 
         try:
             self._streamer.write_predictive(
@@ -1455,7 +1462,7 @@ class ImpactModel(BaseModel):
                     return_sites=return_sites,
                     num_samples=self._num_samples,
                     batch_size=batch_size,
-                    output_dir=output_subdir,
+                    artifact_path=artifact_path,
                     progress=progress,
                     loader_rng_key=self.rng_key,
                     kwargs=kwargs,
@@ -1466,12 +1473,11 @@ class ImpactModel(BaseModel):
                 posterior=self.posterior,
             )
         except BaseException:
-            rmtree(output_subdir, ignore_errors=True)
+            rmtree(artifact_path, ignore_errors=True)
             raise
 
         return _build_datatree(
-            output_dir,
-            output_subdir=output_subdir,
+            artifact_path,
             group=group,
             posterior=self.posterior,
         )
@@ -1511,7 +1517,10 @@ class ImpactModel(BaseModel):
 
         Returns:
             The estimated impact of an intervention. Posterior samples are included if
-            available.
+            available. When a scenario's output was streamed to disk, the effect tree
+            records that scenario's call-specific artifact path in an
+            ``artifact_path_baseline`` / ``artifact_path_intervention`` root attribute;
+            in-memory results set neither.
 
         Raises:
             ValueError: If neither ``output_baseline`` nor ``args_baseline`` is
@@ -1565,18 +1574,16 @@ class ImpactModel(BaseModel):
         out[group] = dt_intervention[group] - dt_baseline[group]
         if self.posterior:
             out["posterior"] = _dict_to_datatree(self.posterior)
-        # Propagate an output directory attribute to the effect result.
-        # Precedence:
-        #   1) intervention output_dir (if present)
-        #   2) baseline output_dir (if present)
-        #   3) model temporary directory (if it exists)
-        output_dir_attr = (
-            dt_intervention.attrs.get("output_dir")
-            or dt_baseline.attrs.get("output_dir")
-            or (self.temp_dir if self.temp_dir is not None else None)
-        )
-        if output_dir_attr is not None:
-            out.attrs["output_dir"] = output_dir_attr
+        # Record each scenario's artifact path when the scenario was computed by a
+        # disk-backed method. In-memory (on_batch / *_on_batch) results carry no
+        # artifact attrs.
+        for suffix, tree in (
+            ("baseline", dt_baseline),
+            ("intervention", dt_intervention),
+        ):
+            artifact_path = tree.attrs.get("artifact_path")
+            if artifact_path is not None:
+                out.attrs[f"artifact_path_{suffix}"] = artifact_path
 
         return out
 
@@ -1617,8 +1624,10 @@ class ImpactModel(BaseModel):
             output_dir: The directory where the outputs will be saved. If the specified
                 directory does not exist, it will be created automatically. If ``None``,
                 a model-owned temporary directory is used. A subdirectory is generated
-                within this directory to store the outputs. The temporary directory is
-                removed by :meth:`~aimz.ImpactModel.cleanup`,
+                within this directory to store the outputs; its path is recorded in
+                the returned tree's ``artifact_path`` attribute (on the root and the
+                group node). The temporary directory is removed
+                by :meth:`~aimz.ImpactModel.cleanup`,
                 :meth:`~aimz.ImpactModel.cleanup_models`, or when the model is
                 garbage-collected. Pass an explicit ``output_dir`` to keep results
                 beyond the model's lifetime.
@@ -1679,7 +1688,7 @@ class ImpactModel(BaseModel):
             self.kernel if self.posterior else seed(self.kernel, rng_seed=self.rng_key)
         )
 
-        output_dir, output_subdir = self._create_output_subdir(output_dir)
+        artifact_path = self._create_artifact_path(output_dir)
 
         try:
             self._streamer.write_log_likelihood(
@@ -1689,7 +1698,7 @@ class ImpactModel(BaseModel):
                     return_sites=(self.param_output,),
                     num_samples=self._num_samples,
                     batch_size=batch_size,
-                    output_dir=output_subdir,
+                    artifact_path=artifact_path,
                     progress=progress,
                     loader_rng_key=self.rng_key,
                     kwargs=kwargs,
@@ -1699,12 +1708,11 @@ class ImpactModel(BaseModel):
                 y=y,
             )
         except BaseException:
-            rmtree(output_subdir, ignore_errors=True)
+            rmtree(artifact_path, ignore_errors=True)
             raise
 
         return _build_datatree(
-            output_dir,
-            output_subdir=output_subdir,
+            artifact_path,
             group="log_likelihood",
             posterior=self.posterior,
         )
@@ -1723,9 +1731,10 @@ class ImpactModel(BaseModel):
             all tracked model instances.
         """
         if hasattr(self, "_temp_dir") and self._temp_dir is not None:
-            logger.info("Temporary directory cleaned up at: %s", self._temp_dir.name)
+            temp_dir = self._temp_dir.name
             self._temp_dir.cleanup()
             self._temp_dir = None
+            logger.info("Temporary directory cleaned up at: %s", temp_dir)
 
     @classmethod
     def cleanup_models(cls) -> None:

--- a/aimz/utils/_format.py
+++ b/aimz/utils/_format.py
@@ -39,17 +39,16 @@ def _make_attrs() -> dict[str, str]:
 
 
 def _build_datatree(
-    output_dir: Path,
-    output_subdir: Path,
+    artifact_path: Path,
     group: str,
     posterior: Mapping[str, Array | npt.NDArray] | None = None,
 ) -> xr.DataTree:
     """Build the aimz output DataTree from a Zarr group.
 
     Args:
-        output_dir: Top-level output directory; stored on the root tree's attrs.
-        output_subdir: Subdirectory holding the Zarr group; read with
-            :external:func:`~xarray.open_zarr` and stored on the group's attrs.
+        artifact_path: Call-specific path holding the Zarr group; read with
+            :external:func:`~xarray.open_zarr` and recorded (as ``str``) in the
+            ``artifact_path`` attribute on both the root tree and the ``group`` node.
         group: Group name to attach the loaded dataset under (e.g.
             ``"log_likelihood"``, ``"prior_predictive"``).
         posterior: Optional posterior samples; when provided, added as a ``"posterior"``
@@ -59,7 +58,7 @@ def _build_datatree(
         A DataTree rooted at ``"root"`` with the loaded dataset attached under ``group``
         and, optionally, a ``"posterior"`` subtree.
     """
-    ds = open_zarr(output_subdir, consolidated=False).expand_dims(dim="chain", axis=0)
+    ds = open_zarr(artifact_path, consolidated=False).expand_dims(dim="chain", axis=0)
     ds = ds.assign_coords(
         {k: np.arange(ds.sizes[k]) for k in ds.sizes},
     ).assign_attrs(_make_attrs())
@@ -68,8 +67,8 @@ def _build_datatree(
     if posterior:
         out["posterior"] = _dict_to_datatree(posterior)
     out[group] = xr.DataTree(ds)
-    out[group].attrs["output_dir"] = str(output_subdir)
-    out.attrs["output_dir"] = str(output_dir)
+    out[group].attrs["artifact_path"] = str(artifact_path)
+    out.attrs["artifact_path"] = str(artifact_path)
 
     return out
 

--- a/aimz/utils/_output.py
+++ b/aimz/utils/_output.py
@@ -465,7 +465,7 @@ def _write_loop(
     items: Iterable,
     n_items: int,
     return_sites: tuple[str, ...],
-    output_dir: Path,
+    artifact_path: Path,
     strategy: _WriteStrategy,
     produce: Callable[[object], dict[str, np.ndarray]],
     pbar: tqdm,
@@ -480,14 +480,14 @@ def _write_loop(
         items: Items to iterate (batches paired with keys, or draw-chunk starts).
         n_items: Number of items (used to size the writer queues).
         return_sites: Names of variables (sites) to write.
-        output_dir: Directory where outputs will be saved.
+        artifact_path: Call-specific path where the Zarr group is written.
         strategy: Write strategy that creates and enqueues each item's site arrays.
         produce: Maps one item to its mapping of site name to array.
         pbar: Progress bar instance to display progress.
 
     Raises:
         Exception: Any exception raised during production or writing is logged, the
-            output directory is cleaned up, and the exception is re-raised.
+            artifacts at ``artifact_path`` are removed, and the exception is re-raised.
     """
     threads = []
     queues = {}
@@ -501,7 +501,7 @@ def _write_loop(
             if error_queue is None:
                 threads, queues, error_queue = _start_writer_threads(
                     return_sites,
-                    group_path=output_dir,
+                    group_path=artifact_path,
                     apply=strategy.apply,
                     queue_size=_determine_writer_queue_size(
                         n_items,
@@ -525,8 +525,8 @@ def _write_loop(
             worker_err = error_queue.get()
             success = False
         if not success:
-            logger.warning("Cleaning up output directory: %s", output_dir)
-            rmtree(output_dir, ignore_errors=True)
+            rmtree(artifact_path, ignore_errors=True)
+            logger.warning("Cleaned up artifact path: %s", artifact_path)
         pbar.close()
     if worker_err is not None:
         _, exc, tb = worker_err

--- a/aimz/utils/_validation.py
+++ b/aimz/utils/_validation.py
@@ -177,7 +177,7 @@ def _validate_aligned_inputs(
 ) -> None:
     """Validate array inputs share one leading-axis size, for either parallel path.
 
-    Called from the streaming entry points before any output directory is created. A
+    Called from the streaming entry points before any artifact path is created. A
     data loader is skipped. For an array ``X``, then ``X``, ``y`` (if given), and every
     array-like kwarg must be at least 1-D and share ``X``'s leading-axis size.
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -142,12 +142,8 @@ It appears in the returned :class:`~xarray.DataTree` only if posterior samples a
 Where is the on-disk output written?
 ------------------------------------
 All outputs are written under the directory passed via ``output_dir``.
-If ``output_dir=None``, a temporary directory is created (accessible via
-:attr:`~aimz.ImpactModel.temp_dir`) and removed when the model is cleaned up
-(either explicitly with :meth:`~aimz.ImpactModel.cleanup` or when the instance is
-garbage collected).
-Each group in the returned :class:`~xarray.DataTree` stores its own artifact path
-in an ``output_dir`` attribute, and the root tree includes the top-level path.
+If ``output_dir=None``, a temporary directory is created (accessible via :attr:`~aimz.ImpactModel.temp_dir`) and removed when the model is cleaned up (either explicitly with :meth:`~aimz.ImpactModel.cleanup` or when the instance is garbage collected).
+The returned :class:`~xarray.DataTree` records the call's artifact path in an ``artifact_path`` attribute on both the root tree and the group node; its parent is the ``output_dir`` (or temporary root) it was written under.
 
 
 Does serialization persist the posterior samples?

--- a/docs/source/user_guide/cleanup.rst
+++ b/docs/source/user_guide/cleanup.rst
@@ -10,18 +10,18 @@ Creation Logic
 --------------
 When a disk‑writing method is called with ``output_dir=None`` (the default), the model creates a process‑scoped temporary root directory (via :class:`tempfile.TemporaryDirectory`) the first time such a call occurs.
 Each invocation then writes to a timestamped subdirectory under that root, ensuring that earlier results are never overwritten.
-Subdirectories follow the pattern ``<caller_name>_<UTC-timestamp>/``, where ``<caller_name>`` is the name of the method that triggered the write operation.
-This root directory is stored in the :attr:`~aimz.ImpactModel.temp_dir` attribute and reused for subsequent calls until the user invoke :meth:`~aimz.ImpactModel.cleanup`.
+Subdirectories follow the pattern ``<UTC-timestamp>_<caller_name>/``, where ``<caller_name>`` is the name of the method that triggered the write operation.
+This root directory is stored in the :attr:`~aimz.ImpactModel.temp_dir` attribute and reused for subsequent calls until the user invokes :meth:`~aimz.ImpactModel.cleanup`.
 
 Example Layout (implicit temp root)::
 
     /tmp/tmpz00u5kxk/       # model.temp_dir (root, reused until cleanup)
-        sample_prior_predictive_20250926T185250223698Z/
-        log_likelihood_20250926T185359570134Z/
-        predict_20250926T185419208087Z/
+        20250926T185250223698Z_sample_prior_predictive/
+        20250926T185359570134Z_log_likelihood/
+        20250926T185419208087Z_predict/
 
 If the user provides ``output_dir``, that directory becomes the root, and it will be created if it does not already exist.
-The same timestamped subdirectory pattern is used there (e.g., ``my_runs/20250917T013040Z``).
+The same timestamped subdirectory pattern is used there (e.g., ``my_runs/20250917T013040123456Z_predict``).
 An explicit ``output_dir`` is **not** deleted by :meth:`~aimz.ImpactModel.cleanup`, since it is assumed that the user intends to manage its lifecycle manually.
 
 
@@ -44,14 +44,12 @@ Although :class:`tempfile.TemporaryDirectory` *attempts* automatic removal upon 
 Large artifacts can accumulate quickly; calling :meth:`~aimz.ImpactModel.cleanup` ensures prompt reclamation of disk space.
 
 
-Accessing Output Directories
-----------------------------
-Every disk-writing method returns an :external:class:`xarray.DataTree` containing the paths where results are stored as attributes:
-
-* ``tree.attrs["output_dir"]`` – the root directory (either the temporary root or the user-provided directory).
-* ``tree[<group>].attrs["output_dir"]`` – the timestamped subdirectory containing the Zarr_ data for that group.
-
-The output below shows an example :external:class:`xarray.DataTree` illustrating the output directory paths.
+Accessing Artifact Paths
+------------------------
+Every disk-writing method records the call's artifact path — the timestamped subdirectory holding the Zarr_ store with the results — in the ``artifact_path`` attribute, set on both the root tree and the group node (``tree.attrs["artifact_path"]`` and ``tree[<group>].attrs["artifact_path"]``).
+The enclosing base directory is simply ``Path(artifact_path).parent``, and the temporary root (when no ``output_dir`` was given) is also available via :attr:`~aimz.ImpactModel.temp_dir`.
+:meth:`~aimz.ImpactModel.estimate_effect` records the artifact paths of its two scenarios under ``artifact_path_baseline`` and ``artifact_path_intervention`` when the corresponding outputs were streamed to disk.
+The output below shows an example :external:class:`xarray.DataTree` illustrating the artifact paths.
 
 .. jupyter-execute::
     :hide-code:

--- a/docs/source/user_guide/disk_and_on_batch.rst
+++ b/docs/source/user_guide/disk_and_on_batch.rst
@@ -146,7 +146,7 @@ The example below illustrates this case.
 
 Reopening Persisted Outputs
 ---------------------------
-When you pass an explicit ``output_dir``, each call writes one subdirectory containing a Zarr_ group with one array per return site.
+When you pass an explicit ``output_dir``, each call writes one subdirectory containing a Zarr_ group with one array per return site; its path is recorded in the returned tree's ``artifact_path`` attribute (the attribute is recorded for temporary-root outputs as well).
 Only the sampled arrays and their dimension names are persisted; coordinates and attributes are not stored on disk.
 
 To reconstruct the same :external:class:`xarray.DataTree` from the files alone, mirror that read-time step:
@@ -156,7 +156,7 @@ To reconstruct the same :external:class:`xarray.DataTree` from the files alone, 
     import numpy as np
     import xarray as xr
 
-    # The per-call directory written under `output_dir`
+    # The per-call directory written under `output_dir` (the tree's `artifact_path`)
     store = ...
 
     # If relevant, add the leading `chain` axis and coordinates as aimz does on read

--- a/docs/source/user_guide/intervention.rst
+++ b/docs/source/user_guide/intervention.rst
@@ -94,6 +94,12 @@ Mixed (precomputed baseline, lazy intervention)::
         },
     )
 
+.. note::
+
+   A lazily generated scenario (``args_baseline`` / ``args_intervention``) runs the disk-backed :meth:`~aimz.ImpactModel.predict` internally, writing its artifacts to disk (under the model's temporary directory unless an ``output_dir`` entry is included in the argument dictionary).
+   Because the intermediate trees are not returned, the effect tree's ``artifact_path_baseline`` / ``artifact_path_intervention`` attributes are the only handle to those artifacts; see :doc:`cleanup` for managing them.
+   Pass ``on_batch=True`` to compute both scenarios in memory without writing to disk.
+
 The returned :class:`~xarray.DataTree` captures the elementwise difference for every variable present in the predictive group.
 Any subsequent summary (e.g. mean, intervals) can be computed using Xarray, ArviZ, or standard NumPy / JAX utilities.
 

--- a/tests/test_estimate_effect.py
+++ b/tests/test_estimate_effect.py
@@ -79,11 +79,11 @@ def test_estimate_effect_argument_validation(
 
 
 @pytest.mark.parametrize("vi", [lm], indirect=True)
-def test_estimate_effect_output_dir_lazy_args(
+def test_estimate_effect_artifact_paths_lazy_args(
     synthetic_data: tuple[Array, Array],
     vi: SVI,
 ) -> None:
-    """Ensure lazy (args_*) inputs work and baseline `output_dir` is propagated."""
+    """Ensure lazy (args_*) inputs work and both scenarios' artifact paths recorded."""
     X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
     im.fit(X=X, y=y, batch_size=len(X))
@@ -105,8 +105,15 @@ def test_estimate_effect_output_dir_lazy_args(
             },
         )
 
-    # Confirm the temporary output directory propagated to effect result
-    assert effect.attrs.get("output_dir") == str(Path(im.temp_dir).resolve())
+    # Each internally computed scenario records its own call-specific subdirectory.
+    # The subdir suffix is the outermost user-called method: `estimate_effect`.
+    path_baseline = Path(effect.attrs["artifact_path_baseline"])
+    path_intervention = Path(effect.attrs["artifact_path_intervention"])
+    assert path_baseline != path_intervention
+    for path in (path_baseline, path_intervention):
+        assert path.is_dir()
+        assert path.parent == Path(im.temp_dir).resolve()
+        assert path.name.endswith("_estimate_effect")
     im.cleanup()
 
 


### PR DESCRIPTION
Refactor output handling to utilize artifact paths instead of output directories across multiple components. This change addresses the issue of call-specific paths and improves clarity by replacing the overloaded `output_dir` attribute with a more appropriate `artifact_path`. The updates ensure that each scenario's artifact path is recorded correctly, enhancing the functionality of the `estimate_effect()` method.

Fixes #277