### PR TITLE
Screen injected posterior samples and score log-likelihood at the data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The streaming methods now emit a `UserWarning` when a data loader with `shuffle=True` is passed ([#303](https://github.com/markean/aimz/issues/303)).
 - Kernel validation now rejects an output parameter whose default is falsy but not `None`; an array default now raises a `KernelValidationError` instead of a `ValueError` ([#303](https://github.com/markean/aimz/issues/303)).
 - A keyword argument named after {attr}`~aimz.ImpactModel.param_input` or {attr}`~aimz.ImpactModel.param_output` now raises a `TypeError` in every entry point. Previously it resolved inconsistently: {meth}`~aimz.ImpactModel.predict` computed with `X` and silently dropped the keyword argument, {meth}`~aimz.ImpactModel.predict_on_batch` did the reverse, and the fitting methods silently trained on the keyword argument instead of `X` ([#303](https://github.com/markean/aimz/issues/303)).
+- {meth}`~aimz.ImpactModel.set_posterior_sample` now removes the output site from the provided samples with a `UserWarning` ([#305](https://github.com/markean/aimz/issues/305)).
+- {meth}`~aimz.ImpactModel.log_likelihood` now substitutes only latent sample sites from the posterior: `deterministic` sites are recomputed from the trace and observed sites score the passed data, so injected posteriors carrying such sites can no longer override either ([#305](https://github.com/markean/aimz/issues/305)).
 
 ## [v0.14.0](https://github.com/markean/aimz/releases/tag/v0.14.0) - 2026-07-24
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -1337,7 +1337,18 @@ class ImpactModel(BaseModel):
             sites are not discovered; predictive methods return only the output site by
             default. Request ``deterministic`` (or other) sites explicitly via
             ``return_sites``.
+
+            Include only latent sample sites. The output site is removed with a
+            warning, but ``deterministic`` sites must be excluded by the caller —
+            if present, they override the values recomputed by
+            :meth:`~aimz.ImpactModel.log_likelihood`.
         """
+        if self.param_output in posterior_sample:
+            posterior_sample = {
+                k: v for k, v in posterior_sample.items() if k != self.param_output
+            }
+            msg = f"The output site {self.param_output!r} is removed."
+            warn(msg, category=UserWarning, stacklevel=2)
         batch_ndims = 1
         posterior_sample = {
             name: sample

--- a/aimz/utils/_log_likelihood.py
+++ b/aimz/utils/_log_likelihood.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from functools import partial
 from typing import TYPE_CHECKING
 
 import jax.numpy as jnp
@@ -70,6 +71,27 @@ def _pin_subsample_indices(msg: Message) -> Array | None:
     return jnp.arange(subsample_size)
 
 
+def _substitute_latent(msg: Message, sample: dict[str, Array]) -> Array | None:
+    """Provide the posterior value for a latent sample site.
+
+    Only latent sample sites take posterior values: deterministic sites are recomputed
+    from the trace, and observed sites score the passed data. This keeps injected
+    posteriors that carry output or deterministic sites from overriding either.
+
+    Args:
+        msg: A NumPyro effect-handler site message.
+        sample: One posterior draw, keyed by site name.
+
+    Returns:
+        The posterior value for a latent sample site, or ``None`` to leave the site
+        unchanged.
+    """
+    if msg["type"] == "deterministic" or msg.get("is_observed", False):
+        return None
+
+    return sample.get(msg["name"])
+
+
 def _log_likelihood(
     model: Callable,
     samples: dict[str, Array] | None,
@@ -98,7 +120,14 @@ def _log_likelihood(
 
     def _loglik_one_sample(sample: dict[str, Array]) -> dict[str, Array]:
         pinned_model = substitute(model, substitute_fn=_pin_subsample_indices)
-        substituted_model = substitute(pinned_model, sample) if sample else pinned_model
+        substituted_model = (
+            substitute(
+                pinned_model,
+                substitute_fn=partial(_substitute_latent, sample=sample),
+            )
+            if sample
+            else pinned_model
+        )
         model_trace = trace(substituted_model).get_trace(**(model_kwargs or {}))
 
         return {


### PR DESCRIPTION
Injected posterior samples are now screened to prevent overriding predictions and log-likelihood data. The output site is removed with a warning, and only latent sample sites are substituted during log-likelihood scoring, ensuring that deterministic sites are recomputed from the trace.

Fixes #305