### PR TITLE
Fix input validation and error handling in ImpactModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The tree returned by {meth}`~aimz.ImpactModel.sample_prior_predictive_on_batch` now lists its `posterior` group before `prior_predictive` ([#293](https://github.com/markean/aimz/issues/293)).
 - Disk-backed Zarr arrays are now compressed with byte-shuffled Zstandard ([#293](https://github.com/markean/aimz/issues/293)).
 - {func}`~aimz.mlflow.get_default_pip_requirements`, and therefore the environments captured by {func}`~aimz.mlflow.save_model` and {func}`~aimz.mlflow.log_model`, now pin `jax` and `numpyro` alongside `aimz` ([#296](https://github.com/markean/aimz/issues/296)).
+- Setting {attr}`~aimz.ImpactModel.vi_result` no longer marks the model fitted: fitted status now means posterior samples exist, established by {meth}`~aimz.ImpactModel.fit`, {meth}`~aimz.ImpactModel.fit_on_batch`, or {meth}`~aimz.ImpactModel.set_posterior_sample`. {meth}`~aimz.ImpactModel.sample` instead requires only the inference state, and calling a predictive method right after setting `vi_result` raises `NotFittedError` ([#299](https://github.com/markean/aimz/issues/299)).
+- {meth}`~aimz.ImpactModel.sample` with MCMC inference no longer consumes the model's internal PRNG key, which it never used ([#299](https://github.com/markean/aimz/issues/299)).
 
 ### Fixed
 
 - An interrupted or failed streamed call no longer keeps its intermediate buffers reachable through the exception's traceback. The in-flight pipeline results and the current batch are dropped in the cleanup path for both stores, and `store="memory"` additionally releases its partially accumulated results ([#293](https://github.com/markean/aimz/issues/293)).
 - Predictions through the pyfunc flavor now default to the in-memory result store. Previously each call streamed its results to a Zarr artifact in the model's temporary directory with no cleanup path at the pyfunc layer, and the lazily-read tree silently returned zeros if the model was garbage-collected before the results were consumed. An explicitly passed `store` is still honored ([#296](https://github.com/markean/aimz/issues/296)).
 - {func}`~aimz.mlflow.save_model` and {func}`~aimz.mlflow.log_model` no longer advance the model's internal PRNG key when inferring a signature from `input_example`, so saving a model leaves its future prediction stream unchanged ([#296](https://github.com/markean/aimz/issues/296)).
+- {meth}`~aimz.ImpactModel.fit` now validates its inputs like the other entry points: a 0-d or misaligned array keyword argument raises a `ValueError` naming the offending argument, and a missing `y` with an array-like `X` raises a clear `ValueError` instead of an internal `TypeError` from the training loop ([#299](https://github.com/markean/aimz/issues/299)).
+- {meth}`~aimz.ImpactModel.sample` on an MCMC model prepared via {meth}`~aimz.ImpactModel.set_posterior_sample` raises a clear `NotFittedError` instead of an `AttributeError` on the missing MCMC state; the same applies to an SVI model without a stored `vi_result` ([#299](https://github.com/markean/aimz/issues/299)).
+- {meth}`~aimz.ImpactModel.cleanup_models` no longer stops at the first model whose cleanup fails: the failure is logged as a warning and the remaining models are still cleaned up ([#299](https://github.com/markean/aimz/issues/299)).
 
 ## [v0.14.0](https://github.com/markean/aimz/releases/tag/v0.14.0) - 2026-07-24
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -47,6 +47,7 @@ from numpyro.infer import MCMC, SVI
 from numpyro.infer.svi import SVIRunResult, SVIState
 from tqdm.auto import tqdm
 
+from aimz._exceptions import NotFittedError
 from aimz.model._core import BaseModel
 from aimz.model._streaming import (
     _OutputStreamer,
@@ -133,6 +134,7 @@ class ImpactModel(BaseModel):
         self._inference = inference
         self._vi_result: SVIRunResult | None = None
         self._vi_state = None
+        self._is_fitted = False
         self._posterior: dict[str, Array] | None = None
         self._init_runtime_attrs()
 
@@ -177,7 +179,7 @@ class ImpactModel(BaseModel):
             f"Inference method: {self.inference.__class__.__name__}",
             f"Input parameter: '{self.param_input}'",
             f"Output parameter: '{self.param_output}'",
-            f"Fitted: {getattr(self, '_is_fitted', False)}",
+            f"Fitted: {self._is_fitted}",
         ]
         temp_dir = getattr(self, "temp_dir", None)
         if temp_dir:
@@ -198,7 +200,7 @@ class ImpactModel(BaseModel):
             f"param_input={self.param_input!r};",
             f"param_output={self.param_output!r};",
             f"kernel_spec={self.kernel_spec!r};",
-            f"fitted={getattr(self, '_is_fitted', False)};",
+            f"fitted={self._is_fitted};",
             f"temp_dir={getattr(self, 'temp_dir', None)!r}>",
         ]
 
@@ -240,6 +242,8 @@ class ImpactModel(BaseModel):
             state: The state to restore, excluding the runtime attributes.
         """
         self.__dict__.update(state)
+        # Models pickled before `_is_fitted` was initialized eagerly may lack it.
+        self.__dict__.setdefault("_is_fitted", False)
         self._init_runtime_attrs()
 
     @property
@@ -291,8 +295,8 @@ class ImpactModel(BaseModel):
     def vi_result(self) -> SVIRunResult | None:
         """Variational inference result, or ``None`` if not set.
 
-        :setter: This sets :external:data:`~numpyro.infer.svi.SVIRunResult` and marks
-            the model as fitted. It does not perform posterior sampling — use
+        :setter: This sets :external:data:`~numpyro.infer.svi.SVIRunResult` without
+            marking the model fitted. It does not perform posterior sampling — use
             :meth:`~aimz.ImpactModel.sample` separately to obtain samples.
         """
         return self._vi_result
@@ -309,16 +313,13 @@ class ImpactModel(BaseModel):
                 - losses (ArrayLike): Loss values recorded during optimization.
 
         Note:
-            This stores the result and marks the model fitted, but does not draw
+            This stores the result but does not mark the model fitted or draw
             posterior samples. Draw them with :meth:`~aimz.ImpactModel.sample` and
             register them via :meth:`~aimz.ImpactModel.set_posterior_sample`.
         """
         if not np.all(np.isfinite(vi_result.losses)):
             msg = "Loss contains NaN or Inf, indicating numerical instability."
             warn(msg, category=RuntimeWarning, stacklevel=2)
-
-        self._is_fitted = True
-
         self._vi_result = vi_result
 
     def _bind_kernel_args(
@@ -487,51 +488,6 @@ class ImpactModel(BaseModel):
 
         return artifact_path
 
-    def _stream_to_datatree(
-        self,
-        write: Callable[[Path | None], dict[str, DaskArray] | None],
-        *,
-        store: str,
-        output_dir: str | Path | None,
-        group: str,
-    ) -> xr.DataTree:
-        """Run one streamed write and assemble its output tree.
-
-        The single place where the result store forks: ``store="persistent"`` creates
-        the call-specific artifact path, streams into it (removing it again if the
-        stream fails), and reads it back lazily; ``store="memory"`` retains the
-        streamed batches in host memory and assembles the tree over them directly.
-
-        Args:
-            write: Runs the streamed write against the given artifact path (``None``
-                for in-memory accumulation) and returns the accumulated site arrays,
-                if any.
-            store: The result store, ``"persistent"`` or ``"memory"``.
-            output_dir: Base directory for disk-backed outputs.
-            group: Output group name for the resulting tree.
-
-        Returns:
-            The output tree: lazy in both modes, Dask-backed by the Zarr store for
-            ``"persistent"`` and by the retained in-memory batches for ``"memory"``.
-        """
-        artifact_path = (
-            self._create_artifact_path(output_dir) if store == "persistent" else None
-        )
-        try:
-            result = write(artifact_path)
-        except BaseException:
-            if artifact_path is not None:
-                rmtree(artifact_path, ignore_errors=True)
-            raise
-        if artifact_path is None:
-            return _build_datatree(
-                cast("dict[str, DaskArray]", result),
-                group=group,
-                posterior=self.posterior,
-            )
-
-        return _build_datatree(artifact_path, group=group, posterior=self.posterior)
-
     def _plan_obs_batching(
         self,
         X: ArrayLike | ArrayLoader,
@@ -581,6 +537,51 @@ class ImpactModel(BaseModel):
             return "whole"
 
         return "fallback"
+
+    def _stream_to_datatree(
+        self,
+        write: Callable[[Path | None], dict[str, DaskArray] | None],
+        *,
+        store: str,
+        output_dir: str | Path | None,
+        group: str,
+    ) -> xr.DataTree:
+        """Run one streamed write and assemble its output tree.
+
+        The single place where the result store forks: ``store="persistent"`` creates
+        the call-specific artifact path, streams into it (removing it again if the
+        stream fails), and reads it back lazily; ``store="memory"`` retains the
+        streamed batches in host memory and assembles the tree over them directly.
+
+        Args:
+            write: Runs the streamed write against the given artifact path (``None``
+                for in-memory accumulation) and returns the accumulated site arrays,
+                if any.
+            store: The result store, ``"persistent"`` or ``"memory"``.
+            output_dir: Base directory for disk-backed outputs.
+            group: Output group name for the resulting tree.
+
+        Returns:
+            The output tree: lazy in both modes, Dask-backed by the Zarr store for
+            ``"persistent"`` and by the retained in-memory batches for ``"memory"``.
+        """
+        artifact_path = (
+            self._create_artifact_path(output_dir) if store == "persistent" else None
+        )
+        try:
+            result = write(artifact_path)
+        except BaseException:
+            if artifact_path is not None:
+                rmtree(artifact_path, ignore_errors=True)
+            raise
+        if artifact_path is None:
+            return _build_datatree(
+                cast("dict[str, DaskArray]", result),
+                group=group,
+                posterior=self.posterior,
+            )
+
+        return _build_datatree(artifact_path, group=group, posterior=self.posterior)
 
     def sample_prior_predictive_on_batch(
         self,
@@ -767,7 +768,7 @@ class ImpactModel(BaseModel):
         return_datatree: bool = True,
         **kwargs: object,
     ) -> xr.DataTree | dict[str, npt.NDArray]:
-        """Draw posterior samples from a fitted model.
+        """Draw posterior samples from the model's inference state.
 
         Args:
             num_samples: The number of posterior samples to draw.
@@ -786,15 +787,20 @@ class ImpactModel(BaseModel):
             Posterior samples.
 
         Raises:
+            NotFittedError: If there is no inference state to sample from — no
+                completed MCMC run, or no ``vi_result`` when the inference method
+                is SVI.
             TypeError: If :attr:`~aimz.ImpactModel.param_output` is not passed as an
                 argument when the inference method is MCMC.
         """
-        _check_is_fitted(self)
-
-        if rng_key is None:
-            self._rng_key, rng_key = random.split(self._rng_key)
-
         if isinstance(self.inference, MCMC):
+            if self.inference.last_state is None:
+                msg = (
+                    "This ImpactModel instance has no MCMC state to sample from. "
+                    "Call `.fit_on_batch()`, or run the MCMC directly, before using "
+                    "`.sample()`."
+                )
+                raise NotFittedError(msg)
             # Validate the provided parameters against the kernel's signature
             args_bound = signature(self.kernel).bind(**kwargs).arguments
             if self.param_output not in args_bound:
@@ -805,6 +811,15 @@ class ImpactModel(BaseModel):
             self.inference.run(self.inference.post_warmup_state.rng_key, **args_bound)
             posterior_samples = device_get(self.inference.get_samples())
         else:
+            if self.vi_result is None:
+                msg = (
+                    "This ImpactModel instance has no inference result to sample from. "
+                    "Call `.fit()` or `.fit_on_batch()`, or set `vi_result`, before "
+                    "using `.sample()`."
+                )
+                raise NotFittedError(msg)
+            if rng_key is None:
+                self._rng_key, rng_key = random.split(self._rng_key)
             posterior_samples = device_get(
                 _sample_forward(
                     substitute(
@@ -1111,8 +1126,7 @@ class ImpactModel(BaseModel):
             self._num_samples = (
                 next(iter(self.posterior.values())).shape[0] if self.posterior else 0
             )
-            # The SVI path is already marked by the `vi_result` setter
-            self._is_fitted = True
+        self._is_fitted = True
 
         return self
 
@@ -1160,6 +1174,8 @@ class ImpactModel(BaseModel):
 
         Raises:
             TypeError: If the inference method is MCMC.
+            ValueError: If ``y`` is missing when ``X`` is array-like, or the array
+                inputs do not share one leading-axis size.
 
         Note:
             This method continues training from the existing SVI state if available.
@@ -1255,6 +1271,7 @@ class ImpactModel(BaseModel):
             samples=None,
             model_kwargs=None,
         )
+        self._is_fitted = True
 
         return self
 
@@ -1265,7 +1282,7 @@ class ImpactModel(BaseModel):
             `True` if the model is fitted, `False` otherwise.
 
         """
-        return hasattr(self, "_is_fitted") and self._is_fitted
+        return self._is_fitted
 
     def set_posterior_sample(self, posterior_sample: dict[str, Array]) -> Self:
         """Set posterior samples for the model.
@@ -1375,6 +1392,7 @@ class ImpactModel(BaseModel):
             Posterior predictive samples. Posterior samples are included if available.
 
         Raises:
+            NotFittedError: If the model is not fitted.
             TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
                 argument.
         """
@@ -1487,11 +1505,13 @@ class ImpactModel(BaseModel):
             Posterior predictive samples. Posterior samples are included if available.
 
         Raises:
+            NotFittedError: If the model is not fitted.
             TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
                 argument, or ``shard_axis="draw"`` is used with a data loader ``X``.
             ValueError: If ``shard_axis`` is not ``"obs"`` or ``"draw"``, ``store`` is
-                not ``"persistent"`` or ``"memory"``, or ``output_dir`` is passed with
-                ``store="memory"``.
+                not ``"persistent"`` or ``"memory"``, ``output_dir`` is passed with
+                ``store="memory"``, or the array inputs do not share one leading-axis
+                size.
             NotImplementedError: If a return site's axis-1 size does not match the
                 input batch size (``shard_axis="obs"`` only).
 
@@ -1616,6 +1636,7 @@ class ImpactModel(BaseModel):
             in-memory results set neither.
 
         Raises:
+            NotFittedError: If the model is not fitted.
             ValueError: If neither ``output_baseline`` nor ``args_baseline`` is
                 provided, or if neither ``output_intervention`` nor
                 ``args_intervention`` is provided.
@@ -1738,10 +1759,12 @@ class ImpactModel(BaseModel):
             Log-likelihood values. Posterior samples are included if available.
 
         Raises:
+            NotFittedError: If the model is not fitted.
             TypeError: If ``shard_axis="draw"`` is used with a data loader ``X``.
             ValueError: If ``shard_axis`` is not ``"obs"`` or ``"draw"``, ``store`` is
-                not ``"persistent"`` or ``"memory"``, or ``output_dir`` is passed with
-                ``store="memory"``.
+                not ``"persistent"`` or ``"memory"``, ``output_dir`` is passed with
+                ``store="memory"``, ``y`` is missing when ``X`` is array-like, or the
+                array inputs do not share one leading-axis size.
             NotImplementedError: If a return site's axis-1 size does not match the
                 input batch size (``shard_axis="obs"`` only).
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -1168,6 +1168,13 @@ class ImpactModel(BaseModel):
             (e.g., using `NumPyro`_'s :external:func:`~numpyro.primitives.subsample` or
             similar constructs).
         """
+        _validate_aligned_inputs(X, y=y, kwargs=kwargs)
+        if y is None and isinstance(X, ArrayLike):
+            msg = (
+                "`y` is required for `fit()` when `X` is array-like. "
+                "Provide `y`, or give `X` as a data loader that carries it."
+            )
+            raise ValueError(msg)
         if isinstance(self.inference, MCMC):
             msg = (
                 "`.fit()` is not supported for MCMC inference. Use `.fit_on_batch()` "

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -1842,4 +1842,11 @@ class ImpactModel(BaseModel):
             single instance.
         """
         for model in cls._models:
-            model.cleanup()
+            try:
+                model.cleanup()
+            except OSError:
+                logger.warning(
+                    "Failed to clean up the temporary directory at: %s",
+                    model.temp_dir,
+                    exc_info=True,
+                )

--- a/aimz/utils/_validation.py
+++ b/aimz/utils/_validation.py
@@ -47,26 +47,18 @@ def _is_arraylike(x: object) -> bool:
     return hasattr(x, "__len__") or hasattr(x, "shape") or hasattr(x, "__array__")
 
 
-def _check_is_fitted(model: ImpactModel, msg: str | None = None) -> None:
+def _check_is_fitted(model: ImpactModel) -> None:
     """Check if the model is fitted.
 
     Raises:
         NotFittedError: If the model has not been fitted.
     """
-    if msg is None:
+    if not model.is_fitted():
         msg = (
-            "This %(name)s instance is not fitted yet. Call ``.fit()`` with "
-            "appropriate arguments before using the model."
+            f"This {type(model).__name__} instance is not fitted yet. Call "
+            "``.fit()`` with appropriate arguments before using the model."
         )
-    if not _is_fitted(model):
-        raise NotFittedError(msg % {"name": type(model).__name__})
-
-
-def _is_fitted(model: ImpactModel) -> bool:
-    if hasattr(model, "_is_fitted"):
-        return model.is_fitted()
-
-    return any(v.endswith("_") and not v.startswith("__") for v in vars(model))
+        raise NotFittedError(msg)
 
 
 def _validate_group(dt_baseline: xr.DataTree, dt_intervention: xr.DataTree) -> str:

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -25,7 +25,6 @@ from numpyro.optim import Adam
 
 from aimz import ImpactModel
 from aimz._exceptions import KernelValidationError
-from aimz.utils._validation import _is_fitted
 from tests.conftest import lm
 
 
@@ -211,4 +210,4 @@ def test_fit_lm(synthetic_data: tuple[Array, Array], vi: SVI) -> None:
     X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
     im.fit(X=X, y=y, batch_size=3)
-    assert _is_fitted(im), "Model fitting check failed"
+    assert im.is_fitted(), "Model fitting check failed"

--- a/tests/test_fit_on_batch.py
+++ b/tests/test_fit_on_batch.py
@@ -21,7 +21,6 @@ from numpyro.infer.autoguide import AutoNormal
 from numpyro.optim import Adam
 
 from aimz import ImpactModel
-from aimz.utils._validation import _is_fitted
 from tests.conftest import lm
 
 
@@ -48,7 +47,7 @@ def test_fit_svi(synthetic_data: tuple[Array, Array], vi: SVI) -> None:
     X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), inference=vi)
     im.fit_on_batch(X=X, y=y)
-    assert _is_fitted(im), "Model fitting check failed"
+    assert im.is_fitted(), "Model fitting check failed"
     assert im.vi_result is not None, "VI result should not be `None`"
     first_loss = im.vi_result.losses[0]
 
@@ -66,7 +65,7 @@ def test_fit_mcmc(synthetic_data: tuple[Array, Array], mcmc: MCMC) -> None:
     X, y = synthetic_data
     im = ImpactModel(lm, rng_key=random.key(42), inference=mcmc)
     im.fit_on_batch(X=X, y=y)
-    assert _is_fitted(im), "Model fitting check failed"
+    assert im.is_fitted(), "Model fitting check failed"
 
 
 def test_fit_on_batch_zero_dim_raises(synthetic_data: tuple[Array, Array]) -> None:

--- a/tests/test_set_posterior_sample.py
+++ b/tests/test_set_posterior_sample.py
@@ -26,7 +26,6 @@ from numpyro.infer import Predictive
 from numpyro.infer.svi import SVIRunResult
 
 from aimz import ImpactModel
-from aimz.utils._validation import _is_fitted
 from tests.conftest import lm
 
 if TYPE_CHECKING:
@@ -62,7 +61,7 @@ def test_set_posterior_sample(synthetic_data: tuple[Array, Array], vi: SVI) -> N
         chain=0,
     )
     im.set_posterior_sample({k: v.values for k, v in posterior_samples.items()})
-    assert _is_fitted(im), "Model fitting check failed"
+    assert im.is_fitted(), "Model fitting check failed"
     assert isinstance(im.vi_result, SVIRunResult)
     assert posterior_sample.keys() == im.posterior.keys()
     for key in posterior_sample:


### PR DESCRIPTION
Enhance input validation in the `fit` method of `ImpactModel` to raise clear errors for missing target variables and misaligned array arguments. Improve error handling during model cleanup to ensure all models are processed, logging warnings for any failures. Update the fitted status semantics to ensure it accurately reflects the existence of posterior samples, and adjust the behavior of the `sample` method to require only the inference state.

Fixes #299