### PR TITLE
Fix handling of empty inputs and 0-D values in streaming and posterior injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - {meth}`~aimz.ImpactModel.fit` now validates its inputs like the other entry points: a 0-d or misaligned array keyword argument raises a `ValueError` naming the offending argument, and a missing `y` with an array-like `X` raises a clear `ValueError` instead of an internal `TypeError` from the training loop ([#299](https://github.com/markean/aimz/issues/299)).
 - {meth}`~aimz.ImpactModel.sample` on an MCMC model prepared via {meth}`~aimz.ImpactModel.set_posterior_sample` raises a clear `NotFittedError` instead of an `AttributeError` on the missing MCMC state; the same applies to an SVI model without a stored `vi_result` ([#299](https://github.com/markean/aimz/issues/299)).
 - {meth}`~aimz.ImpactModel.cleanup_models` no longer stops at the first model whose cleanup fails: the failure is logged as a warning and the remaining models are still cleaned up ([#299](https://github.com/markean/aimz/issues/299)).
+- The streaming entry points now accept list and tuple inputs: {class}`~aimz.utils.data.ArrayDataset` converts values that are not already JAX or NumPy arrays to NumPy arrays at construction, matching {meth}`~aimz.ImpactModel.predict_on_batch` ([#301](https://github.com/markean/aimz/issues/301)).
+- An empty `X` passed to a streaming entry point or {meth}`~aimz.ImpactModel.fit` raises a `ValueError` ([#301](https://github.com/markean/aimz/issues/301)).
+- {meth}`~aimz.ImpactModel.set_posterior_sample` now converts values that are not already JAX or NumPy arrays to NumPy arrays, and a 0-d value raises a `ValueError` ([#301](https://github.com/markean/aimz/issues/301)).
 
 ## [v0.14.0](https://github.com/markean/aimz/releases/tag/v0.14.0) - 2026-07-24
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -1310,7 +1310,8 @@ class ImpactModel(BaseModel):
             method chaining.
 
         Raises:
-            ValueError: If the batch shapes in ``posterior_sample`` are inconsistent.
+            ValueError: If ``posterior_sample`` is empty, a value is 0-D, or the batch
+                shapes in ``posterior_sample`` are inconsistent.
 
         Note:
             The kernel is not traced when samples are set this way, so ``deterministic``
@@ -1319,6 +1320,16 @@ class ImpactModel(BaseModel):
             ``return_sites``.
         """
         batch_ndims = 1
+        posterior_sample = {
+            name: sample
+            if isinstance(sample, (Array, np.ndarray))
+            else np.asarray(sample)
+            for name, sample in posterior_sample.items()
+        }
+        for name, sample in posterior_sample.items():
+            if sample.ndim < batch_ndims:
+                msg = f"`posterior_sample[{name!r}]` must have at least 1 dimension."
+                raise ValueError(msg)
         batch_shapes = {
             sample.shape[:batch_ndims] for sample in posterior_sample.values()
         }

--- a/aimz/utils/_validation.py
+++ b/aimz/utils/_validation.py
@@ -200,8 +200,8 @@ def _validate_aligned_inputs(
             checked.
 
     Raises:
-        ValueError: If any checked input is 0-D, or the inputs do not all share one
-            leading-axis size.
+        ValueError: If any checked input is 0-D, ``X`` is empty, or the inputs do not
+            all share one leading-axis size.
     """
     if not isinstance(X, ArrayLike):
         return
@@ -216,6 +216,9 @@ def _validate_aligned_inputs(
             msg = f"`{name}` must have at least 1 dimension."
             raise ValueError(msg)
         sizes[name] = np.shape(arr)[0]
+    if sizes["X"] == 0:
+        msg = "`X` must not be empty."
+        raise ValueError(msg)
     if len(set(sizes.values())) > 1:
         detail = ", ".join(f"{name}={size}" for name, size in sizes.items())
         msg = f"All inputs must have the same leading-axis size; got {detail}."

--- a/aimz/utils/data/array_dataset.py
+++ b/aimz/utils/data/array_dataset.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 
 if TYPE_CHECKING:
@@ -45,15 +46,20 @@ class ArrayDataset:
 
         Args:
             to_jax: Whether to convert the input arrays to JAX arrays.
-            **arrays: Named JAX arrays, NumPy arrays, or ``None``. At least one
-                non-``None`` array must be provided. All non-``None`` arrays must have
-                the same length.
+            **arrays: Named JAX arrays, NumPy arrays, or ``None``; other array-likes
+                (e.g., lists) are converted to NumPy arrays. At least one non-``None``
+                array must be provided. All non-``None`` arrays must have the same
+                length.
 
         Raises:
             ValueError: If no non-``None`` arrays are provided or if the arrays do not
                 have the same length.
         """
-        arrays = {k: v for k, v in arrays.items() if v is not None}
+        arrays = {
+            k: v if isinstance(v, (Array, np.ndarray)) else np.asarray(v)
+            for k, v in arrays.items()
+            if v is not None
+        }
         if not arrays:
             msg = "At least one array must be provided."
             raise ValueError(msg)


### PR DESCRIPTION
Enhance validation in the ImpactModel and ArrayDataset to properly handle empty inputs and 0-D values. The streaming entry points now accept list and tuple inputs, raising appropriate errors for empty or invalid data. Fixes #301.