### PR TITLE
Enhance input validation and handling for kernel parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The streaming entry points now accept list and tuple inputs: {class}`~aimz.utils.data.ArrayDataset` converts values that are not already JAX or NumPy arrays to NumPy arrays at construction, matching {meth}`~aimz.ImpactModel.predict_on_batch` ([#301](https://github.com/markean/aimz/issues/301)).
 - An empty `X` passed to a streaming entry point or {meth}`~aimz.ImpactModel.fit` raises a `ValueError` ([#301](https://github.com/markean/aimz/issues/301)).
 - {meth}`~aimz.ImpactModel.set_posterior_sample` now converts values that are not already JAX or NumPy arrays to NumPy arrays, and a 0-d value raises a `ValueError` ([#301](https://github.com/markean/aimz/issues/301)).
+- The streaming methods now emit a `UserWarning` when a data loader with `shuffle=True` is passed ([#303](https://github.com/markean/aimz/issues/303)).
+- Kernel validation now rejects an output parameter whose default is falsy but not `None`; an array default now raises a `KernelValidationError` instead of a `ValueError` ([#303](https://github.com/markean/aimz/issues/303)).
+- A keyword argument named after {attr}`~aimz.ImpactModel.param_input` or {attr}`~aimz.ImpactModel.param_output` now raises a `TypeError` in every entry point. Previously it resolved inconsistently: {meth}`~aimz.ImpactModel.predict` computed with `X` and silently dropped the keyword argument, {meth}`~aimz.ImpactModel.predict_on_batch` did the reverse, and the fitting methods silently trained on the keyword argument instead of `X` ([#303](https://github.com/markean/aimz/issues/303)).
 
 ## [v0.14.0](https://github.com/markean/aimz/releases/tag/v0.14.0) - 2026-07-24
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -337,14 +337,23 @@ class ImpactModel(BaseModel):
             Mapping of fully bound keyword arguments to invoke the kernel.
 
         Raises:
-            TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
-                argument.
+            TypeError: If :attr:`~aimz.ImpactModel.param_input` or
+                :attr:`~aimz.ImpactModel.param_output` is passed as an argument.
         """
+        if self.param_input in kwargs:
+            msg = (
+                f"{self.param_input!r} is a reserved kernel parameter and cannot be "
+                "passed as a keyword argument."
+            )
+            raise TypeError(msg)
         args_bound = (
             signature(self.kernel).bind(**{self.param_input: X, **kwargs}).arguments
         )
         if self.param_output in args_bound:
-            msg = f"Specifying {self.param_output!r} is not allowed."
+            msg = (
+                f"{self.param_output!r} is a reserved kernel parameter and cannot be "
+                "passed as a keyword argument."
+            )
             raise TypeError(msg)
 
         return args_bound
@@ -1005,6 +1014,10 @@ class ImpactModel(BaseModel):
             necessary to capture the returned state externally unless explicitly needed.
             However, the returned loss value can be used for monitoring or logging.
         """
+        _, kwargs_extra = _group_kwargs(
+            kwargs,
+            forbid=(self.param_input, self.param_output),
+        )
         batch = {self.param_input: X, self.param_output: y, **kwargs}
 
         if self._vi_state is None:
@@ -1018,7 +1031,6 @@ class ImpactModel(BaseModel):
         # Cache one jitted update per set of non-array kwarg names: the names are baked
         # into `static_argnames`, so a call with different extras needs its own wrapper
         # rather than reusing a stale one.
-        _, kwargs_extra = _group_kwargs(kwargs)
         fn_key = tuple(sorted(kwargs_extra))
         fn_vi_update = self._fn_vi_update.get(fn_key)
         if fn_vi_update is None:
@@ -1081,6 +1093,13 @@ class ImpactModel(BaseModel):
         """
         X, y = _validate_X_y_to_jax(X, y=y)
 
+        for name in (self.param_input, self.param_output):
+            if name in kwargs:
+                msg = (
+                    f"{name!r} is a reserved kernel parameter and cannot be passed "
+                    "as a keyword argument."
+                )
+                raise TypeError(msg)
         # Validate the provided parameters against the kernel's signature
         args_bound = (
             signature(self.kernel)

--- a/aimz/utils/_kwargs.py
+++ b/aimz/utils/_kwargs.py
@@ -17,18 +17,33 @@
 from aimz.utils._validation import _is_arraylike
 
 
-def _group_kwargs(kwargs: dict) -> tuple[dict, dict]:
+def _group_kwargs(
+    kwargs: dict,
+    forbid: tuple[str, ...] = (),
+) -> tuple[dict, dict]:
     """Separate keyword arguments into array-like and non-array-like groups.
 
     Args:
         kwargs: A dictionary of keyword arguments where values could be array-like or
             non-array-like.
+        forbid: Names that must not appear in ``kwargs``. Reserved parameter names whose
+            values are supplied through dedicated arguments instead.
 
     Returns:
         A tuple containing two dictionaries:
             - kwargs_array: Contains the array-like arguments.
             - kwargs_extra: Contains the non-array-like arguments.
+
+    Raises:
+        TypeError: If a forbidden name appears in ``kwargs``.
     """
+    for name in forbid:
+        if name in kwargs:
+            msg = (
+                f"{name!r} is a reserved kernel parameter and cannot be passed as a "
+                "keyword argument."
+            )
+            raise TypeError(msg)
     kwargs_array = {k: v for k, v in kwargs.items() if _is_arraylike(v)}
     kwargs_extra = {k: v for k, v in kwargs.items() if not _is_arraylike(v)}
 

--- a/aimz/utils/_validation.py
+++ b/aimz/utils/_validation.py
@@ -264,7 +264,7 @@ def _validate_kernel_signature(
         sub = param_input
         msg = f"{sub!r} must not have a default value."
         raise KernelValidationError(msg)
-    if sig.parameters[param_output].default:
+    if sig.parameters[param_output].default is not None:
         sub = param_output
         msg = f"{sub!r} must have a default value of `None`."
         raise KernelValidationError(msg)

--- a/aimz/utils/data/_input_setup.py
+++ b/aimz/utils/data/_input_setup.py
@@ -160,7 +160,10 @@ def _setup_inputs(
         - The data loader for batching.
         - Extra keyword arguments to be passed downstream.
     """
-    kwargs_array, kwargs_extra = _group_kwargs(kwargs)
+    kwargs_array, kwargs_extra = _group_kwargs(
+        kwargs,
+        forbid=(param_input, param_output),
+    )
 
     if isinstance(X, ArrayLike):
         X = np.asarray(X)
@@ -203,6 +206,12 @@ def _setup_inputs(
         if y is not None:
             msg = "`y` must be `None` when `X` is already a data loader."
             raise TypeError(msg)
+        if X.shuffle and not shuffle:
+            msg = (
+                "The data loader shuffles, so results will not follow the data order. "
+                "Use `shuffle=False` to preserve it."
+            )
+            warn(msg, category=UserWarning, stacklevel=stacklevel)
         loader = X
         loader.device = device
     else:


### PR DESCRIPTION
Improve input handling by enforcing reserved parameter validation and addressing issues with shuffled data loaders. Emit warnings for shuffled loaders to maintain data order integrity, and ensure kernel validation rejects falsy defaults appropriately. Raise errors for reserved keyword arguments to prevent inconsistent behavior across methods.

Fixes #303