### PR TITLE
Enhance streaming performance and restore subsampling support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - {func}`~aimz.mlflow.save_model` and {func}`~aimz.mlflow.log_model` now infer the model signature by running the model on the input example, validating the example and recording an output schema. Previously the signature was inferred from the input example alone, without input validation or an output schema, and with a `progress` parameter always injected ([#281](https://github.com/markean/aimz/issues/281)).
 - {func}`~aimz.mlflow.autolog` now logs the full ELBO loss steps, the training dataset, and the training parameters, all linked to the logged model ([#281](https://github.com/markean/aimz/issues/281)).
 - {func}`~aimz.mlflow.save_model` now pickles with `pickle.DEFAULT_PROTOCOL`, and {func}`~aimz.mlflow.load_model` honors MLflow's `MLFLOW_ALLOW_PICKLE_DESERIALIZATION` environment variable ([#281](https://github.com/markean/aimz/issues/281)).
+- The disk-backed methods now pipeline the streaming loop: the next batch's (or draw chunk's) computation is dispatched before the previous result is collected, overlapping device compute with result transfer and disk writes. Results are unchanged; the benefit is on accelerator backends, and peak device memory for streamed outputs roughly doubles (at most two in-flight chunks) ([#284](https://github.com/markean/aimz/issues/284)).
 
 ### Removed
 

--- a/aimz/model/_streaming.py
+++ b/aimz/model/_streaming.py
@@ -27,7 +27,7 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, NamedTuple, cast
 
-from jax import Array, device_get, device_put, random
+from jax import Array, device_get, device_put, random, tree
 from tqdm.auto import tqdm
 from zarr import open_group
 
@@ -178,7 +178,7 @@ class _OutputStreamer:
         """Resolve the ordered kwarg names, array count, and extras for a stream.
 
         The names drive both the ``shard_map`` in-spec arity and the by-name binding
-        in ``produce``, so they come from a single source and cannot drift. Array
+        in ``dispatch``, so they come from a single source and cannot drift. Array
         arguments come from the data loader's dataset fields when ``req.X`` is an
         :class:`~aimz.utils.data.ArrayLoader`; otherwise from the call kwargs. Non-array
         extras always come from the call kwargs.
@@ -477,10 +477,11 @@ class _OutputStreamer:
         """Stream over data-parallel batches and write to ``req.artifact_path``.
 
         Shards the observation axis across devices and conditions every batch on the
-        whole (replicated) ``samples``. For each batch it assembles a :class:`_Step`,
-        runs ``compute``, trims the observation padding (axis 1), and drives
-        ``_write_loop``. Kind-agnostic: ``compute`` carries the sampler / log-likelihood
-        call. ``rng_key`` is ``None`` for log-likelihood (no per-draw keys).
+        whole (replicated) ``samples``. For each batch it assembles a :class:`_Step`
+        and dispatches ``compute`` (asynchronous); collection blocks on the result and
+        trims the observation padding (axis 1). ``_write_loop`` keeps consecutive
+        batches in flight, so the next batch computes while the previous one is pulled
+        to host and written.
 
         Args:
             req: The streamed write job.
@@ -516,7 +517,7 @@ class _OutputStreamer:
             if self._ctx.replicated_sharding is not None:
                 subkeys = device_put(subkeys, device=self._ctx.replicated_sharding)
 
-        def produce(item: object) -> dict[str, np.ndarray]:
+        def dispatch(item: object) -> tuple[dict[str, Array], int]:
             (batch, n_pad), subkey = cast("tuple", item)
             # Bind by name (array kwargs from the batch, extras from the call) in
             # `kwargs_key` order, so positions match the sharded callable's in-specs.
@@ -532,11 +533,17 @@ class _OutputStreamer:
                 y=batch.get(self._ctx.param_output),
                 tail=tail,
             )
-            dict_arr = device_get(compute(step))
+            out = compute(step)
+            tree.map(lambda arr: arr.copy_to_host_async(), out)
+
+            return out, n_pad
+
+        def finalize(pending: object) -> dict[str, np.ndarray]:
+            out, n_pad = cast("tuple[dict[str, Array], int]", pending)
 
             return {
                 site: arr[:, None] if arr.ndim == 1 else arr[:, : -n_pad or None]
-                for site, arr in dict_arr.items()
+                for site, arr in device_get(out).items()
             }
 
         _write_loop(
@@ -548,7 +555,8 @@ class _OutputStreamer:
                 open_group(req.artifact_path, mode="w"),
                 dataloader=dataloader,
             ),
-            produce=produce,
+            dispatch=dispatch,
+            finalize=finalize,
             pbar=pbar,
         )
 
@@ -566,10 +574,10 @@ class _OutputStreamer:
         Shards the draw axis across devices and holds the whole input resident:
         replicates the input/output/array-kwargs once, splits the per-draw keys once,
         and for each chunk slices a posterior chunk (``_prepare_draw_chunk``), assembles
-        a :class:`_Step`, runs ``compute``, trims to the chunk's true draw count
-        (axis 0), and drives ``_write_loop``. Kind-agnostic: ``compute`` carries the
-        sampler / log-likelihood call. ``rng_key`` is ``None`` for log-likelihood;
-        ``posterior`` is empty for prior predictive (each chunk draws fresh).
+        a :class:`_Step`, and dispatches ``compute`` (asynchronous); collection blocks
+        on the result and trims to the chunk's true draw count (axis 0).
+        ``_write_loop`` keeps consecutive chunks in flight, so the next chunk computes
+        while the previous one is pulled to host and written.
 
         Args:
             req: The streamed write job.
@@ -617,7 +625,7 @@ class _OutputStreamer:
             random.split(rng_key, num=req.num_samples) if rng_key is not None else None
         )
 
-        def produce(item: object) -> dict[str, np.ndarray]:
+        def dispatch(item: object) -> tuple[dict[str, Array], int]:
             start = cast("int", item)
             stop = min(start + batch_size, req.num_samples)
             chunk_samples, chunk_keys, per_device = _prepare_draw_chunk(
@@ -636,8 +644,17 @@ class _OutputStreamer:
                 y=y_dev,
                 tail=tail,
             )
+            out = compute(step)
+            # Start the device-to-host copy as soon as each result is ready, so
+            # `finalize` only waits on it instead of initiating it.
+            tree.map(lambda arr: arr.copy_to_host_async(), out)
 
-            return {s: a[: stop - start] for s, a in device_get(compute(step)).items()}
+            return out, stop - start
+
+        def finalize(pending: object) -> dict[str, np.ndarray]:
+            out, n_draws = cast("tuple[dict[str, Array], int]", pending)
+
+            return {s: a[:n_draws] for s, a in device_get(out).items()}
 
         _write_loop(
             items=range(0, req.num_samples, batch_size),
@@ -650,6 +667,7 @@ class _OutputStreamer:
                 batch_size=batch_size,
                 axis=0,
             ),
-            produce=produce,
+            dispatch=dispatch,
+            finalize=finalize,
             pbar=pbar,
         )

--- a/aimz/utils/_log_likelihood.py
+++ b/aimz/utils/_log_likelihood.py
@@ -18,11 +18,56 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import jax.numpy as jnp
 from jax import Array, lax
 from numpyro.handlers import substitute, trace
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
+
+    from numpyro._typing import Message
+
+
+def _pin_subsample_indices(msg: Message) -> Array | None:
+    """Provide deterministic indices for subsample plate sites.
+
+    Log-likelihood evaluation passes each data batch to the model explicitly. For
+    kernels that consume the batch through the model's arguments, the indices of a
+    ``numpyro.plate`` site with ``subsample_size`` set smaller than ``size`` only
+    determine broadcasting shapes. Drawing them randomly would require an rng key that a
+    bare (unseeded) kernel does not have; pinning them to ``arange`` keeps tracing
+    seed-free.
+
+    Kernels that instead gather rows from a closed-over full-size array via the
+    plate's indices (``with plate(...) as idx``, or ``numpyro.subsample``) are not
+    supported by batched evaluation: the pinned indices always select the leading
+    rows.
+
+    Args:
+        msg: A NumPyro effect-handler site message.
+
+    Returns:
+        Deterministic indices for a subsample plate site, or ``None`` to leave the site
+        unchanged.
+
+    Raises:
+        ValueError: If the batch is larger than the plate size, which would require
+            out-of-range indices.
+    """
+    if msg["type"] != "plate":
+        return None
+    size, subsample_size = msg["args"]
+    if subsample_size is None or subsample_size == size:
+        return None
+    if subsample_size > size:
+        err_msg = (
+            f"Plate site {msg['name']!r} declares size={size}, but the evaluated "
+            f"batch has {subsample_size} observations. Evaluate at most `size` "
+            "observations per batch, or declare a plate size covering the data."
+        )
+        raise ValueError(err_msg)
+
+    return jnp.arange(subsample_size)
 
 
 def _log_likelihood(
@@ -31,6 +76,11 @@ def _log_likelihood(
     model_kwargs: Mapping[str, object] | None,
 ) -> dict[str, Array]:
     """Compute per-site log-likelihood at observed sites for each posterior draw.
+
+    Kernels that subsample inside a ``numpyro.plate`` (``subsample_size``) get
+    deterministic plate indices (see :func:`_pin_subsample_indices`): the batch passed
+    through the model's arguments is scored as-is, and the trace stays free of
+    subsampling randomness.
 
     Args:
         model: A probabilistic model with NumPyro primitives.
@@ -47,7 +97,8 @@ def _log_likelihood(
     """
 
     def _loglik_one_sample(sample: dict[str, Array]) -> dict[str, Array]:
-        substituted_model = substitute(model, sample) if sample else model
+        pinned_model = substitute(model, substitute_fn=_pin_subsample_indices)
+        substituted_model = substitute(pinned_model, sample) if sample else pinned_model
         model_trace = trace(substituted_model).get_trace(**(model_kwargs or {}))
 
         return {

--- a/aimz/utils/_output.py
+++ b/aimz/utils/_output.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import logging
+from collections import deque
 from os import cpu_count
 from queue import Queue
 from shutil import rmtree
@@ -33,7 +34,7 @@ from zarr import open_group
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Mapping
+    from collections.abc import Callable, Iterable, Iterator, Mapping
     from pathlib import Path
     from types import ModuleType
 
@@ -44,8 +45,44 @@ if TYPE_CHECKING:
     from aimz.utils.data import ArrayLoader
 
 
+# Maximum in-flight compute steps in `_write_loop`. Depth 2 dispatches the next step
+# before collecting the previous one, overlapping device compute with device-to-host
+# transfer and the host-side write work; each in-flight step holds one output chunk on
+# device, so raising this raises peak device memory proportionally.
+_PIPELINE_DEPTH = 2
 _QUEUE_SIZE_MAX = 128
 _QUEUE_SIZE_FALLBACK_CAP = 4
+
+
+def _iter_pipelined(
+    items: Iterable,
+    dispatch: Callable[[object], object],
+    finalize: Callable[[object], dict[str, np.ndarray]],
+) -> Iterator[dict[str, np.ndarray]]:
+    """Dispatch up to :data:`_PIPELINE_DEPTH` items ahead and finalize them in order.
+
+    ``dispatch`` launches an item's computation (JAX dispatch is asynchronous, so it
+    returns without waiting) and ``finalize`` blocks on the result, so keeping a
+    bounded queue of in-flight steps lets the device compute item N+1 while the
+    consumer collects and writes item N. Items are finalized in dispatch (FIFO)
+    order.
+
+    Args:
+        items: Items to iterate (batches paired with keys, or draw-chunk starts).
+        dispatch: Launches one item's computation and returns its in-flight handle.
+        finalize: Blocks on an in-flight handle and returns its mapping of site name
+            to array.
+
+    Yields:
+        Each item's mapping of site name to (post-slice) array, in item order.
+    """
+    pending: deque = deque()
+    for item in items:
+        pending.append(dispatch(item))
+        if len(pending) >= _PIPELINE_DEPTH:
+            yield finalize(pending.popleft())
+    while pending:
+        yield finalize(pending.popleft())
 
 
 def _determine_writer_queue_size(num_items: int, item_nbytes: int) -> int:
@@ -467,14 +504,17 @@ def _write_loop(
     return_sites: tuple[str, ...],
     artifact_path: Path,
     strategy: _WriteStrategy,
-    produce: Callable[[object], dict[str, np.ndarray]],
+    dispatch: Callable[[object], object],
+    finalize: Callable[[object], dict[str, np.ndarray]],
     pbar: tqdm,
 ) -> None:
     """Produce per-item site arrays and write them concurrently to disk.
 
-    Shared by the data- and draw-parallel write paths. For each item from ``items``,
-    ``produce`` returns the (post-slice) per-site arrays; array creation/enqueuing is
-    delegated to ``strategy`` and writing to background threads.
+    Shared by the data- and draw-parallel write paths. Items are produced through
+    :func:`_iter_pipelined`, which keeps consecutive items' computations in flight on
+    the device and finalizes them in item order — preserving the write order the
+    strategies rely on. Array creation/enqueuing is delegated to ``strategy`` and
+    writing to background threads.
 
     Args:
         items: Items to iterate (batches paired with keys, or draw-chunk starts).
@@ -482,7 +522,9 @@ def _write_loop(
         return_sites: Names of variables (sites) to write.
         artifact_path: Call-specific path where the Zarr group is written.
         strategy: Write strategy that creates and enqueues each item's site arrays.
-        produce: Maps one item to its mapping of site name to array.
+        dispatch: Launches one item's computation and returns its in-flight handle.
+        finalize: Blocks on an in-flight handle and returns its mapping of site name
+            to array.
         pbar: Progress bar instance to display progress.
 
     Raises:
@@ -495,8 +537,7 @@ def _write_loop(
     worker_err: tuple | None = None
     success = False
     try:
-        for item in items:
-            sliced = produce(item)
+        for sliced in _iter_pipelined(items, dispatch=dispatch, finalize=finalize):
             strategy.create_arrays(sliced)
             if error_queue is None:
                 threads, queues, error_queue = _start_writer_threads(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,21 @@ def mlm(X: Array, y: Array | None = None) -> None:
         sample("y", dist.Normal(X @ w, sigma).to_event(1), obs=y)
 
 
+def lm_subsample(X: Array, y: Array | None = None) -> None:
+    """Linear regression consuming subsampled batches through its arguments.
+
+    The plate declares the full data size of the ``synthetic_data`` fixture, with
+    ``subsample_size`` tracking the batch passed in.
+    """
+    n_features = X.shape[1]
+    w = sample("w", dist.Normal(jnp.zeros(n_features), jnp.ones(n_features)))
+    b = sample("b", dist.Normal(0, 1))
+    sigma = sample("sigma", dist.Exponential(1.0))
+    with numpyro.plate("data", size=100, subsample_size=X.shape[0]):
+        mu = jnp.dot(X, w) + b
+        sample("y", dist.Normal(mu, sigma), obs=y)
+
+
 def latent_variable_model(X: Array, y: Array | None = None) -> None:
     """Latent variable model."""
     z = numpyro.sample(
@@ -165,6 +180,22 @@ def im_lm_svi_fitted(synthetic_data: tuple[Array, Array]) -> Iterator[ImpactMode
     X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), inference=_make_svi(lm))
     im.fit(X=X, y=y, batch_size=len(X), progress=False)
+    yield im
+    im.cleanup()
+
+
+@pytest.fixture(scope="module")
+def im_lm_subsample_svi_fitted(
+    synthetic_data: tuple[Array, Array],
+) -> Iterator[ImpactModel]:
+    """`lm_subsample` fitted with SVI on subsampled batches. For read-only tests."""
+    X, y = synthetic_data
+    im = ImpactModel(
+        lm_subsample,
+        rng_key=random.key(42),
+        inference=_make_svi(lm_subsample),
+    )
+    im.fit(X=X, y=y, batch_size=20, progress=False)
     yield im
     im.cleanup()
 

--- a/tests/test_array_loader.py
+++ b/tests/test_array_loader.py
@@ -70,6 +70,11 @@ class TestArrayDataset:
 class TestArrayLoader:
     """Tests class to ensure compatibility and correct handling."""
 
+    @staticmethod
+    def _shuffled_batches(loader: ArrayLoader) -> np.ndarray:
+        """Concatenate one epoch's batches of `y` into a single array."""
+        return np.concatenate([batch["y"] for batch, _ in loader])
+
     def test_legacy_prng_key(self) -> None:
         """A legacy uint32 PRNGKey raises a UserWarning."""
         y = jnp.array([1, 2, 3])
@@ -102,6 +107,40 @@ class TestArrayLoader:
             match=r"Padding 1D arrays is only supported along axis 0.",
         ):
             loader.pad_array(y, n_pad=1, axis=1)
+
+    def test_shuffle_is_deterministic_given_key(self) -> None:
+        """Loaders built with the same key yield identical shuffled batches."""
+        y = np.arange(100)
+        loaders = [
+            ArrayLoader(
+                ArrayDataset(y=y),
+                rng_key=random.key(42),
+                batch_size=7,
+                shuffle=True,
+            )
+            for _ in range(2)
+        ]
+
+        np.testing.assert_array_equal(
+            self._shuffled_batches(loaders[0]),
+            self._shuffled_batches(loaders[1]),
+        )
+
+    def test_shuffle_epochs_are_distinct_permutations(self) -> None:
+        """Each epoch contains every row exactly once, in a fresh order."""
+        y = np.arange(100)
+        loader = ArrayLoader(
+            ArrayDataset(y=y),
+            rng_key=random.key(42),
+            batch_size=7,
+            shuffle=True,
+        )
+
+        epochs = [self._shuffled_batches(loader) for _ in range(2)]
+
+        for epoch in epochs:
+            np.testing.assert_array_equal(np.sort(epoch), y)
+        assert not np.array_equal(epochs[0], epochs[1])
 
     @pytest.mark.parametrize("vi", [lm], indirect=True)
     def test_fit_dataloader_y_not_none_error(

--- a/tests/test_log_likelihood.py
+++ b/tests/test_log_likelihood.py
@@ -17,6 +17,8 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import jax.numpy as jnp
+import numpy as np
 import pytest
 from jax import Array, random
 from numpyro.infer import SVI, Trace_ELBO
@@ -60,6 +62,55 @@ def test_empty_posterior(
     out = im_lm_svi_fitted.log_likelihood(X=X, y=y, progress=False)
 
     assert out.log_likelihood["y"].sizes["draw"] == 1
+
+
+def test_subsampled_kernel(
+    synthetic_data: tuple[Array, Array],
+    im_lm_subsample_svi_fitted: ImpactModel,
+) -> None:
+    """A kernel subsampling inside a plate is evaluated without an rng key.
+
+    Subsample indices are pinned deterministically rather than drawn at random, so
+    the bare (unseeded) kernel traces cleanly and every passed observation is scored
+    on both sharding paths.
+    """
+    X, y = synthetic_data
+    im = im_lm_subsample_svi_fitted
+
+    out = im.log_likelihood(X=X, y=y, batch_size=30, progress=False)
+    out_draw = im.log_likelihood(
+        X=X,
+        y=y,
+        shard_axis="draw",
+        batch_size=250,
+        progress=False,
+    )
+
+    assert out.log_likelihood["y"].shape == (1, 1000, len(X))
+    assert np.isfinite(out.log_likelihood["y"].values).all()
+    # Plate indices never gather here, so the sharding paths agree.
+    assert np.allclose(
+        out.log_likelihood["y"].values,
+        out_draw.log_likelihood["y"].values,
+        atol=1e-6,
+    )
+
+
+def test_subsampled_kernel_batch_exceeds_plate(
+    synthetic_data: tuple[Array, Array],
+    im_lm_subsample_svi_fitted: ImpactModel,
+) -> None:
+    """A batch larger than the declared plate size is rejected loudly."""
+    X, y = synthetic_data
+    X_big, y_big = jnp.tile(X, (6, 1)), jnp.tile(y, 6)
+
+    with pytest.raises(ValueError, match="declares size=100"):
+        im_lm_subsample_svi_fitted.log_likelihood(
+            X=X_big,
+            y=y_big,
+            batch_size=600,
+            progress=False,
+        )
 
 
 def test_log_likelihood_requires_y(

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -12,19 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for writer-thread queue sizing in :mod:`aimz.utils._output`."""
+"""Tests for the write loop and writer queues in :mod:`aimz.utils._output`."""
 
 from pathlib import Path
 from queue import Queue
 from threading import Thread
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
+from tqdm.auto import tqdm
+from zarr import open_group
 
 from aimz.utils._output import (
     _QUEUE_SIZE_FALLBACK_CAP,
     _QUEUE_SIZE_MAX,
     _determine_writer_queue_size,
+    _SliceWriteStrategy,
+    _write_loop,
     _writer,
 )
 
@@ -89,6 +94,83 @@ class TestDetermineWriterQueueSize:
         # The function's floor must keep `Queue(maxsize)` bounded.
         fake_psutil.virtual_memory.return_value.available = 1
         assert _determine_writer_queue_size(num_items=100, item_nbytes=10**18) == 1
+
+
+class TestWriteLoop:
+    """Test class for the pipelined :func:`_write_loop`."""
+
+    N_ITEMS = 4
+    CHUNK = 2
+    N_COLS = 5
+
+    def _run(
+        self,
+        artifact_path: Path,
+        log: list[tuple[str, int]],
+        finalize_error_at: int | None = None,
+    ) -> None:
+        """Drive `_write_loop` over draw-style items with recording fakes."""
+
+        class FinalizeError(RuntimeError):
+            """Test exception for a failure while collecting a result."""
+
+        def dispatch(item: object) -> object:
+            log.append(("dispatch", item))
+            return item
+
+        def finalize(pending: object) -> dict[str, np.ndarray]:
+            log.append(("finalize", pending))
+            if pending == finalize_error_at:
+                raise FinalizeError
+            return {
+                "y": np.full(
+                    (self.CHUNK, self.N_COLS),
+                    fill_value=pending,
+                    dtype=np.float32,
+                ),
+            }
+
+        _write_loop(
+            items=range(self.N_ITEMS),
+            n_items=self.N_ITEMS,
+            return_sites=("y",),
+            artifact_path=artifact_path,
+            strategy=_SliceWriteStrategy(
+                zarr_group=open_group(artifact_path, mode="w"),
+                total=self.N_ITEMS * self.CHUNK,
+                batch_size=self.CHUNK,
+                axis=0,
+            ),
+            dispatch=dispatch,
+            finalize=finalize,
+            pbar=tqdm(disable=True),
+        )
+
+    def test_dispatch_runs_ahead_and_order_is_preserved(self, tmp_path: Path) -> None:
+        """Dispatch runs ahead of collection while results stay in item order."""
+        artifact_path = tmp_path / "out"
+        log: list[tuple[str, int]] = []
+
+        self._run(artifact_path, log=log)
+
+        # Pipelining engaged: item 1 was dispatched before item 0 was collected.
+        assert log.index(("dispatch", 1)) < log.index(("finalize", 0))
+        # Every item landed at its own offset (FIFO order, including the tail drain).
+        written = open_group(artifact_path, mode="r")["y"][:]
+        expected = np.repeat(
+            np.arange(self.N_ITEMS, dtype=np.float32),
+            self.CHUNK,
+        )[:, None] * np.ones(self.N_COLS, dtype=np.float32)
+        np.testing.assert_array_equal(written, expected)
+
+    def test_finalize_failure_cleans_output_and_raises(self, tmp_path: Path) -> None:
+        """An error while collecting a result propagates and removes the output."""
+        artifact_path = tmp_path / "out"
+
+        with pytest.raises(RuntimeError):
+            self._run(artifact_path, log=[], finalize_error_at=1)
+
+        assert not artifact_path.exists()
 
 
 def test_writer_reports_open_group_failure_and_drains_queue(


### PR DESCRIPTION
Improve streaming and writing performance by implementing pipelined processing, allowing for overlapping device compute with result transfer and disk writes. Additionally, restore subsampling support in log likelihood evaluation, which was previously broken.

Fixes #284