### PR TITLE
MLflow lifecycle and reproducibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The tree returned by {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch` now lists its `posterior` group before `prior_predictive` ([#293](https://github.com/markean/aimz/issues/293)).
 - Disk-backed Zarr arrays are now compressed with byte-shuffled Zstandard ([#293](https://github.com/markean/aimz/issues/293)).
+- {func}`~aimz.mlflow.get_default_pip_requirements`, and therefore the environments captured by {func}`~aimz.mlflow.save_model` and {func}`~aimz.mlflow.log_model`, now pin `jax` and `numpyro` alongside `aimz`. The pickled model contains serialized state from both libraries that must be restored against the versions used at save time, which the previous floor-only constraints inherited from the package metadata did not guarantee ([#296](https://github.com/markean/aimz/issues/296)).
+- The {mod}`aimz.mlflow` documentation now states that REST serving (e.g. `mlflow models serve`) is not supported, as the MLflow scoring server cannot serialize the {class}`xarray.DataTree` returned by predictions; the pyfunc flavor is intended for batch inference in Python ([#296](https://github.com/markean/aimz/issues/296)).
 
 ### Fixed
 
 - An interrupted or failed streamed call no longer keeps its intermediate buffers reachable through the exception's traceback. The in-flight pipeline results and the current batch are dropped in the cleanup path for both stores, and `store="memory"` additionally releases its partially accumulated results ([#293](https://github.com/markean/aimz/issues/293)).
+- Predictions through the pyfunc flavor now default to the in-memory result store. Previously each call streamed its results to a Zarr artifact in the model's temporary directory with no cleanup path at the pyfunc layer, and the lazily-read tree silently returned zeros if the model was garbage-collected before the results were consumed. An explicitly passed `store` is still honored ([#296](https://github.com/markean/aimz/issues/296)).
+- {func}`~aimz.mlflow.save_model` and {func}`~aimz.mlflow.log_model` no longer advance the model's internal PRNG key when inferring a signature from `input_example`, so saving a model leaves its future prediction stream unchanged ([#296](https://github.com/markean/aimz/issues/296)).
 
 ## [v0.14.0](https://github.com/markean/aimz/releases/tag/v0.14.0) - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The tree returned by {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch` now lists its `posterior` group before `prior_predictive` ([#293](https://github.com/markean/aimz/issues/293)).
 - Disk-backed Zarr arrays are now compressed with byte-shuffled Zstandard ([#293](https://github.com/markean/aimz/issues/293)).
-- {func}`~aimz.mlflow.get_default_pip_requirements`, and therefore the environments captured by {func}`~aimz.mlflow.save_model` and {func}`~aimz.mlflow.log_model`, now pin `jax` and `numpyro` alongside `aimz`. The pickled model contains serialized state from both libraries that must be restored against the versions used at save time, which the previous floor-only constraints inherited from the package metadata did not guarantee ([#296](https://github.com/markean/aimz/issues/296)).
-- The {mod}`aimz.mlflow` documentation now states that REST serving (e.g. `mlflow models serve`) is not supported, as the MLflow scoring server cannot serialize the {class}`xarray.DataTree` returned by predictions; the pyfunc flavor is intended for batch inference in Python ([#296](https://github.com/markean/aimz/issues/296)).
+- {func}`~aimz.mlflow.get_default_pip_requirements`, and therefore the environments captured by {func}`~aimz.mlflow.save_model` and {func}`~aimz.mlflow.log_model`, now pin `jax` and `numpyro` alongside `aimz` ([#296](https://github.com/markean/aimz/issues/296)).
 
 ### Fixed
 

--- a/aimz/mlflow/__init__.py
+++ b/aimz/mlflow/__init__.py
@@ -19,7 +19,9 @@ This module exports aimz models with the following flavors:
 aimz (native) format
     This is the main flavor that can be loaded back into aimz.
 :py:mod:`mlflow.pyfunc`
-    Produced for use by generic pyfunc-based deployment tools and batch inference.
+    Produced for generic pyfunc-based batch inference in Python. Predictions are
+    returned as an :py:class:`xarray.DataTree`, which the MLflow scoring server does
+    not serialize, so REST serving (e.g. ``mlflow models serve``) is not supported.
 """
 
 from __future__ import annotations
@@ -121,7 +123,11 @@ def get_default_pip_requirements(*, include_cloudpickle: bool = False) -> list[s
         Calls to :func:`save_model()` and :func:`log_model()` produce a pip environment
         that, at minimum, contains these requirements.
     """
-    pip_deps = [_get_pinned_requirement("aimz")]
+    pip_deps = [
+        _get_pinned_requirement("aimz"),
+        _get_pinned_requirement("jax"),
+        _get_pinned_requirement("numpyro"),
+    ]
     if include_cloudpickle:
         pip_deps.append(_get_pinned_requirement("cloudpickle"))
 
@@ -206,8 +212,16 @@ def save_model(
     saved_example = _save_example(mlflow_model, input_example, str(path))
 
     if signature is None and saved_example is not None:
-        wrapped_model = _AimzModelWrapper(model)
-        signature = _infer_signature_from_input_example(saved_example, wrapped_model)
+        # Signature inference runs a real prediction; restore the rng key so that
+        # saving does not change the model's future prediction stream.
+        rng_key = model.rng_key
+        try:
+            signature = _infer_signature_from_input_example(
+                saved_example,
+                _AimzModelWrapper(model),
+            )
+        finally:
+            model._rng_key = rng_key
     elif signature is False:
         signature = None
 
@@ -551,12 +565,19 @@ class _AimzModelWrapper:
         Returns:
             Model predictions.
         """
+        # Results default to the in-memory store
         if isinstance(data, dict):
             return self.aimz_model.predict(
-                **cast("dict[str, Any]", data),
-                **(params or {}),
+                **{
+                    "store": "memory",
+                    **cast("dict[str, Any]", data),
+                    **(params or {}),
+                },
             )
-        return self.aimz_model.predict(cast("Any", data), **(params or {}))
+        return self.aimz_model.predict(
+            cast("Any", data),
+            **{"store": "memory", **(params or {})},
+        )
 
 
 @autologging_integration(FLAVOR_NAME)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ per-file-ignores = { "aimz/model/_core.py" = [
     "PLR0913", # too-many-arguments
     "PLR0917", # too-many-positional-arguments
     "PLC0415", # import-outside-top-level
+    "SLF001",  # private-member-access
 ], "docs*" = [
     "A001", # builtin-variable-shadowing
     "F401", # unused-import

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -40,6 +40,7 @@ from aimz.mlflow import (
     autolog,
     get_default_conda_env,
     load_model,
+    log_model,
     save_model,
 )
 
@@ -194,6 +195,33 @@ def test_load_model_returns_raw_impact_model(
     reloaded = load_model(str(tmp_path / "model"))
 
     assert isinstance(reloaded, ImpactModel)
+
+
+def test_log_model_round_trip_outputs_match(
+    im_lm_svi_fitted: ImpactModel,
+    synthetic_data: tuple[Array, Array],
+) -> None:
+    """A logged model reloads predicting identically to the original.
+
+    Across a :func:`~aimz.mlflow.log_model` -> :func:`~aimz.mlflow.load_model` round
+    trip, the reloaded model must reproduce predictions draw-for-draw under the same
+    explicit PRNG key, without a refit.
+    """
+    X, _ = synthetic_data
+    with mlflow.start_run():
+        info = log_model(im_lm_svi_fitted, name="model")
+
+    reloaded = load_model(info.model_uri)
+
+    expected = cast(
+        "xr.DataTree",
+        im_lm_svi_fitted.predict_on_batch(X, rng_key=random.key(0)),
+    )
+    actual = cast("xr.DataTree", reloaded.predict_on_batch(X, rng_key=random.key(0)))
+    np.testing.assert_array_equal(
+        np.asarray(actual["posterior_predictive"]["y"]),
+        np.asarray(expected["posterior_predictive"]["y"]),
+    )
 
 
 def test_load_model_disallowed_when_pickle_deserialization_disabled(

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -15,14 +15,29 @@
 """Tests for saving and loading functionality of models."""
 
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 import cloudpickle
+import numpy as np
+from jax import Array, random
 
 from aimz import ImpactModel
 
+if TYPE_CHECKING:
+    import xarray as xr
 
-def test_save_load(im_lm_svi_fitted: ImpactModel, tmp_path: Path) -> None:
-    """Test saving and loading an ImpactModel without errors."""
+
+def test_save_load(
+    im_lm_svi_fitted: ImpactModel,
+    synthetic_data: tuple[Array, Array],
+    tmp_path: Path,
+) -> None:
+    """A pickled model round-trips its posterior and predictions without a refit.
+
+    The posterior samples survive the round trip unchanged, and the loaded model
+    predicts draw-for-draw identically under the same explicit PRNG key.
+    """
+    X, _ = synthetic_data
     p = tmp_path / "model.pkl"
     with p.open("wb") as f:
         cloudpickle.dump(im_lm_svi_fitted, f)
@@ -30,3 +45,20 @@ def test_save_load(im_lm_svi_fitted: ImpactModel, tmp_path: Path) -> None:
         im = cloudpickle.load(f)
 
     assert isinstance(im, ImpactModel)
+    assert im.posterior is not None
+    assert im_lm_svi_fitted.posterior is not None
+    assert set(im.posterior) == set(im_lm_svi_fitted.posterior)
+    for site, sample in im_lm_svi_fitted.posterior.items():
+        np.testing.assert_array_equal(
+            np.asarray(im.posterior[site]),
+            np.asarray(sample),
+        )
+    expected = cast(
+        "xr.DataTree",
+        im_lm_svi_fitted.predict_on_batch(X, rng_key=random.key(0)),
+    )
+    actual = cast("xr.DataTree", im.predict_on_batch(X, rng_key=random.key(0)))
+    np.testing.assert_array_equal(
+        np.asarray(actual["posterior_predictive"]["y"]),
+        np.asarray(expected["posterior_predictive"]["y"]),
+    )


### PR DESCRIPTION
Addressed several lifecycle and reproducibility issues in the MLflow integration. Predictions through the pyfunc flavor now default to an in-memory result store, preventing artifact leaks and ensuring consistent results. The `save_model` function no longer alters the model's internal RNG key during signature inference, preserving future prediction streams. Additionally, the captured requirements now pin `jax` and `numpyro` to ensure compatibility with serialized model states. Updated documentation clarifies the limitations of REST serving with the current setup.

Fixes #296