### PR TITLE
Fix minor contract inconsistencies across entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A keyword argument named after {attr}`~aimz.ImpactModel.param_input` or {attr}`~aimz.ImpactModel.param_output` now raises a `TypeError` in every entry point. Previously it resolved inconsistently: {meth}`~aimz.ImpactModel.predict` computed with `X` and silently dropped the keyword argument, {meth}`~aimz.ImpactModel.predict_on_batch` did the reverse, and the fitting methods silently trained on the keyword argument instead of `X` ([#303](https://github.com/markean/aimz/issues/303)).
 - {meth}`~aimz.ImpactModel.set_posterior_sample` now removes the output site from the provided samples with a `UserWarning` ([#305](https://github.com/markean/aimz/issues/305)).
 - {meth}`~aimz.ImpactModel.log_likelihood` now substitutes only latent sample sites from the posterior: `deterministic` sites are recomputed from the trace and observed sites score the passed data, so injected posteriors carrying such sites can no longer override either ([#305](https://github.com/markean/aimz/issues/305)).
+- {meth}`~aimz.ImpactModel.sample` with `return_sites=[]` now returns no sites instead of falling back to all latent sites, matching the predictive methods ([#307](https://github.com/markean/aimz/issues/307)).
+- {meth}`~aimz.ImpactModel.estimate_effect` no longer truth-tests its arguments: an explicitly passed output tree or arguments dictionary is honored even when empty ([#307](https://github.com/markean/aimz/issues/307)).
+- {class}`~aimz.utils.data.ArrayLoader` now pads batches by the device count of the sharding the data is placed on, rather than the host's device count, avoiding unnecessary padding for shardings that span fewer devices ([#307](https://github.com/markean/aimz/issues/307)).
 
 ## [v0.14.0](https://github.com/markean/aimz/releases/tag/v0.14.0) - 2026-07-24
 

--- a/aimz/model/impact_model.py
+++ b/aimz/model/impact_model.py
@@ -837,7 +837,7 @@ class ImpactModel(BaseModel):
                     ),
                     rng_keys=random.split(rng_key, num=num_samples),
                     return_sites=self._coerce_return_sites(return_sites)
-                    if return_sites
+                    if return_sites is not None
                     else None,
                     samples=None,
                     model_kwargs=None,
@@ -880,7 +880,8 @@ class ImpactModel(BaseModel):
             **kwargs: Additional arguments passed to the model.
 
         Returns:
-            Posterior predictive samples. Posterior samples are included if available.
+            Posterior predictive samples. Posterior samples are included if available
+            when a :external:class:`~xarray.DataTree` is returned.
 
         Raises:
             TypeError: If :attr:`~aimz.ImpactModel.param_output` is passed as an
@@ -1430,7 +1431,9 @@ class ImpactModel(BaseModel):
             **kwargs: Additional arguments passed to the model.
 
         Returns:
-            Posterior predictive samples. Posterior samples are included if available.
+            Posterior predictive samples. Posterior samples are included if available
+            when a :external:class:`~xarray.DataTree` is returned; the dictionary
+            contains only the requested sites.
 
         Raises:
             NotFittedError: If the model is not fitted.
@@ -1690,17 +1693,17 @@ class ImpactModel(BaseModel):
 
         _predict = self.predict_on_batch if on_batch else self.predict
 
-        if output_baseline:
+        if output_baseline is not None:
             dt_baseline = output_baseline
-        elif args_baseline:
+        elif args_baseline is not None:
             dt_baseline = _predict(**args_baseline)
         else:
             msg = "Either `output_baseline` or `args_baseline` must be provided."
             raise ValueError(msg)
 
-        if output_intervention:
+        if output_intervention is not None:
             dt_intervention = output_intervention
-        elif args_intervention:
+        elif args_intervention is not None:
             dt_intervention = _predict(**args_intervention)
         else:
             msg = (

--- a/aimz/model/kernel_spec.py
+++ b/aimz/model/kernel_spec.py
@@ -39,7 +39,10 @@ class KernelSpec:
     Notes:
         Re-tracing only upgrades a prior-only spec (``output_observed`` is ``False``) to
         one that includes an observed output, merging the newly discovered sites with
-        the existing ones; the user kernel is assumed immutable after construction.
+        the existing ones; the user kernel is assumed immutable after construction, and
+        its site structure is assumed independent of the call's arguments. Sites that
+        appear only under specific arguments are not discovered by later calls and must
+        be requested explicitly via ``return_sites``.
     """
 
     traced: bool

--- a/aimz/utils/data/array_loader.py
+++ b/aimz/utils/data/array_loader.py
@@ -22,7 +22,7 @@ from warnings import warn
 
 import jax.numpy as jnp
 import numpy as np
-from jax import Array, device_put, local_device_count, random
+from jax import Array, device_put, random
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -34,7 +34,11 @@ if TYPE_CHECKING:
 
 
 class ArrayLoader:
-    """Data loader for batching and padding arrays."""
+    """Data loader for batching and padding arrays.
+
+    Passing a loader to a model method adopts it for the call: the method sets
+    ``device`` to its own setting and, when shuffling, iteration advances ``rng_key``.
+    """
 
     def __init__(
         self,
@@ -72,7 +76,6 @@ class ArrayLoader:
             warn(msg, category=UserWarning, stacklevel=2)
             rng_key = random.wrap_key_data(rng_key)
         self.rng_key = rng_key
-        self._num_devices = local_device_count()
         self.device = device
 
     def pad_array(
@@ -129,7 +132,7 @@ class ArrayLoader:
             end = start + self.batch_size
             batch_idx = indices[start:end]
             if self.device is not None:
-                n_pad = (-len(batch_idx)) % self._num_devices
+                n_pad = (-len(batch_idx)) % self.device.num_devices
                 if n_pad > 0:
                     batch = {
                         k: self.pad_array(arr[batch_idx], n_pad=n_pad)


### PR DESCRIPTION
Addressed inconsistencies in the `sample` method to ensure it returns no sites when `return_sites=[]`, aligning it with the behavior of predictive methods. Updated the `ArrayLoader` to pad batches based on the device count of the data's sharding, improving efficiency.

Fixes #307