### PR TITLE
Add subsampling support in log likelihood evaluation

### DIFF
--- a/aimz/utils/_log_likelihood.py
+++ b/aimz/utils/_log_likelihood.py
@@ -18,11 +18,56 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import jax.numpy as jnp
 from jax import Array, lax
 from numpyro.handlers import substitute, trace
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
+
+    from numpyro._typing import Message
+
+
+def _pin_subsample_indices(msg: Message) -> Array | None:
+    """Provide deterministic indices for subsample plate sites.
+
+    Log-likelihood evaluation passes each data batch to the model explicitly. For
+    kernels that consume the batch through the model's arguments, the indices of a
+    ``numpyro.plate`` site with ``subsample_size`` set smaller than ``size`` only
+    determine broadcasting shapes. Drawing them randomly would require an rng key that a
+    bare (unseeded) kernel does not have; pinning them to ``arange`` keeps tracing
+    seed-free.
+
+    Kernels that instead gather rows from a closed-over full-size array via the
+    plate's indices (``with plate(...) as idx``, or ``numpyro.subsample``) are not
+    supported by batched evaluation: the pinned indices always select the leading
+    rows.
+
+    Args:
+        msg: A NumPyro effect-handler site message.
+
+    Returns:
+        Deterministic indices for a subsample plate site, or ``None`` to leave the site
+        unchanged.
+
+    Raises:
+        ValueError: If the batch is larger than the plate size, which would require
+            out-of-range indices.
+    """
+    if msg["type"] != "plate":
+        return None
+    size, subsample_size = msg["args"]
+    if subsample_size is None or subsample_size == size:
+        return None
+    if subsample_size > size:
+        err_msg = (
+            f"Plate site {msg['name']!r} declares size={size}, but the evaluated "
+            f"batch has {subsample_size} observations. Evaluate at most `size` "
+            "observations per batch, or declare a plate size covering the data."
+        )
+        raise ValueError(err_msg)
+
+    return jnp.arange(subsample_size)
 
 
 def _log_likelihood(
@@ -31,6 +76,11 @@ def _log_likelihood(
     model_kwargs: Mapping[str, object] | None,
 ) -> dict[str, Array]:
     """Compute per-site log-likelihood at observed sites for each posterior draw.
+
+    Kernels that subsample inside a ``numpyro.plate`` (``subsample_size``) get
+    deterministic plate indices (see :func:`_pin_subsample_indices`): the batch passed
+    through the model's arguments is scored as-is, and the trace stays free of
+    subsampling randomness.
 
     Args:
         model: A probabilistic model with NumPyro primitives.
@@ -47,7 +97,8 @@ def _log_likelihood(
     """
 
     def _loglik_one_sample(sample: dict[str, Array]) -> dict[str, Array]:
-        substituted_model = substitute(model, sample) if sample else model
+        pinned_model = substitute(model, substitute_fn=_pin_subsample_indices)
+        substituted_model = substitute(pinned_model, sample) if sample else pinned_model
         model_trace = trace(substituted_model).get_trace(**(model_kwargs or {}))
 
         return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,21 @@ def mlm(X: Array, y: Array | None = None) -> None:
         sample("y", dist.Normal(X @ w, sigma).to_event(1), obs=y)
 
 
+def lm_subsample(X: Array, y: Array | None = None) -> None:
+    """Linear regression consuming subsampled batches through its arguments.
+
+    The plate declares the full data size of the ``synthetic_data`` fixture, with
+    ``subsample_size`` tracking the batch passed in.
+    """
+    n_features = X.shape[1]
+    w = sample("w", dist.Normal(jnp.zeros(n_features), jnp.ones(n_features)))
+    b = sample("b", dist.Normal(0, 1))
+    sigma = sample("sigma", dist.Exponential(1.0))
+    with numpyro.plate("data", size=100, subsample_size=X.shape[0]):
+        mu = jnp.dot(X, w) + b
+        sample("y", dist.Normal(mu, sigma), obs=y)
+
+
 def latent_variable_model(X: Array, y: Array | None = None) -> None:
     """Latent variable model."""
     z = numpyro.sample(
@@ -165,6 +180,22 @@ def im_lm_svi_fitted(synthetic_data: tuple[Array, Array]) -> Iterator[ImpactMode
     X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), inference=_make_svi(lm))
     im.fit(X=X, y=y, batch_size=len(X), progress=False)
+    yield im
+    im.cleanup()
+
+
+@pytest.fixture(scope="module")
+def im_lm_subsample_svi_fitted(
+    synthetic_data: tuple[Array, Array],
+) -> Iterator[ImpactModel]:
+    """`lm_subsample` fitted with SVI on subsampled batches. For read-only tests."""
+    X, y = synthetic_data
+    im = ImpactModel(
+        lm_subsample,
+        rng_key=random.key(42),
+        inference=_make_svi(lm_subsample),
+    )
+    im.fit(X=X, y=y, batch_size=20, progress=False)
     yield im
     im.cleanup()
 

--- a/tests/test_log_likelihood.py
+++ b/tests/test_log_likelihood.py
@@ -17,6 +17,8 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import jax.numpy as jnp
+import numpy as np
 import pytest
 from jax import Array, random
 from numpyro.infer import SVI, Trace_ELBO
@@ -60,6 +62,55 @@ def test_empty_posterior(
     out = im_lm_svi_fitted.log_likelihood(X=X, y=y, progress=False)
 
     assert out.log_likelihood["y"].sizes["draw"] == 1
+
+
+def test_subsampled_kernel(
+    synthetic_data: tuple[Array, Array],
+    im_lm_subsample_svi_fitted: ImpactModel,
+) -> None:
+    """A kernel subsampling inside a plate is evaluated without an rng key.
+
+    Subsample indices are pinned deterministically rather than drawn at random, so
+    the bare (unseeded) kernel traces cleanly and every passed observation is scored
+    on both sharding paths.
+    """
+    X, y = synthetic_data
+    im = im_lm_subsample_svi_fitted
+
+    out = im.log_likelihood(X=X, y=y, batch_size=30, progress=False)
+    out_draw = im.log_likelihood(
+        X=X,
+        y=y,
+        shard_axis="draw",
+        batch_size=250,
+        progress=False,
+    )
+
+    assert out.log_likelihood["y"].shape == (1, 1000, len(X))
+    assert np.isfinite(out.log_likelihood["y"].values).all()
+    # Plate indices never gather here, so the sharding paths agree.
+    assert np.allclose(
+        out.log_likelihood["y"].values,
+        out_draw.log_likelihood["y"].values,
+        atol=1e-6,
+    )
+
+
+def test_subsampled_kernel_batch_exceeds_plate(
+    synthetic_data: tuple[Array, Array],
+    im_lm_subsample_svi_fitted: ImpactModel,
+) -> None:
+    """A batch larger than the declared plate size is rejected loudly."""
+    X, y = synthetic_data
+    X_big, y_big = jnp.tile(X, (6, 1)), jnp.tile(y, 6)
+
+    with pytest.raises(ValueError, match="declares size=100"):
+        im_lm_subsample_svi_fitted.log_likelihood(
+            X=X_big,
+            y=y_big,
+            batch_size=600,
+            progress=False,
+        )
 
 
 def test_log_likelihood_requires_y(


### PR DESCRIPTION
Reintroduce subsampling support for log likelihood evaluation and tests. Ensure deterministic indices for subsampled plate sites, allowing for clean tracing without random number generation. Include tests to validate behavior when batch sizes exceed plate sizes.