### PR TITLE
Harden CI, release, and docs infrastructure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
     push:
       branches: [ main ]
     pull_request:
-      branches: [ main ]
+      branches: [ main, dev ]
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,14 +19,28 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
           python-version: "3.11"
+
+      - name: Verify version
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          PROJECT_VERSION="$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          if [ "$PROJECT_VERSION" != "$REQUESTED_VERSION" ]; then
+            echo "::error::Requested version '$REQUESTED_VERSION' does not match pyproject.toml version '$PROJECT_VERSION'"
+            exit 1
+          fi
+
       - name: Install pypa/build
         run: python3 -m pip install build --user
+
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
+
       - name: Store the distribution packages
         uses: actions/upload-artifact@v7
         with:
@@ -49,10 +63,12 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+
       - name: Publish distribution 📦 to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
 
   publish-to-pypi:
     name: Publish to PyPI
@@ -70,5 +86,6 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
+
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -12,13 +12,18 @@ permissions:
 jobs:
   ruff:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: ruff-action
-        uses: astral-sh/ruff-action@v3
+      - name: Install ruff
+        uses: astral-sh/ruff-action@v4.1.0
+        with:
+          version-file: "uv.lock"
+
+      - name: Run ruff check
+        run: ruff check
+
+      - name: Run ruff format
+        run: ruff format --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.16.0
+    rev: v0.16.3
     hooks:
       # Run the linter.
       - id: ruff-check
@@ -46,10 +46,10 @@ repos:
         args: [--fix, --config=pyproject.toml]
       # Run the formatter.
       - id: ruff-format
-        types_or: [python, pyi]
+        types_or: [python, pyi, jupyter, markdown]
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.32
+    rev: 0.12.5
     hooks:
       - id: uv-lock

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -78,7 +78,6 @@ intersphinx_mapping = {
     "arviz": ("https://python.arviz.org/en/stable/", None),
     "mlflow": ("https://mlflow.org/docs/latest/api_reference/", None),
 }
-tls_verify = False
 
 
 def linkcode_resolve(domain: str, info: dict) -> str | None:
@@ -130,7 +129,7 @@ html_context = {
     "github_user": "markean",
     "github_repo": "aimz",
     "github_version": "main",
-    "doc_path": "doc",
+    "doc_path": "docs/source",
 }
 html_theme_options = {
     "github_url": "https://github.com/markean/aimz",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,9 @@ extend-exclude = []
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = []
+ignore = [
+    "COM812", # missing-trailing-comma
+]
 pep8-naming = { ignore-names = ["*X*"] }
 per-file-ignores = { "aimz/model/_core.py" = [
     "ANN001", # missing-type-function-argument


### PR DESCRIPTION
Pre-release infrastructure cleanup ahead of v0.15.
 
- Ruff: CI now enforces formatting as well as linting (ruff check + ruff format --check as explicit steps) and installs the exact ruff version pinned in uv.lock via ruff-action@v4.1.0 with version-file, instead of floating to the latest release. The dead python-version matrix is removed, so the job runs once. Pre-commit is aligned to the locked ruff version, and its format hook now also covers notebooks and markdown. COM812 moved to lint.ignore to resolve the formatter-conflict warning.

- CI triggers: workflows now also run on pull requests targeting dev, so Dependabot's action-bump PRs are tested before merging instead of landing with no checks.

- Publish workflow: the required version dispatch input is now actually enforced — the build fails if it doesn't match pyproject.toml — and TestPyPI uploads use skip-existing so a partially failed release can be re-run without a version bump.

- Docs: fixed the "Edit this Page" button 404 (wrong doc_path) and re-enabled TLS certificate verification for intersphinx fetches.

- Packaging: added a setuptools floor to build-system.requires, matching the PEP 639 license metadata requirement.